### PR TITLE
feat(palette): wire titlebar bg to Surface var + Titlebar Background override field

### DIFF
--- a/inc/colors-palette.php
+++ b/inc/colors-palette.php
@@ -469,9 +469,16 @@ if ( ! function_exists( 'customify_color_get_slots' ) ) {
 		// Slot primary / secondary reuse existing legacy theme_mod keys to keep
 		// storage compatibility with 30K+ sites. Every read is normalized to
 		// guard against wp-cli / external writes that bypass sanitize_callback.
+		// Surface default `#f9f9f9` aligns with the canvas-tinted SCSS hardcode
+		// historically used on `.page-titlebar` (and similar elevated chrome).
+		// Wiring the titlebar SCSS to `var(--customify-surface, #f9f9f9)` means
+		// 30K legacy sites keep the byte-identical render (fallback fires when
+		// the surface var isn't emitted to :root), while palette-opt-in sites
+		// pick up a coherent surface tone — e.g. dark-base saved → surface
+		// auto-tones with it instead of leaving the titlebar stuck at light gray.
 		$defaults = array(
 			'base'      => '#FFFFFF',
-			'surface'   => '#ECECEC',
+			'surface'   => '#f9f9f9',
 			'text'      => '#2b2b2b',
 			'primary'   => '#235787',
 			'secondary' => '#c3512f',
@@ -687,16 +694,18 @@ if ( ! function_exists( 'customify_color_palette_root_css' ) ) {
 		}
 
 		// Surface slot is the elevated-container background (cards / table
-		// cells / code blocks / form inputs / calendar headers). Only emit
-		// to :root when the user EXPLICITLY saved palette_surface — for
-		// unsaved sites the bundled SCSS fallback resolves to
-		// `color-mix(in srgb, currentcolor 6-12%, transparent)` which
-		// auto-adapts to the page background. Emitting the slot default
-		// `#ECECEC` here would bake a light gray into :root and break that
-		// adaptive behavior for users who saved Base = dark but didn't
-		// touch Surface. (Note: --customify-border used to follow this same
-		// opt-in gate per Phase 2.6, but was switched to unconditional emit
-		// in Phase 2.13 to fix invisible-border-on-dark-surface regressions —
+		// cells / code blocks / form inputs / calendar headers / page
+		// titlebar). Only emit to :root when the user EXPLICITLY saved
+		// palette_surface — for unsaved sites the bundled SCSS fallback
+		// resolves to `color-mix(in srgb, currentcolor 6-12%, transparent)`
+		// for the card/widget/code surface tints, while `.page-titlebar`
+		// uses the slot default `#f9f9f9` as its fallback (matches the
+		// historical hardcoded SCSS). Emitting the slot default here would
+		// bake a fixed light gray into :root and break the adaptive
+		// fallback for users who saved Base = dark but didn't touch Surface.
+		// (Note: --customify-border used to follow this same opt-in gate
+		// per Phase 2.6, but was switched to unconditional emit in Phase
+		// 2.13 to fix invisible-border-on-dark-surface regressions —
 		// surface stays gated because cards/widgets/code blocks consume the
 		// adaptive 6-12% fallback that the rigid hex would suppress.)
 		$ov_surface = ( is_array( $_saved_mods ) && array_key_exists( 'customify_palette_surface', $_saved_mods ) )
@@ -1666,7 +1675,7 @@ if ( ! function_exists( 'customify_color_palette_preview_js' ) ) {
 		'global_styling_color_secondary': '#c3512f',
 		'customify_palette_accent':       '#FFD042',
 		'customify_palette_text':         '#2b2b2b',
-		'customify_palette_surface':      '#ECECEC',
+		'customify_palette_surface':      '#f9f9f9',
 		'customify_palette_base':         '#FFFFFF'
 	};
 	function _readSlot(setting) {

--- a/inc/customizer/configs/page-header.php
+++ b/inc/customizer/configs/page-header.php
@@ -369,6 +369,23 @@ class Customify_Page_Header {
 				'css_format' => 'color: {{value}};',
 			),
 
+			// Titlebar Background — explicit override. When set, the
+			// generated CSS rule `#page-titlebar { background-color: <hex> }`
+			// wins by id-selector specificity over the SCSS fallback chain
+			// `.page-titlebar { background: var(--customify-surface, #f9f9f9) }`.
+			// When empty (default for 30K legacy sites), the SCSS chain
+			// applies — surface var if user opted in to Palette, else the
+			// historical `#f9f9f9` hex.
+			array(
+				'name'        => $name . '_bg_color',
+				'type'        => 'color',
+				'section'     => $section,
+				'label'       => __( 'Titlebar Background', 'customify' ),
+				'description' => __( 'Override the titlebar background. Leave empty to follow the Palette Surface color (or the legacy #f9f9f9 fallback when Palette is not used).', 'customify' ),
+				'selector'    => "$selector",
+				'css_format'  => 'background-color: {{value}};',
+			),
+
 			array(
 				'name'            => "{$name}_align",
 				'type'            => 'text_align_no_justify',

--- a/src/frontend/scss/header/_header_builder_common.scss
+++ b/src/frontend/scss/header/_header_builder_common.scss
@@ -80,11 +80,17 @@
 }
 
 // Titlebar
+// Background follows --customify-surface when the user has opted in to
+// the Palette panel (saved palette_surface). Fallback `#f9f9f9` matches
+// the historical hardcoded value so 30K legacy sites render byte-identical.
+// The Customizer "Titlebar Background" field (page-header.php) emits a
+// higher-specificity `#page-titlebar { background-color: <hex> }` rule
+// that wins over this declaration when set.
 .page-titlebar {
 	padding: 21px 0px 22px;
 	border-bottom: 1px solid $color_border;
 	word-break: break-word;
-	background: #f9f9f9;
+	background: var(--customify-surface, #f9f9f9);
 	@include for_device(tablet) {
 		padding: 19px 0px 20px;
 	}


### PR DESCRIPTION
## Summary

After PR #398 merged the Palette doctrine, sites with dark Base saves still had `.page-titlebar` stuck at the hardcoded SCSS `#f9f9f9` — mismatched with dark canvas. This wires the titlebar to the Surface slot with a proper cascade, and adds a per-site Customizer override.

**Cascade:**
```
titlebar bg = explicit "Titlebar Background" override   (highest, id selector)
            ?: var(--customify-surface)                  (palette opt-in)
            ?: #f9f9f9                                   (legacy fallback)
```

**3 changes:**
1. **Surface slot default `#ECECEC` → `#f9f9f9`** (`inc/colors-palette.php` PHP slot + JS preview mirror) — aligns slot value with the SCSS hardcode the titlebar has rendered for years.
2. **`.page-titlebar` SCSS `background: #f9f9f9` → `var(--customify-surface, #f9f9f9)`** — 1 line in `_header_builder_common.scss`.
3. **New "Titlebar Background" field** (`titlebar_bg_color`) in `config_titlebar()`, selector `#page-titlebar`. ID selector beats SCSS class, so override wins via specificity.

## 30K safety

| State | Pre-PR render | Post-PR render | Δ |
|---|---|---|---|
| Default install, no saves | `#f9f9f9` (hardcoded SCSS) | `#f9f9f9` (var fallback fires; surface not in :root) | **byte-identical ✓** |
| Surface saved (e.g. dark) | `#f9f9f9` (mismatch with dark base) | follows surface | **fixes regression** |
| Titlebar override saved | n/a (field didn't exist) | override hex wins | new option, no regression |

Surface slot default change only affects the theme.json palette picker swatch (block editor) and new opt-in starting state. Existing palette-opt-in sites keep their own saved values.

## Verification (Chrome MCP live preview iframe)

| # | Test | Result |
|---|---|---|
| 1 | Default install, no saves | titlebar = `rgb(249,249,249)` = `#f9f9f9` ✓ |
| 2 | Surface live drag → `#1a1a1a` / `#ff00aa` | titlebar tracks live ✓ |
| 3 | Titlebar override = `#ff0000`, no surface | titlebar = `#ff0000` ✓ |
| 4 | Titlebar `#ff0000` + surface `#1a1a1a` | titlebar = `#ff0000` (override wins) ✓ |
| 5 | Clear titlebar override, surface kept `#1a1a1a` | titlebar = `#1a1a1a` (cascades to surface) ✓ |

## Test plan

- [ ] Pull DEV after merge, rebuild (`npm run build`)
- [ ] Verify 30K: fresh install renders `.page-titlebar` bg = `#f9f9f9` byte-identical
- [ ] Verify opt-in: save Palette → Surface = dark hex → titlebar follows
- [ ] Verify override: Customizer → Page Header → Titlebar Settings → Titlebar Background → set hex → titlebar uses that hex
- [ ] Verify clear: clear override → titlebar reverts to surface (or `#f9f9f9` if no surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)