### PR TITLE
Fix missing post pagination

### DIFF
--- a/inc/blog/class-post-entry.php
+++ b/inc/blog/class-post-entry.php
@@ -497,6 +497,7 @@ class Customify_Post_Entry {
 		<div class="entry-content entry--item">
 			<?php
 			the_content();
+			$this->post_pagination();
 			?>
 		</div><!-- .entry-content -->
 		<?php
@@ -614,7 +615,21 @@ class Customify_Post_Entry {
 		echo '</div>';
 	}
 
+	/**
+	 * Post pagination markup
+	 */
+	function post_pagination() {
+		if ( ! is_single() ) {
+			return '';
+		}
 
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'customify' ),
+				'after'  => '</div>',
+			)
+		);
+	}
 
 	/**
 	 * Display related post


### PR DESCRIPTION
Post pagination got lost in May when `get_template_part( 'template-parts/content', get_post_type() )` was replaced by `customify_single_post()`.

---
Example

```
Post Page 1

<!--nextpage-->

Post Page 2

<!--nextpage-->

Post Page 3
```

Before fix

![png](https://user-images.githubusercontent.com/42134098/48671418-1ea2b900-eb28-11e8-9895-6aded9f6b6de.png)

After fix

![after](https://user-images.githubusercontent.com/42134098/48671495-7d1c6700-eb29-11e8-966c-b47671b30db8.png)
