### PR TITLE
Add support for wp_body open

### DIFF
--- a/header.php
+++ b/header.php
@@ -20,6 +20,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php do_action( 'wp_body_open' ); ?>
 <div id="page" <?php customify_site_classes(); ?>>
 	<a class="skip-link screen-reader-text" href="#site-content"><?php esc_html_e( 'Skip to content', 'customify' ); ?></a>
 	<?php


### PR DESCRIPTION
WP 5.2 introduced a new `wp_body_open()` function that is used to trigger a `wp_body_open` action. This action is intended to allow developers to inject code immediately following the opening `<body>` tag.