### PR TITLE
fix(layouts): wire site_content_layout setting — 8-year dead radio comes alive

### DIFF
--- a/inc/element-classes.php
+++ b/inc/element-classes.php
@@ -101,12 +101,30 @@ if ( ! function_exists( 'customify_site_content_classes' ) ) {
 	/**
 	 * Adds custom classes to the array of site content classes.
 	 *
+	 * Mirrors the header builder pattern: the Customizer field
+	 * `site_content_layout` (radio: `site-content-fullwidth` / `site-content-boxed`)
+	 * uses `css_format = 'html_class'`, which is a no-op marker in the
+	 * auto-CSS pipeline. The class has to be pushed into the element's
+	 * class array manually here — same wiring as `site_layout` above and
+	 * the header `header_main_layout` field.
+	 *
+	 * Was orphaned since the setting first shipped in 2017 (b04c6a44):
+	 * UI saved the value but no handler ever applied the class. The
+	 * paired SCSS rule (`.site-content-fullwidth .customify-container
+	 * { max-width: initial }`) lives in `src/frontend/scss/layouts/_layouts.scss`,
+	 * mirroring the existing `.layout-fullwidth` pattern in the header SCSS.
+	 *
 	 * @param array $classes Classes for the site content element.
 	 *
 	 * @return array
 	 */
 	function customify_site_content_classes( $classes ) {
 		$classes[] = 'site-content';
+
+		$site_content_layout = sanitize_text_field( Customify()->get_setting( 'site_content_layout' ) );
+		if ( $site_content_layout ) {
+			$classes[] = $site_content_layout;
+		}
 
 		return $classes;
 	}

--- a/src/frontend/scss/layouts/_layouts.scss
+++ b/src/frontend/scss/layouts/_layouts.scss
@@ -63,6 +63,22 @@
     margin: 0 auto;
 }
 
+// Site content full-width mode — mirrors the header `.layout-fullwidth`
+// pattern (`_header_builder_common.scss:34-38`). Customizer field
+// `site_content_layout` writes class `site-content-fullwidth` onto
+// `.site-content`; this rule lets the inner container escape the
+// default 1248px max-width and span the viewport.
+//
+// The companion class `site-content-boxed` deliberately has no rule —
+// boxed = default behavior of `.customify-container` above. Setting
+// default is `site-content-boxed`, so 30K legacy sites that never
+// touched the radio keep rendering the same boxed layout.
+.site-content-fullwidth {
+    .customify-container {
+        max-width: initial;
+    }
+}
+
 .site-content {
     // Hard-coded `#fff` overrode the body bg and broke dark-Palette sites:
     // setting Base=#000 made the body dark but `.site-content` still painted


### PR DESCRIPTION
## Summary

The **Site content layout** radio at Customizer → Global → Layouts has been orphaned since 2017-12-27 (`b04c6a44`, Kien T). 3-axis git history search confirms: no commit ever wired the handler to read the setting, and no SCSS rule ever consumed the `.site-content-fullwidth` / `.site-content-boxed` class.

Quick fix in 2 files (34 LOC), mirroring the header `.layout-fullwidth` pattern at [_header_builder_common.scss:34-38](src/frontend/scss/header/_header_builder_common.scss#L34).

## Changes

**1. `inc/element-classes.php`** — `customify_site_content_classes()` now pushes the saved `site_content_layout` value into the `.site-content` class array. Same wiring convention as the neighboring `site_layout` reader.

**2. `src/frontend/scss/layouts/_layouts.scss`** — Add `.site-content-fullwidth .customify-container { max-width: initial; }` mirror of the header rule. Companion `.site-content-boxed` deliberately has no rule (boxed = default container max-width 1248px).

## 30K safety

| Saved value | Pre-fix render | Post-fix render | Δ |
|---|---|---|---|
| (default `site-content-boxed`) | boxed 1248px | boxed 1248px | byte-identical ✓ |
| `site-content-boxed` (explicit save) | boxed 1248px | boxed 1248px | byte-identical ✓ |
| `site-content-fullwidth` (explicit save) | boxed 1248px (UI lied for 8 years) | full width | **bug FIX, not regression** |

The visual change only fires for sites whose admin explicitly chose "Full width" — they picked it expecting full width, never got it, now do.

## Verification (Chrome MCP live preview)

| Case | DOM class | Container max-width | Rendered width |
|---|---|---|---|
| 1 — initial default | `site-content site-content-boxed` | `1248px` | 1248px (boxed) ✓ |
| 2 — set fullwidth | `site-content site-content-fullwidth` | `none` (= initial) | 1530px (expanded) ✓ |
| 3 — back to boxed | `site-content site-content-boxed` | `1248px` | 1248px ✓ |

## Test plan

- [ ] Pull DEV after merge, rebuild (`npm run build`)
- [ ] Customizer → Global → Layouts → Site content layout
- [ ] Verify "Full width" → container expands to viewport
- [ ] Verify "Boxed" → container caps at 1248px
- [ ] Verify 30K legacy default render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)