### PR TITLE
fix(editor): inject :root palette tokens into block editor canvas

### DIFF
--- a/inc/admin/editor.php
+++ b/inc/admin/editor.php
@@ -56,11 +56,30 @@ class Customify_Editor {
 		$css = '';
 		if ( function_exists( 'customify_color_palette_root_css' ) ) {
 			$css .= customify_color_palette_root_css();
+
+			// Editor-canvas-specific overrides. The palette-tokens block emits
+			// `body{background-color:var(--customify-base, hex)}` for the
+			// frontend, but the block editor iframe ships at least 2 LATER-in-
+			// source-order `body{background:white}` defaults (one from
+			// `:where(body)` reset, one from the iframe canvas stylesheet) that
+			// outrank a plain `body` selector by source order. Bump specificity
+			// to `.editor-styles-wrapper` — WP's canonical "this content gets
+			// theme styling" wrapper, more specific than `body` and scoped to
+			// the editor canvas. Same cascade chain, same saved-vs-default
+			// resolution as frontend.
+			$base_default = '#ffffff';
+			$slots_fn     = 'customify_color_get_slots';
+			if ( function_exists( $slots_fn ) ) {
+				$slots        = $slots_fn();
+				$base_default = $slots['base'] ?? $base_default;
+			}
+			$css .= '.editor-styles-wrapper{background-color:var(--customify-base, ' . esc_attr( $base_default ) . ');}';
 		}
 
 		$fields = array();
 		$keys   = array(
 			'container_width',
+			'background',                       // Page bg composite — re-scoped to .editor-styles-wrapper below
 			'site_content_styling',
 			'content_background',
 			'single_blog_post_content_width',
@@ -119,6 +138,19 @@ class Customify_Editor {
 		if ( isset( $fields['content_background'] ) && $fields['content_background'] ) {
 			// WP 6.0+ uses .editor-visual-editor instead of .edit-post-layout__content.
 			$fields['content_background']['selector'] = array(
+				'normal' => '.editor-styles-wrapper',
+			);
+		}
+
+		if ( isset( $fields['background'] ) && $fields['background'] ) {
+			// Page-bg composite — frontend targets `body`, but editor canvas
+			// has WP/theme.json `body { background: white }` defaults loaded
+			// AFTER the auto-CSS inline block (source order beats `body`-on-
+			// `body` specificity). Re-scope to .editor-styles-wrapper so the
+			// composite's saved bg_color, bg_image, bg_position etc. show in
+			// the editor canvas. Same wrapper used by site_content_styling +
+			// content_background above.
+			$fields['background']['selector'] = array(
 				'normal' => '.editor-styles-wrapper',
 			);
 		}

--- a/inc/admin/editor.php
+++ b/inc/admin/editor.php
@@ -44,6 +44,20 @@ class Customify_Editor {
 	 * @return string CSS code.
 	 */
 	public function css() {
+		// Mirror the frontend :root palette tokens block (printed at wp_head
+		// priority 8 by Customify::print_palette_tokens) into the editor
+		// canvas so var(--customify-X) expressions in bundled SCSS + cascade
+		// chains (heading→text, link→primary, link-hover color-mix, etc.)
+		// resolve identically. Without this, the editor iframe falls back
+		// to each var()'s literal-hex fallback — which is the field default,
+		// not the user-saved or cascade-resolved value. Result: opted-in
+		// users (Phase 2.8 Palette panel) see frontend cascade ≠ editor
+		// preview, breaking the WYSIWYG promise.
+		$css = '';
+		if ( function_exists( 'customify_color_palette_root_css' ) ) {
+			$css .= customify_color_palette_root_css();
+		}
+
 		$fields = array();
 		$keys   = array(
 			'container_width',
@@ -110,7 +124,7 @@ class Customify_Editor {
 		}
 
 		$c   = new Customify_Customizer_Auto_CSS();
-		$css = $c->render_css( $fields );
+		$css .= $c->render_css( $fields );
 
 		// Metabox compatibility (selectors stable in WP 6.x).
 		$css .= '.interface-interface-skeleton__footer { background: #FFF; }


### PR DESCRIPTION
## Summary

Block editor canvas was missing the `:root --customify-*` palette tokens that the frontend gets at `wp_head` priority 8. Result: `var(--customify-X)` expressions in the bundled editor SCSS fell back to literal-hex defaults instead of cascade-resolved values. For users who opted into the new Palette panel (Phase 2.8), cascade chains like heading→text and link→primary did NOT show in editor preview, breaking WYSIWYG parity.

## Fix

`inc/admin/editor.php::css()` now prepends the same `:root` block that `Customify::print_palette_tokens()` prints on the frontend. The editor iframe sees identical token values, so:

- `var(--customify-heading, default)` resolves through `:root --customify-heading: var(--customify-text)` → text slot value
- `var(--customify-link, default)` resolves through `:root --customify-link: var(--customify-primary)` → primary slot value
- `var(--customify-link-hover, default)` resolves through the `color-mix(in oklab, var(--customify-link) 85%, white)` declaration

## Verification

Test on a Studio site with `customify_palette_text = #FF0000` saved (opt-in trigger), `global_styling_color_heading` + `_link` removed (let cascade fire):

| Element | Pre-fix (editor) | Post-fix (editor) | Frontend | Match |
|---|---|---|---|---|
| h2 color | `rgb(43, 43, 43)` `#2b2b2b` (default fallback) | `rgb(255, 0, 0)` `#FF0000` | `#FF0000` | ✅ |
| link color | default fallback | `rgb(231, 76, 60)` `#E74C3C` | `#E74C3C` | ✅ |
| body color | `rgb(52, 73, 94)` (saved text override) | `rgb(52, 73, 94)` (unchanged) | `rgb(52, 73, 94)` | ✅ |
| `:root --customify-primary` | `(unset)` | `#e74c3c` | (same) | ✅ |

## Test plan

- [x] Editor iframe `:root` now has all `--customify-*` tokens
- [x] Cascade chains resolve identically frontend ↔ editor
- [x] Explicit saved overrides still win (paragraph body color unchanged)
- [x] No regression for non-opted-in users (legacy gate still suppresses `--customify-on-*` lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)