### PR TITLE
Fixing hide title bar

### DIFF
--- a/inc/customizer/configs/page-header.php
+++ b/inc/customizer/configs/page-header.php
@@ -972,7 +972,7 @@ class Customify_Page_Header {
 	function render_titlebar( $args = array() ) {
 		$args = $this->get_settings();
 
-		if ( is_array( $args ) && isset( $args['force_display_single_title'] ) && $args['force_display_single_title'] != '' && 'hide' != trim( $args['force_display_single_title'] ) ) {
+		if ( is_array( $args ) && isset( $args['force_display_single_title'] ) && $args['force_display_single_title'] != '' && 'hide' == trim( $args['force_display_single_title'] ) ) {
 			return;
 		}
 


### PR DESCRIPTION
I don't know why the condition changed in page title hide function 2 years ago, but with this the hide doesn't work
https://github.com/PressMaximum/customify/commit/3233080f2b94437bfdd8b538bdea3b001af84fc6#diff-e682440d9156936c9b497e2df6621eb8bc6d18bb50ebdca3d9385c5d43b4a19cL971

It returns empty if the `force_display_single_title` is not empty, and not `hide` - don't understand why it changed. 

With my fix it's working