### PR TITLE
style(customizer): refresh Pro upsell teaser CTA

### DIFF
--- a/inc/customizer/class-customify-section-pro.php
+++ b/inc/customizer/class-customify-section-pro.php
@@ -82,7 +82,12 @@ if ( class_exists( 'WP_Customize_Section' ) && ! class_exists( 'Customify_WP_Cus
 						<# }); #>
 					</ul>
 					<# } #>
-					<a href="{{ data.pro_url }}" class="button button-secondary" target="_blank" rel="noopener"><?php echo esc_html_x( 'Learn More', 'Customify Pro upsell', 'customify' ); ?></a>
+					<a href="{{ data.pro_url }}" class="button button-primary" target="_blank" rel="noopener">
+						<?php echo esc_html_x( 'Learn More', 'Customify Pro upsell', 'customify' ); ?>
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" focusable="false" class="customify-pro-teaser__external-icon">
+							<path d="M19.5 4.5h-7V6h4.44l-5.97 5.97 1.06 1.06L18 7.06v4.44h1.5v-7Zm-13 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3H17v3a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h3V5.5h-3Z" fill="currentColor"/>
+						</svg>
+					</a>
 				</div>
 			</li>
 			<# } else { #>

--- a/src/backend/customizer/scss/_control.scss
+++ b/src/backend/customizer/scss/_control.scss
@@ -1562,11 +1562,9 @@ $text_color: #555d66;
 }
 
 .customify-pro-teaser {
-    color: #856404;
-    background-color: #fff3cd;
     margin: 1em 0px;
     position: relative;
-    padding: .75rem 1.25rem;
+    padding: .75rem 1.25rem 1.5rem;
     margin-bottom: 1rem;
     border-top: 1px solid #ddd;
     border-bottom: 1px solid #ddd;
@@ -1575,8 +1573,17 @@ $text_color: #555d66;
         margin-bottom: 1em;
     }
     .button {
-        display: block;
-        text-align: center;
+        // Flex container so the trailing external-link icon sits inline
+        // with the text and spaced consistently regardless of label length.
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+    }
+    .customify-pro-teaser__external-icon {
+        flex-shrink: 0;
+        width: 16px;
+        height: 16px;
     }
 }
 .customize-control {


### PR DESCRIPTION
## Summary

Tweaks the *More \<area\> options in Customify Pro* teaser that appears in the Header / Footer panels when the Pro plugin is not active.

| Before | After |
|---|---|
| Warm yellow alert box (`#fff3cd` bg, `#856404` text) with grey *Learn More* button | Transparent block matching surrounding chrome, blue primary CTA with trailing external-link icon |

## Changes

- `.customify-pro-teaser` ([src/backend/customizer/scss/_control.scss](src/backend/customizer/scss/_control.scss))
  - Removed `background-color: #fff3cd` and `color: #856404`. The top/bottom borders and `border-radius` stay so the teaser is still visually delimited.
  - Padding `.75rem 1.25rem` → `.75rem 1.25rem 1.5rem` for extra bottom breathing room above the CTA.
  - Button switched from `display: block + text-align: center` to a flex container with `gap: 6px` so a trailing icon stays inline.
- Teaser template ([inc/customizer/class-customify-section-pro.php](inc/customizer/class-customify-section-pro.php))
  - Button class `button-secondary` → `button-primary` (picks up WP admin theme colour).
  - Appended an inline SVG of the `external` glyph from `@wordpress/icons` (`fill="currentColor"`, 16×16, `aria-hidden`) so the link telegraphs that it opens in a new tab.

## Scope

- Visible only when Customify Pro is **not active** (`upsell.php:8` early-returns when `Customify_Pro` class exists).
- The top-of-panel "Customify Pro modules available" strip (the other branch of the same template) is untouched.
- No PHP / JS behaviour change; pure presentation. No `theme_mod`, option, or hook touched.

## Test plan

- [ ] Deactivate Customify Pro plugin.
- [ ] Open Customize → Header panel → scroll to bottom: teaser shows transparent bg, blue primary button with external icon trailing the *Learn More* label, icon inherits white from button text.
- [ ] Same in Footer panel.
- [ ] Reactivate Customify Pro: teaser disappears (existing behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)