### PR TITLE
feat(customizer): group top-level panels into 4 labelled sections

### DIFF
--- a/inc/customizer/class-customify-section-divider.php
+++ b/inc/customizer/class-customify-section-divider.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Panel group divider section.
+ *
+ * A non-expandable section that renders as a visual heading in the Customizer
+ * panel list. Used to separate groups of top-level panels (e.g. theme settings
+ * vs. WordPress core & plugin settings) without adding any settings of its own.
+ *
+ * The section opts out of expand/collapse behaviour via the `cannot-expand`
+ * CSS class — clicking it does nothing.
+ *
+ * @package customify
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( class_exists( 'WP_Customize_Section' ) && ! class_exists( 'Customify_WP_Customize_Section_Divider' ) ) {
+
+	class Customify_WP_Customize_Section_Divider extends WP_Customize_Section {
+
+		/**
+		 * Section type — paired with the `register_section_type()` call in
+		 * Customify_Customizer::register_panel_groups() so the Customizer JS
+		 * picks up our `render_template()` instead of falling back to the
+		 * default section template.
+		 *
+		 * @var string
+		 */
+		public $type = 'customify-divider';
+
+		/**
+		 * Underscore template for the divider row.
+		 *
+		 * No description, no help toggle, no settings — just a labelled `<li>`
+		 * with `cannot-expand` so the accordion behaviour is suppressed.
+		 */
+		protected function render_template() {
+			?>
+			<li
+				id="accordion-section-{{ data.id }}"
+				class="accordion-section control-section control-section-{{ data.type }} cannot-expand customify-divider"
+			>
+				<h3>{{{ data.title }}}</h3>
+			</li>
+			<?php
+		}
+	}
+}

--- a/inc/customizer/class-customizer.php
+++ b/inc/customizer/class-customizer.php
@@ -38,6 +38,12 @@ class  Customify_Customizer {
 
 		if ( is_admin() || is_customize_preview() ) {
 			add_action( 'customize_register', array( $this, 'register' ), 666 );
+			// Run last so every panel (core, plugins, third-party) is already registered
+			// when we slot panels into groups and bump foreign items below the divider.
+			add_action( 'customize_register', array( $this, 'register_panel_groups' ), 99999 );
+			// Override JS section constructor for the divider type so WP customizer
+			// doesn't auto-hide it (default behaviour hides sections with no controls).
+			add_action( 'customize_controls_print_footer_scripts', array( $this, 'print_divider_section_constructor' ) );
 			add_action( 'customize_preview_init', array( $this, 'preview_js' ) );
 			add_action( 'wp_ajax_customify/customizer/ajax/get_icons', array( $this, 'get_icons' ) );
 
@@ -1177,6 +1183,176 @@ class  Customify_Customizer {
 		);
 
 		do_action( 'customify/customize/register_completed', $this );
+	}
+
+	/**
+	 * Definition of panel groups shown in the Customizer side list.
+	 *
+	 * Each group renders a non-clickable divider section (see
+	 * Customify_WP_Customize_Section_Divider) at its `priority`, and every
+	 * panel/top-level-section named under `panels` is re-priorit­ised to sit
+	 * directly under that divider.
+	 *
+	 * Extend via the `customify/customizer/panel_groups` filter — e.g. a
+	 * companion plugin can append its own panels to the `post_types` group
+	 * without forking this list.
+	 *
+	 * Priority budget: each group has a 100-priority window for its panels
+	 * (`group_priority + 10, +20, +30, …`). The bump applied to foreign
+	 * panels (+2000) sits comfortably above this range.
+	 *
+	 * @return array<string, array{title:string, priority:int, panels:string[]}>
+	 */
+	public function get_panel_groups() {
+		$groups = array(
+			'general_options' => array(
+				'title'    => __( 'General Options', 'customify' ),
+				'priority' => 50,
+				'panels'   => array(
+					'styling_panel',
+					'typography_panel',
+				),
+			),
+			'layouts'         => array(
+				'title'    => __( 'Layouts', 'customify' ),
+				'priority' => 200,
+				'panels'   => array(
+					'layout_panel',
+					'header_settings',
+					'footer_settings',
+				),
+			),
+			'post_types'      => array(
+				'title'    => __( 'Post Types', 'customify' ),
+				'priority' => 350,
+				'panels'   => array(
+					'blog_panel',
+					// `portfolio_panel` is added by the Pro Portfolio module — if the module
+					// is inactive the panel won't exist and `get_panel()` returns null below.
+					'portfolio_panel',
+				),
+			),
+			'core_plugins'    => array(
+				'title'    => __( 'Core & Plugins', 'customify' ),
+				'priority' => 1000,
+				'panels'   => array(
+					// Compatibility is a theme panel but conceptually belongs with the
+					// plugin-integration settings, so it heads the Core & Plugins group.
+					'compatibility_panel',
+				),
+			),
+		);
+
+		/**
+		 * Filter the Customizer panel groups.
+		 *
+		 * @param array $groups Group definitions keyed by group slug.
+		 */
+		return apply_filters( 'customify/customizer/panel_groups', $groups );
+	}
+
+	/**
+	 * Insert group dividers in the Customizer panel list and push everything
+	 * not managed by Customify (WordPress core, plugins) into the bottom group.
+	 *
+	 * Runs at `customize_register` priority 99999 so every other extension has
+	 * already registered its panels and sections by the time we sweep.
+	 *
+	 * @param WP_Customize_Manager $wp_customize
+	 */
+	public function register_panel_groups( $wp_customize ) {
+		require_once get_template_directory() . '/inc/customizer/class-customify-section-divider.php';
+		$wp_customize->register_section_type( 'Customify_WP_Customize_Section_Divider' );
+
+		$groups = $this->get_panel_groups();
+
+		// 1. Add each divider section + re-priorit­ise its panels to follow it.
+		foreach ( $groups as $group_key => $group ) {
+			$divider_id = 'customify_divider_' . $group_key;
+
+			$wp_customize->add_section(
+				new Customify_WP_Customize_Section_Divider(
+					$wp_customize,
+					$divider_id,
+					array(
+						'title'    => $group['title'],
+						'priority' => $group['priority'],
+					)
+				)
+			);
+
+			$offset = 10;
+			foreach ( $group['panels'] as $name ) {
+				$obj = $wp_customize->get_panel( $name );
+				if ( ! $obj ) {
+					// Fall back to a top-level section with the same name (the upsell
+					// strip in upsell.php uses this shape — kept here for symmetry even
+					// though no current group references a top-level section).
+					$section = $wp_customize->get_section( $name );
+					if ( $section && empty( $section->panel ) ) {
+						$obj = $section;
+					}
+				}
+				if ( $obj ) {
+					$obj->priority = $group['priority'] + $offset;
+					$offset       += 10;
+				}
+			}
+		}
+
+		// 2. Bump anything not managed by Customify into the Core & Plugins zone.
+		$managed       = self::get_config();
+		$divider_token = 'customify_divider_';
+
+		foreach ( $wp_customize->panels() as $panel_id => $panel ) {
+			if ( isset( $managed[ 'panel|' . $panel_id ] ) ) {
+				continue;
+			}
+			$panel->priority = (int) $panel->priority + 2000;
+		}
+
+		foreach ( $wp_customize->sections() as $section_id => $section ) {
+			// Sections nested under a panel only appear when their parent is
+			// expanded; they have no effect on the top-level order.
+			if ( ! empty( $section->panel ) ) {
+				continue;
+			}
+			if ( isset( $managed[ 'section|' . $section_id ] ) ) {
+				continue;
+			}
+			// Skip the dividers we just registered.
+			if ( strpos( $section_id, $divider_token ) === 0 ) {
+				continue;
+			}
+			$section->priority = (int) $section->priority + 2000;
+		}
+	}
+
+	/**
+	 * Print the JS section constructor for the divider type.
+	 *
+	 * Why: by default WP's wp.customize.Section sets `display: none` on any
+	 * section whose `isContextuallyActive()` returns false — and a section with
+	 * zero controls is, by definition, not contextually active. The divider
+	 * carries no controls (it's purely visual), so the default constructor
+	 * would always hide it. We extend the prototype to force the section to
+	 * count as contextually active.
+	 */
+	public function print_divider_section_constructor() {
+		?>
+		<script>
+		( function () {
+			if ( typeof wp === 'undefined' || ! wp.customize || ! wp.customize.Section ) {
+				return;
+			}
+			wp.customize.sectionConstructor['customify-divider'] = wp.customize.Section.extend( {
+				isContextuallyActive: function () {
+					return true;
+				}
+			} );
+		} )();
+		</script>
+		<?php
 	}
 
 }

--- a/src/backend/customizer/scss/customizer.scss
+++ b/src/backend/customizer/scss/customizer.scss
@@ -532,3 +532,62 @@ $builder_active_color: #0073aa;
 		}
 	}
 }
+
+// ── Panel focus ring: keyboard-only ──────────────────────────────────────────
+// Default WP customizer paints a 2px blue box-shadow ring on every panel /
+// section button on `:focus`, which also fires on mouse-click. The lingering
+// ring after a click is visually noisy. `:focus-visible` lets us suppress it
+// for pointer focus while keeping the full ring for keyboard Tab navigation
+// (WCAG 2.4.7-compliant).
+#customize-controls .accordion-section-title button.accordion-trigger:focus:not(:focus-visible) {
+	box-shadow: none;
+	outline: none;
+}
+
+// ── Panel group divider ──────────────────────────────────────────────────────
+// Non-clickable section rendered as a visual heading in the Customizer panel
+// list. Used to separate top-level panels into logical groups (General
+// Options / Layouts / Post Types / Core & Plugins).
+//
+// Paired with Customify_WP_Customize_Section_Divider (PHP) and the priority
+// scheme in Customify_Customizer::register_panel_groups().
+//
+// Alignment & spacing reasoning:
+//   - padding-left: 18px → matches WP panel title text x-position
+//     (panel <h3><button class="accordion-trigger"> button has
+//     padding-left 14px sitting at LI x=4px; text-left therefore at x=18px).
+//   - padding-top: 14px → breathing room above the label.
+//   - padding-bottom: 6px → tight to the first panel of the group so the
+//     label visually attaches to "the items below me".
+//   - transparent bg + no border → reads as a gap-with-label between cards,
+//     not as another card row. Panel rows themselves are transparent <li>s
+//     with a white-bg <button> inside; matching that absence keeps the
+//     hierarchy clean.
+//   - colour #646970 + 11px / 600 / uppercase + 0.5px letter-spacing →
+//     standard WP-admin subordinate label (one tier below the panel title
+//     which is #50575e / 14px / 600 / sentence case).
+#customize-controls .customify-divider {
+	margin: 0;
+	padding: 14px 18px 13px;
+	background: transparent;
+	border: none;
+	// Match the panel row separator (same colour as the 1px line on every
+	// .accordion-section-title) so the divider sits in the same horizontal
+	// rule rhythm as the panels below.
+	border-bottom: 1px solid #dcdcde;
+	cursor: default;
+	pointer-events: none;
+
+	h3 {
+		margin: 0;
+		padding: 0;
+		font-size: 11px;
+		font-weight: 600;
+		line-height: 1.4;
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
+		color: #646970;
+		border: none;
+		background: none;
+	}
+}


### PR DESCRIPTION
## Summary

Reorganises the Customizer side panel into four labelled groups so theme settings sit visually apart from WordPress core and plugin settings.

```
─── GENERAL OPTIONS ───
  Styling, Typography

─── LAYOUTS ───
  Layouts, Header, Footer

─── POST TYPES ───
  Blog, Portfolio (if Pro Portfolio module active)

─── CORE & PLUGINS ───
  Compatibility + Menus / Widgets / Homepage / Additional CSS / any
  plugin-injected panels (auto-detected, no whitelist needed)
```

## Implementation

- **`Customify_WP_Customize_Section_Divider`** — new non-clickable section type. Renders `<li class=\"... cannot-expand customify-divider\"><h3>{title}</h3></li>` via `render_template()`.
- **`Customify_Customizer::register_panel_groups()`** — hooks `customize_register` at priority `99999` (after every other extension). For each group: registers the divider section, then walks `$group['panels']` to set their priority directly under the divider. Then sweeps `$wp_customize->panels()` + top-level `sections()`, bumping any name *not* in Customify's central config by `+2000` so foreign panels always land in Core & Plugins.
- **`customify/customizer/panel_groups` filter** — companion modules append panels to a group without forking the list.
- **JS `sectionConstructor` override** — printed via `customize_controls_print_footer_scripts`. Default `wp.customize.Section.isContextuallyActive()` returns `false` when a section has no controls, which triggers `display: none`; we extend the prototype to keep the divider visible.
- **SCSS** — sized to WP's panel rhythm: padding `14px 18px 13px`, `border-bottom: 1px solid #dcdcde` matching panel separators, label `11px / 600 / uppercase / #646970`. Also adds `:focus:not(:focus-visible)` on `.accordion-trigger` so the focus ring no longer lingers after a pointer click while staying visible for Tab navigation (WCAG 2.4.7 intact).

## Backward compatibility (30,000-site install base)

- Pure additive — no `theme_mod`, option, sanitize callback, function name, hook, or class touched.
- Foreign-panel priority bump only affects display order, not behaviour or data.
- When Customify Pro is inactive, the upsell strip (priority 0) still sits above the first divider, as before.

## Test plan

- [ ] Theme panels appear under correct group dividers.
- [ ] Customify Pro Portfolio module active → Portfolio panel sits in Post Types group.
- [ ] WP core panels (Menus, Widgets, Homepage, Additional CSS) land in Core & Plugins group.
- [ ] Activate a third-party plugin that registers a Customizer panel → panel auto-routes to Core & Plugins.
- [ ] Click a panel → focus ring does NOT appear.
- [ ] Tab through panels with keyboard → focus ring DOES appear.
- [ ] Deactivate Pro → upsell strip renders above the first divider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)