### PR TITLE
fix(layouts): dynamic content-size + wide-size + Narrow content_layout Phase 1

### DIFF
--- a/docs/SPEC-editor-style.md
+++ b/docs/SPEC-editor-style.md
@@ -1,0 +1,404 @@
+# SPEC — Editor Style: content-size + wide-size + Content Layout
+
+Drives block alignment widths (`align=none`, `alignwide`, `alignfull`) across the frontend AND the block editor canvas, so authors see the rendered widths their visitors will see. Built on `--wp--style--global--content-size` + `--wp--style--global--wide-size` CSS variables, plus a per-post `_customify_content_layout` meta with values `''` (default) / `full-width` / `full-stretched` / `narrow`.
+
+Related references:
+- [`SPEC-customizer.md`](SPEC-customizer.md) §12 — Customizer → editor bridge (architectural view)
+- [`SPEC-block-editor.md`](SPEC-block-editor.md) §4 — `Customify_Editor` class
+- [`../AGENTS.md`](../AGENTS.md) §4.11 — container_width must sync to wide-size CSS var
+
+This file is permanent. For transient session notes, use `docs/handoffs/`.
+
+---
+
+## 1. Overview
+
+The system has **three input sources** that resolve to **two CSS variables** that block-layout SCSS + theme block consumers read. The variables are layout-driven (per body class) and content-layout-driven (per `.site-content` class), with editor JS mirroring the resolved values into the block-editor settings store so toolbar alignment dropdowns stay in sync.
+
+| Surface | Role |
+|---|---|
+| `container_width` Customizer slider | Scales the typography readability cap proportionally per-site |
+| `narrow_width` Customizer slider | Width used by the "Narrow" Content Layout option (default 800px) |
+| `single_blog_post_content_width` Customizer slider | User override for single posts only |
+| `_customify_content_layout` post meta | Per-post override: `''` / `full-width` / `full-stretched` / `narrow` |
+| `--wp--style--global--content-size` | Block max-width for `align=none` (also read by Blocksify Section "Inherit ON") |
+| `--wp--style--global--wide-size` | Block max-width for `alignwide` |
+| Frontend SCSS (`_blocks.scss`) | Applies the vars + alignwide breakout |
+| Editor PHP (`editor.php`) | Initial body var + per-post sidebar resolution |
+| Editor JS (`page-settings/index.js::ContentSizeSync`) | Live updates body var + block-editor settings store |
+| Anchor option (`customify_layout_content_size_anchor`) | Per-site upgrade-time snapshot for 30K zero-diff |
+
+---
+
+## 2. File map
+
+| File | Lines | Responsibility |
+|---|---|---|
+| [`inc/template-functions.php`](../inc/template-functions.php) | ~21-296 | `customify_get_container_width_value()`, `customify_get_layout_content_sizes()`, `customify_get_narrow_width_value()`, `customify_layout_content_size_css()`, anchor migration |
+| [`inc/customizer/configs/layouts.php`](../inc/customizer/configs/layouts.php) | ~85-125 | `container_width` + `narrow_width` slider fields |
+| [`inc/customizer/configs/single-blog-post.php`](../inc/customizer/configs/single-blog-post.php) | ~22-40 | `single_blog_post_content_width` slider |
+| [`inc/admin/editor.php`](../inc/admin/editor.php) | ~178-240 | `Customify_Editor::css()` — emits body content-size + alignwide breakout for editor canvas |
+| [`inc/admin/page-settings.php`](../inc/admin/page-settings.php) | ~131-200 | Localizes config (`contentSizeMap`, `postType`, `postContentSize`, `narrowWidth`, `wideSize`) |
+| [`inc/class-metabox.php`](../inc/class-metabox.php) | ~60-72 | Classic editor Content Layout dropdown |
+| [`src/backend/page-settings/index.js`](../src/backend/page-settings/index.js) | ~25-260 | `ContentSizeSync` + `syncEditorLayoutSettings` |
+| [`src/frontend/scss/base/_blocks.scss`](../src/frontend/scss/base/_blocks.scss) | ~16-50 | Frontend alignwide breakout |
+
+---
+
+## 3. Storage shape & data contract
+
+### 3.1 `theme_mod` keys
+
+| Key | Stored type | Default | Notes |
+|---|---|---|---|
+| `container_width` | array `{ value: int, unit: 'px' }` | unsaved → falls back to 1248 (SCSS hardcode) | Slider, range 700–2000 |
+| `narrow_width` | array `{ value: int, unit: 'px' }` | unsaved → 800 | Slider, range 400–1000 |
+| `single_blog_post_content_width` | array `{ value: int, unit: 'px' }` | unsaved → 863 | Slider, range 400–1200 |
+
+### 3.2 `wp_options` keys
+
+| Option | Stored type | Notes |
+|---|---|---|
+| `customify_layout_content_size_anchor` | int | Per-site anchor for proportional scaling (= container_width snapshot at upgrade). Default 1248. |
+| `customify_layout_anchor_migrated_v1` | string `'1'` | Idempotency flag for `customify_migrate_layout_content_size_anchor()` |
+
+### 3.3 `post_meta` keys
+
+| Meta key | Post type | Stored type | Possible values |
+|---|---|---|---|
+| `_customify_content_layout` | any | string | `''` (default) / `'full-width'` / `'full-stretched'` / `'narrow'` |
+
+### 3.4 Anchor migration
+
+`customify_migrate_layout_content_size_anchor()` hooked at `after_setup_theme:5`. Captures current `container_width` (or 1248 fallback when unsaved) into `customify_layout_content_size_anchor`. Idempotent via the `_v1` flag. See [`migration-guide.md`](migration-guide.md) §2.
+
+**Why per-site**: a global anchor (e.g. hardcoded 1248) would silently scale content-size on sites that had explicitly saved `container_width = 1500`. Per-site capture means `factor = 1.0` immediately after upgrade — zero rendered diff for every existing site regardless of their saved values. Scaling only kicks in when the user moves the slider AFTER the upgrade.
+
+### 3.5 Defaults
+
+| Setting | Default at unsaved state | What renders |
+|---|---|---|
+| `container_width` | unsaved | SCSS hardcoded 1248 wins (Customizer Auto-CSS skips emission for default values) |
+| `narrow_width` | 800 | `.site-content.content-narrow` rule emits this fallback |
+| `single_blog_post_content_width` | 863 | `body.single-post` rule emits this fallback |
+| anchor | first run → captured from container_width | factor = 1.0 |
+
+---
+
+## 4. Render pipeline
+
+### 4.1 Resolution priority for `--wp--style--global--content-size` on body
+
+Cascade order (later wins for same selector):
+
+1. **`theme.json`** (static, loaded as `:root { --wp--style--global--content-size: 863px }`)
+2. **`body.main-layout-<layout>`** — emitted by `customify_layout_content_size_css()` (inline CSS on `customify-style` handle):
+   - `.main-layout-content` → no_sidebar formula
+   - 1-sidebar variants → falls through to theme.json (no body rule), wide-size body rule sets wide explicitly
+   - 2-sidebar variants → two_sidebars formula
+3. **`body.single-post`** — emitted by `single_blog_post_content_width` field's `css_format` (auto-CSS pipeline). Wins for single posts over the layout rule by source order.
+4. **`.site-content.content-<layout>`** — closer ancestor than body, overrides for per-post Content Layout:
+   - `.content-narrow` → narrow_width Customizer value
+   - `.content-full-width` → `calc(100vw - 64px)`
+   - `.content-full-stretched` → `100vw`
+
+### 4.2 Per-layout sizes (matrix)
+
+At default state (`container_width` unsaved → anchor 1248):
+
+| Layout / Content Layout | `--wp--style--global--content-size` | `--wp--style--global--wide-size` |
+|---|---|---|
+| Default no-sidebar (`.main-layout-content`) | **1184px** (= no_sidebar, scaled) | **1584px** (= content + 400) |
+| 1-sidebar (content-sidebar, sidebar-content) | 863px (theme.json fallback, scaled cap) | **863px** (explicit body rule, no breakout into sidebar) |
+| 2-sidebar (3 variants) | **542px** (scaled cap) | **542px** (= content) |
+| `.content-narrow` | **800px** (Customizer narrow_width) | **1200px** (= narrow + 400) |
+| `.content-full-width` | **calc(100vw - 64px)** (container content-box at 100% with 2em padding each side) | **calc(100vw - 64px)** |
+| `.content-full-stretched` | **100vw** (no container padding) | **100vw** |
+
+When `container_width` is saved away from anchor, the **scaled cap** scales proportionally: `value = round(default * container_width / anchor)`.
+
+### 4.3 Formula: `customify_get_layout_content_sizes()`
+
+```
+cw     = customify_get_container_width_value()       // 1248 fallback when unsaved
+anchor = get_option( 'customify_layout_content_size_anchor', 1248 )
+factor = cw / anchor
+
+cap_no_sidebar   = round( 1184 * factor )
+cap_one_sidebar  = round(  863 * factor )
+cap_two_sidebars = round(  542 * factor )
+
+inner = max(0, cw - 64)        // .customify-container content-box (after 2em*2 padding)
+grid  = inner + 32             // gridlex grid (negative 1em margin each side)
+
+parent_no_sidebar   = grid - 32           // col padding only
+parent_one_sidebar  = round(grid * 0.75) - 32 - 16   // col + 1-side content-inner pad
+parent_two_sidebars = round(grid * 0.5)  - 32 - 32   // col + 2-side content-inner pad
+
+return min(cap, parent)  per layout
+```
+
+**Why `min(cap, parent)`**: the cap is a typography readability target (~60–80 chars/line). The parent is the actual frontend column geometry. Returning the smaller value gives the width blocks actually reach on the frontend — which the editor canvas can then use directly (no nesting structure to constrain editor blocks naturally). Keeps editor WYSIWYG honest.
+
+### 4.4 Frontend SCSS — alignwide breakout
+
+[`_blocks.scss:29-58`](../src/frontend/scss/base/_blocks.scss):
+
+```scss
+.entry-content > .alignwide {
+    --customify-alignwide-actual: max(
+        100%,
+        min(var(--wp--style--global--wide-size, 1200px), calc(100vw - 32px))
+    );
+    width: var(--customify-alignwide-actual);
+    margin-left:  calc((100% - var(--customify-alignwide-actual)) / 2);
+    margin-right: calc((100% - var(--customify-alignwide-actual)) / 2);
+    box-sizing: border-box;
+}
+```
+
+- **`max(100%, ...)`** — floor at parent width so a narrow viewport never makes alignwide visually smaller than `align=none`. Cascade intent: "wide ≥ none, always".
+- **`min(wide-size, 100vw - 32px)`** — ceiling at viewport-32 so breakout never causes horizontal scroll. The breakout dynamically shrinks (down to 0/side on tiny viewports).
+- **Negative inline margins** center the over-wide box across the parent's midline, same approach as alignfull's `calc(50% - 50vw)` but bounded.
+
+### 4.5 Editor canvas mirror
+
+[`editor.php::css()`](../inc/admin/editor.php):
+1. Resolves layout from post sidebar meta + force-no-sidebar overrides
+2. Resolves `$size` based on content_layout / post type:
+   - `narrow` → narrow_width
+   - `full-width` → `calc(100vw - 64px)`
+   - `full-stretched` → `100vw`
+   - post type `post` + saved single_blog_post_content_width → user value
+   - else → layout-derived
+3. Emits `body { --wp--style--global--content-size: $size; }` (no `!important`)
+4. Emits `.editor-styles-wrapper > .is-root-container > .alignwide` rule (same formula as frontend SCSS)
+
+[`page-settings/index.js::ContentSizeSync`](../src/backend/page-settings/index.js):
+1. Watches `_customify_sidebar` + `_customify_content_layout` meta via `useEntityProp`
+2. Computes `size` (priority: full-width/stretched calc, narrow, post override, layout)
+3. Computes `wideSize` (size + 400 for no-sidebar family, same as size for viewport-bound or sidebar layouts)
+4. `buildContentSizeCss()` → injects `<style id="customify-layout-content-size">` into editor iframe head with body content-size + per-layout max-width override on root blocks
+5. `syncEditorLayoutSettings()` → dispatches `updateSettings({ layout, __experimentalFeatures })` so block-toolbar dropdown labels match runtime values
+6. Subscribes to `core/block-editor` store to re-apply after WP overwrites settings during bootstrap
+
+---
+
+## 5. Design decisions
+
+### 5.1 Per-site anchor migration vs global hardcoded anchor
+
+- **Chose**: capture `container_width` per-site at first `after_setup_theme:5` run after upgrade
+- **Rejected**: hardcoded anchor = 1248 globally
+- **Reason**: a global anchor would shift content-size on sites that explicitly saved non-default container_width. Per-site capture gives `factor=1.0` immediately after migration → zero rendered diff for every existing site. Scaling only kicks in when the user moves the slider AFTER upgrade — which is when they actually want scaling.
+
+### 5.2 `min(cap, parent)` formula for layout content sizes
+
+- **Chose**: return `min(typography_cap, frontend_parent_geometry)` per layout
+- **Rejected**: cap-only OR parent-only
+- **Reason**: cap-only would let editor blocks render at sizes the frontend column can't actually reach (lying about WYSIWYG). Parent-only would let alignment dropdown labels grow without bound on wide containers, ignoring readability. Both bounds, smaller wins.
+
+### 5.3 Viewport-bound content-size for Full Width / Full Stretched
+
+- **Chose**: emit `calc(100vw - 64px)` (Full Width) and `100vw` (Stretched) directly to the CSS variable
+- **Rejected**: keep variable at no_sidebar fallback (1184) and use SCSS exclusions to bypass the cap per layout
+- **Reason**: third-party consumers (Blocksify Section's "Inherit Max Width from Theme") read `--wp--style--global--content-size` directly. If theme keeps it at 1184 even for Full Width, those blocks stay capped at reading-column width even though the section spans viewport. Emitting the variable correctly makes ALL consumers (Core blocks via SCSS, third-party blocks reading the var) naturally fill the available container space without per-block CSS hacks.
+
+### 5.4 Wide-size = content for sidebar layouts (no breakout into sidebar)
+
+- **Chose**: emit `--wp--style--global--wide-size: <content_size>` for 1-sidebar and 2-sidebar layouts
+- **Rejected**: emit wide-size = content + 400 for ALL layouts, let alignwide breakout into sidebar visually
+- **Reason**: alignwide extending into the sidebar area looks broken. User confirmed Q2: "if page has sidebar layout, don't worry — wide stays in content, doesn't overlap sidebar". Setting wide-size = column width lets alignwide visually = align=none in sidebar layouts (which IS the expected behavior).
+
+### 5.5 Editor settings.layout sync via subscribe
+
+- **Chose**: `syncEditorLayoutSettings()` subscribes to `core/block-editor` store, re-applies on every settings change
+- **Rejected**: dispatch once on mount
+- **Reason**: WP editor bootstrap loads theme.json values into settings AFTER plugin mount. A one-shot dispatch gets overwritten. Subscribe + re-apply with internal bail-out (compare current vs desired) keeps values stuck without infinite loop.
+
+### 5.6 PHP no-op for full-width max-width override; JS owns it
+
+- **Chose**: PHP `editor.php` only emits body content-size; JS handles the per-block max-width override for full-width / full-stretched
+- **Rejected**: PHP also emits `max-width: none` based on saved meta
+- **Reason**: PHP CSS is static for the page load. When user toggles content_layout in the metabox, PHP-emitted override stays applied and JS can't undo it (different CSS rules). Letting JS own the dynamic part keeps the metabox toggle responsive — JS `<style>` re-renders on every meta change.
+
+### 5.7 Cap removal via dynamic content-size, not SCSS exclusion
+
+- **Chose**: emit content-size = viewport-bound for full-width/stretched. SCSS rule applies uniformly.
+- **Rejected**: keep content-size at fixed value, use `:not(.content-full-width):not(.content-full-stretched)` to exclude from cap rule
+- **Reason**: dynamic value approach makes ALL consumers adapt automatically (Core blocks via SCSS, third-party blocks via var). The exclusion approach only handles Core blocks via custom SCSS and leaves third-party consumers stuck at 1184.
+
+---
+
+## 6. Adding / extending
+
+### 6.1 Adding a new Content Layout value (similar to Narrow)
+
+```php
+// Step 1 — Add to CONTENT_LAYOUT_OPTIONS in src/backend/page-settings/index.js
+{ label: __( 'My Layout', 'customify' ), value: 'my-layout' }
+
+// Step 2 — If it forces no-sidebar, add to NO_SIDEBAR_CONTENT_LAYOUTS in JS
+const NO_SIDEBAR_CONTENT_LAYOUTS = [ 'full-width', 'full-stretched', 'narrow', 'my-layout' ];
+
+// Step 3 — Add to PHP force-no-sidebar guard in inc/template-functions.php
+if ( in_array( $content_layout, array( 'full-width', 'full-stretched', 'narrow', 'my-layout' ), true ) ) {
+    return 'content';
+}
+
+// Step 4 — If it needs a Customizer width slider, add to inc/customizer/configs/layouts.php
+// (model on narrow_width)
+
+// Step 5 — Emit .site-content.content-my-layout rule in customify_layout_content_size_css()
+
+// Step 6 — Handle in editor.php editor canvas branch:
+elseif ( 'my-layout' === $content_layout ) {
+    $size = '...';
+}
+
+// Step 7 — Handle in JS buildContentSizeCss + size resolution
+
+// Step 8 — Add to classic editor metabox in inc/class-metabox.php
+
+// Step 9 — npm run build
+```
+
+### 6.2 Overriding sizes via filter
+
+```php
+// Override content-size values per layout (frontend + editor consume same function)
+add_filter( 'customify/layout_content_sizes', function ( $sizes ) {
+    $sizes['no_sidebar'] = '1400px';
+    return $sizes;
+} );
+```
+
+### 6.3 Reading the resolved sizes programmatically
+
+```php
+$sizes = customify_get_layout_content_sizes();
+// array( 'no_sidebar' => '1184px', 'one_sidebar' => '863px', 'two_sidebars' => '542px' )
+
+$narrow = customify_get_narrow_width_value();
+// '800px' (CSS length string)
+
+$cw = customify_get_container_width_value();
+// 1248 (int, px)
+```
+
+---
+
+## 7. Hooks & filters catalog
+
+### 7.1 Filters
+
+| Hook | Type | Payload | Purpose |
+|---|---|---|---|
+| `customify/layout_content_sizes` | filter | `array{ no_sidebar:string, one_sidebar:string, two_sidebars:string }` | Override per-layout content-size values |
+| `customify_get_layout` | filter | `string|null $layout` | Force no-sidebar for full-width/full-stretched/narrow content_layout (priority via `customify_force_no_sidebar_for_full_content_layout`) |
+
+### 7.2 Actions
+
+| Hook | Type | Purpose |
+|---|---|---|
+| `after_setup_theme` (priority 5) | action | `customify_migrate_layout_content_size_anchor()` — one-time anchor capture |
+
+---
+
+## 8. Known issues / edge cases
+
+### Issue #1 — Customizer live preview slider drag doesn't re-render content-size body rules
+
+When the user moves the `container_width` slider in Customizer live preview, only the field's own `css_format` re-renders (container max-width + wide-size). The static `customify_layout_content_size_css()` output (body content-size rules) is NOT in the auto-CSS rebuild pipeline.
+
+**Effect**: live preview shows container max-width + wide-size updating; content-size body rules stay at page-load values until publish + reload.
+
+**Workaround**: publish, then refresh the preview iframe.
+
+### Issue #2 — theme.json `wideSize` is static (1200px)
+
+Site Editor (if enabled) reads theme.json directly. Customizer changes don't propagate. Edge case for classic theme flow.
+
+### Issue #3 — Blocksify Section + Inherit ON + Full Stretched overflows 64px
+
+When Blocksify Section is set to alignfull with "Inherit Max Width from Theme" enabled, the inner uses `calc(var(content-size) + section_inner_padding * 2)`. In Full Stretched mode, content-size = 100vw → inner = 100vw + 64 → overflows viewport by 64px.
+
+**Workaround**: turn OFF "Inherit Max Width from Theme" for Stretched sections, OR avoid Stretched layout when using Blocksify Section with inherit.
+
+**Root cause**: Blocksify-side — they add inner padding to the content-size cap regardless of whether the section provides padding itself. Fix belongs in Blocksify CSS rule.
+
+### Issue #4 — Editor dropdown labels for Full Width / Stretched are non-numeric
+
+The toolbar alignment dropdown labels read settings.__experimentalFeatures.layout.contentSize. For Full Width / Stretched we push the calc-string `'calc(100vw - 64px)'` / `'100vw'` to keep CSS behaviour aligned. Labels display "Max calc(100vw - 64px) wide" instead of a numeric "Max 1780px wide".
+
+**Cosmetic**: functional behavior is correct. Could be improved by computing a viewport-aware numeric snapshot for the settings push while keeping the body var as calc.
+
+---
+
+## 9. Pro plugin handoff
+
+`Customify_Pro_Module_<Editor>` doesn't exist — this is theme-side only. If a future Pro module wants to extend, it must:
+
+- Honor the `customify/layout_content_sizes` filter and pass through the array shape `{ no_sidebar, one_sidebar, two_sidebars }`
+- Honor the `--wp--style--global--content-size` / `--wp--style--global--wide-size` CSS variable contract on body + `.site-content.content-<layout>`
+- Honor the `_customify_content_layout` meta values (`'' / full-width / full-stretched / narrow`) and the body class derivation `.site-content.content-<value>`
+
+See [`SPEC-pro-integration.md`](SPEC-pro-integration.md) for the full contract.
+
+---
+
+## 10. Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Editor block widths don't match frontend | Outdated browser cache → hard reload (Cmd+Shift+R). Also check `getSettings().__experimentalFeatures.layout.contentSize` in console matches `getComputedStyle(body).getPropertyValue('--wp--style--global--content-size')`. |
+| Container width slider doesn't visibly change content area on existing sites | Site has `container_width` saved at a value that produces `factor=1.0` against the captured anchor. Expected — anchor migration zero-diff design. |
+| Narrow Content Layout dropdown doesn't appear | Build outdated. Run `npm run build` and reload editor. |
+| Block toolbar dropdown shows "Max 100vw wide" or "Max calc(...) wide" | Expected for Full Width / Stretched. Cosmetic — see Issue #4. |
+| `_customify_content_layout = narrow` but sidebar still renders | Sidebar meta took precedence over theme support meta lookup. Check `customify_force_no_sidebar_for_full_content_layout` filter ran (`'narrow' in array`). |
+| Blocksify Section inner doesn't fill section in alignfull | Either: (a) section is in Stretched mode → Issue #3 (Blocksify-side); (b) "Inherit Max Width from Theme" is OFF (per-block custom max-width set). |
+| Single post `single_blog_post_content_width` doesn't show in editor | Customizer hasn't been saved (still default). OR post is being edited as `page` post type (single_blog_post_content_width is post-only). |
+
+---
+
+## 11. Quick reference — how do I…?
+
+| I want to… | Code |
+|---|---|
+| Read resolved layout content sizes (PHP) | `customify_get_layout_content_sizes()` |
+| Read resolved narrow_width (PHP) | `customify_get_narrow_width_value()` |
+| Read resolved container_width (PHP) | `customify_get_container_width_value()` |
+| Override content-sizes for a child theme | `add_filter( 'customify/layout_content_sizes', fn ($s) => [ ... ] );` |
+| Detect Narrow content_layout (PHP, post context) | `get_post_meta( $post_id, '_customify_content_layout', true ) === 'narrow'` |
+| Detect Narrow content_layout (JS, editor) | `wp.data.select( 'core/editor' ).getEditedPostAttribute( 'meta' )._customify_content_layout === 'narrow'` |
+| Force a content_layout via REST | `POST /wp-json/wp/v2/pages/<id>` with `{ meta: { _customify_content_layout: 'narrow' } }` |
+
+---
+
+## 12. Where to look next
+
+**PHP**
+- [`inc/template-functions.php`](../inc/template-functions.php) — helpers + `customify_layout_content_size_css()` + migration
+- [`inc/customizer/configs/layouts.php`](../inc/customizer/configs/layouts.php) — Customizer fields
+- [`inc/customizer/configs/single-blog-post.php`](../inc/customizer/configs/single-blog-post.php) — `single_blog_post_content_width`
+- [`inc/admin/editor.php`](../inc/admin/editor.php) — `Customify_Editor` class, editor canvas inline CSS
+- [`inc/admin/page-settings.php`](../inc/admin/page-settings.php) — block editor metabox + JS config localize
+- [`inc/class-metabox.php`](../inc/class-metabox.php) — classic editor metabox
+
+**JavaScript**
+- [`src/backend/page-settings/index.js`](../src/backend/page-settings/index.js) — `ContentSizeSync` + `syncEditorLayoutSettings`
+
+**SCSS**
+- [`src/frontend/scss/base/_blocks.scss`](../src/frontend/scss/base/_blocks.scss) — `.entry-content > .alignwide` breakout, `> *` content-size cap
+- [`src/frontend/scss/layouts/_layouts.scss`](../src/frontend/scss/layouts/_layouts.scss) — `.customify-container` padding, `.content-full-{width,stretched}` container overrides, per-sidebar `.content-inner` padding
+
+**Related specs**
+- [`SPEC-customizer.md`](SPEC-customizer.md) §12 — Customizer → editor bridge
+- [`SPEC-block-editor.md`](SPEC-block-editor.md) §4 — `Customify_Editor` overview
+- [`SPEC-data-migration-policy.md`](SPEC-data-migration-policy.md) — anchor migration pattern
+
+**Conventions**
+- [`../AGENTS.md`](../AGENTS.md) §4.1 — 30k-site safety (migration design rationale)
+- [`../AGENTS.md`](../AGENTS.md) §4.7 — CSS handle must be `customify-style`
+- [`../AGENTS.md`](../AGENTS.md) §4.11 — container_width sync to wide-size var
+- [`../AGENTS.md`](../AGENTS.md) §4.13 — alignwide / alignfull modern pattern

--- a/inc/admin/editor.php
+++ b/inc/admin/editor.php
@@ -82,11 +82,15 @@ class Customify_Editor {
 			'background',                       // Page bg composite — re-scoped to .editor-styles-wrapper below
 			'site_content_styling',
 			'content_background',
-			'single_blog_post_content_width',
 			'global_typography_heading_h1',
 			'global_typography_base_heading',
 			'global_styling_color_heading',
 		);
+		// `single_blog_post_content_width` intentionally NOT in $keys: a :root rule
+		// emitted via the standard pipeline would be shadowed by the body-scoped
+		// content-size rule the layout-driven block below emits. The user value is
+		// folded into that branch when editing a single post, mirroring how the
+		// frontend `body.single-post` rule wins by cascade source-order.
 
 		foreach ( $keys as $k ) {
 			$f = Customify()->customizer->get_field_setting( $k );
@@ -112,19 +116,6 @@ class Customify_Editor {
 			// Sync wide-size CSS var into editor so theme.json + customizer stay in sync.
 			$fields['container_width']['selector']   = ':root';
 			$fields['container_width']['css_format'] = '--wp--style--global--wide-size: {{value}};';
-		}
-
-		if ( $fields['single_blog_post_content_width'] ) {
-			// Sync content-size CSS var only when editing a post (setting is single-post scoped);
-			// pages and other post types keep theme.json's default to match frontend behavior.
-			$screen            = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-			$editing_post_type = $screen ? $screen->post_type : '';
-			if ( 'post' === $editing_post_type ) {
-				$fields['single_blog_post_content_width']['selector']   = ':root';
-				$fields['single_blog_post_content_width']['css_format'] = '--wp--style--global--content-size: {{value}};';
-			} else {
-				unset( $fields['single_blog_post_content_width'] );
-			}
 		}
 
 		if ( $fields['global_typography_base_heading'] ) {
@@ -172,6 +163,17 @@ class Customify_Editor {
 		.editor-styles-wrapper > .is-root-container > *:not(.alignfull):not(.alignwide) {
 			max-width: var(--wp--style--global--content-size, 780px);
 		}
+		.editor-styles-wrapper > .is-root-container > .alignwide {
+			--customify-alignwide-actual: max(
+				100%,
+				min(var(--wp--style--global--wide-size, 1200px), calc(100vw - 32px))
+			);
+			width: var(--customify-alignwide-actual);
+			margin-left: calc((100% - var(--customify-alignwide-actual)) / 2);
+			margin-right: calc((100% - var(--customify-alignwide-actual)) / 2);
+			max-width: none;
+			box-sizing: border-box;
+		}
 		';
 
 		$post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0;
@@ -182,31 +184,63 @@ class Customify_Editor {
 
 		// Layout-driven contentSize: keep block max-width in sync with the active
 		// sidebar layout so what the user sees in the editor matches the frontend
-		// column width. Applied last so it wins over single_blog_post_content_width
-		// and theme.json. Targets `body` with `!important` because theme.json emits
-		// the variable on `body` — a `:root` rule loses to that within body's scope.
+		// column width. Targets `body` (no !important): the variable is custom-
+		// property-inheritable, so the closer-ancestor body rule overrides the
+		// theme.json :root baseline for any element inside body without needing
+		// to win specificity.
 		//
 		// Content Layout meta (full-width / full-stretched) overrides the sidebar
 		// layout to the no-sidebar size — these modes hide the sidebar regardless
 		// of the per-post sidebar setting.
 		//
+		// Single-post override: when editing a post, the user's
+		// single_blog_post_content_width Customizer setting (if saved) wins over
+		// the layout-derived size. Mirrors the frontend `body.single-post` rule
+		// (inc/customizer/configs/single-blog-post.php) so editor matches render.
+		//
 		// Live-reactive counterpart lives in src/backend/page-settings/index.js.
 		if ( $post_id ) {
 			$content_layout = get_post_meta( $post_id, '_customify_content_layout', true );
-			if ( in_array( $content_layout, array( 'full-width', 'full-stretched' ), true ) ) {
+			if ( in_array( $content_layout, array( 'full-width', 'full-stretched', 'narrow' ), true ) ) {
 				$layout = 'content';
 			} else {
 				$layout = self::resolve_post_sidebar_layout( $post_id );
 			}
 			$size = customify_get_content_size_for_layout( $layout );
-			$css .= "body { --wp--style--global--content-size: {$size} !important; }";
 
-			// Full-stretched additionally drops the max-width so blocks fill the
-			// container, matching the frontend `.site-content.content-full-stretched`
-			// rule in src/frontend/scss/base/_blocks.scss.
-			if ( 'full-stretched' === $content_layout ) {
-				$css .= '.editor-styles-wrapper > .is-root-container > *:not(.alignfull):not(.alignwide) { max-width: none; }';
+			// Content Layout overrides for content-size — match the per-layout
+			// rules emitted by customify_layout_content_size_css() so the editor
+			// canvas matches the frontend. Full-Width uses calc(100vw - 64px)
+			// (container content-box at 100% with 2em padding each side);
+			// Full-Stretched uses 100vw (no container padding); Narrow uses the
+			// Customizer narrow_width value.
+			if ( 'narrow' === $content_layout ) {
+				$size = customify_get_narrow_width_value();
+			} elseif ( 'full-width' === $content_layout ) {
+				$size = 'calc(100vw - 64px)';
+			} elseif ( 'full-stretched' === $content_layout ) {
+				$size = '100vw';
 			}
+
+			$screen            = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+			$editing_post_type = $screen ? $screen->post_type : '';
+			if ( 'post' === $editing_post_type ) {
+				$user_cw = Customify()->get_setting( 'single_blog_post_content_width' );
+				if ( is_array( $user_cw ) && isset( $user_cw['value'] ) && '' !== $user_cw['value'] ) {
+					$unit = ! empty( $user_cw['unit'] ) ? $user_cw['unit'] : 'px';
+					$size = $user_cw['value'] . $unit;
+				}
+			}
+
+			$css .= "body { --wp--style--global--content-size: {$size}; }";
+
+			// Block max-width override for full-width / full-stretched is emitted
+			// from JS (src/backend/page-settings/index.js::buildContentSizeCss), NOT
+			// here. PHP-emitted CSS is static for the page load — if it included the
+			// override based on the saved meta, toggling content_layout in the
+			// editor sidebar wouldn't be able to undo it because the PHP rule keeps
+			// applying. Letting JS own the dynamic override keeps the metabox
+			// toggle responsive.
 		}
 
 		$css .= '.editor-styles-wrapper ul,

--- a/inc/admin/page-settings.php
+++ b/inc/admin/page-settings.php
@@ -141,15 +141,66 @@ class Customify_Page_Settings {
 			? Customify_Editor::customizer_sidebar_layout_for_post_type( $post_type )
 			: 'content-sidebar';
 
+		// Single-post user override: matches the frontend body.single-post rule
+		// from inc/customizer/configs/single-blog-post.php — when editing a post,
+		// the user's saved single_blog_post_content_width takes precedence over
+		// the layout-derived size. Scoped to post_type === 'post' only; other
+		// post types fall through to the layout map. Sent as the normalized
+		// CSS length string (e.g., "600px") so JS doesn't have to recreate the
+		// {value, unit} → length logic.
+		$post_content_size = null;
+		if ( 'post' === $post_type ) {
+			$pcw = Customify()->get_setting( 'single_blog_post_content_width' );
+			if ( is_array( $pcw ) && isset( $pcw['value'] ) && '' !== $pcw['value'] ) {
+				$pcw_unit          = ! empty( $pcw['unit'] ) ? $pcw['unit'] : 'px';
+				$post_content_size = $pcw['value'] . $pcw_unit;
+			}
+		}
+
+		// wideSize for the editor's layout settings sync — pushed into
+		// getSettings().__experimentalFeatures.layout so block dropdown labels
+		// (e.g., "Wide width — Max 1200px wide") match the runtime CSS variable.
+		//
+		// Resolution mirrors what `--wp--style--global--wide-size` actually
+		// resolves to in the editor iframe:
+		//   - container_width has a saved value → editor.php's container_width
+		//     branch emits `:root { --wp--style--global--wide-size: VALUE }`
+		//     via the auto-CSS pipeline. wideSize === saved value.
+		//   - container_width is unsaved → auto-CSS skips emission; only
+		//     theme.json's static wideSize (1200px) applies. Read it via
+		//     wp_get_global_settings() so any theme.json overrides upstream
+		//     stay authoritative.
+		$wide_size = null;
+		$cw_raw    = get_theme_mod( 'container_width' );
+		if ( is_array( $cw_raw ) && ! empty( $cw_raw['value'] ) ) {
+			$wide_size = (int) $cw_raw['value'] . ( ! empty( $cw_raw['unit'] ) ? $cw_raw['unit'] : 'px' );
+		} elseif ( is_numeric( $cw_raw ) && (int) $cw_raw > 0 ) {
+			$wide_size = (int) $cw_raw . 'px';
+		} else {
+			$global_settings = function_exists( 'wp_get_global_settings' ) ? wp_get_global_settings() : array();
+			$wide_size       = $global_settings['layout']['wideSize'] ?? '1200px';
+		}
+
+		// narrowWidth — used when content_layout meta is 'narrow'. Mirrors
+		// customify_get_narrow_width_value() + the .site-content.content-narrow
+		// frontend rule, so editor + frontend stay in sync.
+		$narrow_width = function_exists( 'customify_get_narrow_width_value' )
+			? customify_get_narrow_width_value()
+			: '800px';
+
 		wp_localize_script(
 			'customify-page-settings',
 			'customifyPageSettings',
 			array(
-				'sidebarLayouts' => customify_get_config_sidebar_layouts(),
-				'hasProFeatures' => (bool) class_exists( 'Customify_Pro' ),
-				'hasBreadcrumb'  => (bool) $has_breadcrumb,
-				'fallbackLayout' => $fallback_layout,
-				'contentSizeMap' => customify_get_layout_content_sizes(),
+				'sidebarLayouts'  => customify_get_config_sidebar_layouts(),
+				'hasProFeatures'  => (bool) class_exists( 'Customify_Pro' ),
+				'hasBreadcrumb'   => (bool) $has_breadcrumb,
+				'fallbackLayout'  => $fallback_layout,
+				'contentSizeMap'  => customify_get_layout_content_sizes(),
+				'postType'        => $post_type,
+				'postContentSize' => $post_content_size,
+				'wideSize'        => $wide_size,
+				'narrowWidth'     => $narrow_width,
 			)
 		);
 

--- a/inc/class-metabox.php
+++ b/inc/class-metabox.php
@@ -66,6 +66,7 @@ class Customify_MetaBox {
 				'choices'      => array(
 					'full-width'     => __( 'Full Width', 'customify' ),
 					'full-stretched' => __( 'Full Width - Stretched', 'customify' ),
+					'narrow'         => __( 'Narrow', 'customify' ),
 				),
 				'show_default' => true,
 			)

--- a/inc/customizer/configs/layouts.php
+++ b/inc/customizer/configs/layouts.php
@@ -99,6 +99,33 @@ if ( ! function_exists( 'customify_customizer_layouts_config' ) ) {
 				'css_format'      => ':root { --wp--style--global--wide-size: {{value}}; } .customify-container, .layout-contained, .site-framed .site, .site-boxed .site { max-width: {{value}}; }',
 			),
 
+			// Narrow content width — paired with the "Narrow" Content Layout
+			// option (per-post metabox). Mirrors the Full Width / Full Width –
+			// Stretched pattern: a content_layout value that overrides sidebar
+			// layout to no-sidebar and constrains content-size to this value.
+			// .site-content.content-narrow CSS rule consumes the saved value;
+			// see customify_layout_content_size_css() in inc/template-functions.php.
+			//
+			// Wide-size for narrow = narrow_width + 400 (200px breakout each side)
+			// per the dynamic wide-size design — see the same SPEC in
+			// customify_layout_content_size_css(). `calc({{value}} + 400px)` lets
+			// the Customizer live-preview auto-CSS rebuild keep wide-size in sync
+			// without a separate handler.
+			array(
+				'name'            => 'narrow_width',
+				'type'            => 'slider',
+				'device_settings' => false,
+				'default'         => 800,
+				'min'             => 400,
+				'step'            => 10,
+				'max'             => 1000,
+				'section'         => 'global_layout_section',
+				'title'           => __( 'Narrow Content Width', 'customify' ),
+				'description'     => __( 'Max width when a post uses the "Narrow" Content Layout option in the Page Settings panel.', 'customify' ),
+				'selector'        => 'format',
+				'css_format'      => '.site-content.content-narrow { --wp--style--global--content-size: {{value}}; --wp--style--global--wide-size: calc({{value}} + 400px); }',
+			),
+
 			// Site content layout.
 			array(
 				'name'       => 'site_content_layout',

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -18,6 +18,39 @@ if ( ! function_exists( 'customify_get_config_sidebar_layouts' ) ) {
 	}
 }
 
+if ( ! function_exists( 'customify_get_container_width_value' ) ) {
+	/**
+	 * Resolve the numeric container_width Customizer value in pixels.
+	 *
+	 * The slider control stores its value as either:
+	 *   - array shape: array( 'value' => 1500, 'unit' => 'px' )  — modern
+	 *   - scalar number: 1500                                    — legacy
+	 *   - empty/false: Customizer never saved                    — unsaved
+	 *
+	 * For the unsaved case we return 1248, which is the value 30K production
+	 * sites actually render at — the SCSS `.customify-container { max-width: 1248px }`
+	 * declaration in src/frontend/scss/layouts/_layouts.scss:62 wins because the
+	 * auto-CSS slider pipeline skips emission when the field has no saved value.
+	 *
+	 * @return int Container width in pixels (always > 0).
+	 */
+	function customify_get_container_width_value() {
+		$raw = get_theme_mod( 'container_width' );
+		if ( is_array( $raw ) && ! empty( $raw['value'] ) ) {
+			$value = (int) $raw['value'];
+			if ( $value > 0 ) {
+				return $value;
+			}
+		} elseif ( is_numeric( $raw ) ) {
+			$value = (int) $raw;
+			if ( $value > 0 ) {
+				return $value;
+			}
+		}
+		return 1248;
+	}
+}
+
 if ( ! function_exists( 'customify_get_layout_content_sizes' ) ) {
 	/**
 	 * Single source of truth for the layout-driven block contentSize.
@@ -27,21 +60,109 @@ if ( ! function_exists( 'customify_get_layout_content_sizes' ) ) {
 	 *   - inc/admin/page-settings.php    — localized to JS for live updates
 	 *   - customify_layout_content_size_css() — frontend inline CSS below
 	 *
+	 * The returned size is `min(cap, parent)`:
+	 *
+	 *   - **cap** — a typography-driven readability target (originally 1184/863/542
+	 *     at container_width=1248). Scaled proportionally by `container_width / anchor`,
+	 *     where `anchor` is captured per-site at install / migration time so existing
+	 *     sites see `factor=1` immediately after upgrade (zero rendered diff).
+	 *   - **parent** — the frontend column geometry: container content-box (after
+	 *     2em padding each side), gridlex grid (negative -1em margin each side),
+	 *     gridlex column (col-12/9/6 = 100%/75%/50%), minus col padding (1em each
+	 *     side) and content-inner right padding (16px). Border (1px when
+	 *     sidebar_vertical_border is enabled) is intentionally ignored — sub-pixel.
+	 *
+	 * Returning `min(cap, parent)` produces the value that blocks actually reach
+	 * on the frontend (parent constrains when sliders are at default; the cap
+	 * kicks in when container is widened enough that the readability ceiling
+	 * matters). Editor consumers apply the same value directly because the editor
+	 * iframe has no .customify-container > grid > column nesting — feeding it the
+	 * resolved render-width keeps WYSIWYG honest.
+	 *
 	 * Filterable so a child theme / plugin can override values in one place.
 	 *
 	 * @return array{no_sidebar:string,one_sidebar:string,two_sidebars:string} CSS lengths.
 	 */
 	function customify_get_layout_content_sizes() {
+		$cw     = customify_get_container_width_value();
+		$anchor = (int) get_option( 'customify_layout_content_size_anchor', 1248 );
+		if ( $anchor <= 0 ) {
+			$anchor = 1248;
+		}
+		$factor = $cw / $anchor;
+
+		// Typography readability caps (original hardcoded targets at anchor=1248).
+		$cap_no_sidebar   = (int) round( 1184 * $factor );
+		$cap_one_sidebar  = (int) round(  863 * $factor );
+		$cap_two_sidebars = (int) round(  542 * $factor );
+
+		// Frontend column geometry. See src/frontend/scss/layouts/_layouts.scss
+		// (.customify-container padding 2em) and src/frontend/scss/vendors/gridlex/
+		// (gutter 2em → grid margin -1em, col padding 1em).
+		//
+		// .content-inner padding varies per layout (layouts/_layouts.scss §"Layout: *"):
+		//   - `.content`            (no sidebar)        → no padding (no sidebar to gap from)
+		//   - `.content-sidebar`    (1 right sidebar)   → padding-right: ms(0) ≈ 16px
+		//   - `.sidebar-content`    (1 left sidebar)    → padding-left: ms(0)  ≈ 16px
+		//   - `.sidebar-content-sidebar` (2 sidebars)   → both sides: 32px total
+		//   - `.sidebar-sidebar-content` / `.content-sidebar-sidebar` → only one side: 16px
+		//
+		// Borders from sidebar_vertical_border (1px when enabled) are sub-pixel and
+		// intentionally ignored — they don't drive block layout decisions.
+		//
+		// `two_sidebars` uses the symmetric variant (`sidebar-content-sidebar`) — the most
+		// constrained of the 2-sidebar trio. Asymmetric variants render the same value
+		// (cap-bound, since cap=542 < parent for asymmetric), which is acceptable: editor
+		// is conservative-by-1 rather than divergent.
+		$inner = max( 0, $cw - 64 );
+		$grid  = $inner + 32;
+
+		$parent_no_sidebar   = $grid - 32;                              // col padding only
+		$parent_one_sidebar  = (int) round( $grid * 0.75 ) - 32 - 16;   // col + 1-side content-inner
+		$parent_two_sidebars = (int) round( $grid * 0.5 )  - 32 - 32;   // col + 2-side content-inner
+
+		// Floor at a sane minimum so unusual configs don't produce nonsense like 0px.
+		$no_sidebar   = max( 200, min( $cap_no_sidebar,   $parent_no_sidebar ) );
+		$one_sidebar  = max( 200, min( $cap_one_sidebar,  $parent_one_sidebar ) );
+		$two_sidebars = max( 200, min( $cap_two_sidebars, $parent_two_sidebars ) );
+
 		return apply_filters(
 			'customify/layout_content_sizes',
 			array(
-				'no_sidebar'   => '1184px',
-				'one_sidebar'  => '863px',
-				'two_sidebars' => '542px',
+				'no_sidebar'   => $no_sidebar . 'px',
+				'one_sidebar'  => $one_sidebar . 'px',
+				'two_sidebars' => $two_sidebars . 'px',
 			)
 		);
 	}
 }
+
+if ( ! function_exists( 'customify_migrate_layout_content_size_anchor' ) ) {
+	/**
+	 * One-time migration: capture the per-site anchor for content-size scaling.
+	 *
+	 * Without this, switching customify_get_layout_content_sizes() from hardcoded
+	 * 1184/863/542 to a container_width-driven formula would silently widen the
+	 * content-area on sites that explicitly saved container_width > 1248 (and shrink
+	 * it on sites < 1248). Capturing the anchor at upgrade-time keeps factor=1.0
+	 * immediately after migration — zero rendered diff across the 30K install base.
+	 *
+	 * Subsequent slider changes alter `container_width` but the anchor stays put,
+	 * so the proportional scaling kicks in only when the user actually moves the
+	 * slider after upgrading.
+	 *
+	 * Idempotent via the `customify_layout_anchor_migrated_v1` flag. AGENTS.md §4.1.
+	 */
+	function customify_migrate_layout_content_size_anchor() {
+		if ( get_option( 'customify_layout_anchor_migrated_v1' ) ) {
+			return;
+		}
+		$anchor = customify_get_container_width_value();
+		update_option( 'customify_layout_content_size_anchor', $anchor, false );
+		update_option( 'customify_layout_anchor_migrated_v1', '1', false );
+	}
+}
+add_action( 'after_setup_theme', 'customify_migrate_layout_content_size_anchor', 5 );
 
 if ( ! function_exists( 'customify_get_content_size_for_layout' ) ) {
 	/**
@@ -67,34 +188,109 @@ if ( ! function_exists( 'customify_get_content_size_for_layout' ) ) {
 	}
 }
 
+if ( ! function_exists( 'customify_get_narrow_width_value' ) ) {
+	/**
+	 * Resolve the Customizer narrow_width value as a CSS length string.
+	 *
+	 * Mirrors customify_get_container_width_value() shape handling — slider
+	 * stores either { value, unit } array or scalar, falls back to the field
+	 * default 800px when unsaved.
+	 *
+	 * @return string CSS length (e.g. "800px").
+	 */
+	function customify_get_narrow_width_value() {
+		$raw = get_theme_mod( 'narrow_width' );
+		if ( is_array( $raw ) && isset( $raw['value'] ) && '' !== $raw['value'] ) {
+			$unit = ! empty( $raw['unit'] ) ? $raw['unit'] : 'px';
+			return (int) $raw['value'] . $unit;
+		} elseif ( is_numeric( $raw ) && (int) $raw > 0 ) {
+			return (int) $raw . 'px';
+		}
+		return '800px';
+	}
+}
+
 if ( ! function_exists( 'customify_layout_content_size_css' ) ) {
 	/**
 	 * Frontend CSS that maps body.main-layout-* classes to the matching
-	 * --wp--style--global--content-size, so blocks shrink/expand with the
-	 * active sidebar layout. Kept here (not in SCSS) so all values come
-	 * from customify_get_layout_content_sizes().
+	 * --wp--style--global--content-size and --wp--style--global--wide-size,
+	 * so default-aligned AND wide-aligned blocks both follow the active
+	 * sidebar layout. Kept here (not in SCSS) so all values come from
+	 * customify_get_layout_content_sizes() + customify_get_narrow_width_value().
 	 *
-	 * Per-page Content Layout (.site-content.content-full-{width,stretched})
-	 * forces the no-sidebar size — these rules are scoped to .site-content
-	 * which is closer in the inheritance chain than body, so they win the
-	 * variable resolution regardless of body.main-layout-* specificity.
+	 * Wide-size design (per user spec):
+	 *   - No-sidebar layouts: wide-size = content-size + 400 (200px breakout each side)
+	 *   - Narrow content_layout: wide-size = narrow_width + 400
+	 *   - Sidebar layouts: wide-size = content-size (parent-constrained — wide stays
+	 *     inside the content column, doesn't overlap sidebars per Q2 confirmation)
+	 *
+	 * The visual breakout itself happens in SCSS (.entry-content > .alignwide uses
+	 * negative margins with a max(100%, min(wide-size, 100vw - 32px)) clamp so the
+	 * wide block can't overflow the viewport — see src/frontend/scss/base/_blocks.scss).
+	 *
+	 * Per-page Content Layout (.site-content.content-{full-width,full-stretched,narrow})
+	 * forces a specific content+wide-size — these rules are scoped to .site-content
+	 * which is closer in the inheritance chain than body, so they win the variable
+	 * resolution regardless of body.main-layout-* specificity.
 	 *
 	 * Hooked into customify-style via wp_add_inline_style in class-customify.php.
 	 *
 	 * @return string CSS.
 	 */
 	function customify_layout_content_size_css() {
-		$sizes = customify_get_layout_content_sizes();
+		$sizes  = customify_get_layout_content_sizes();
+		$narrow = customify_get_narrow_width_value();
+
+		// Compute wide-size = content-size + 400 (px) for breakout layouts.
+		// `customify_layout_content_size_value_plus()` keeps unit handling local
+		// so '800px' + 400 stays as '1200px'.
+		$no_sidebar_wide = customify_layout_content_size_value_plus( $sizes['no_sidebar'], 400 );
+		$narrow_wide     = customify_layout_content_size_value_plus( $narrow, 400 );
+
+		// Full-Width / Full-Stretched content_layout: content-size + wide-size are
+		// viewport-bound, not capped at the reading-column no_sidebar value. This
+		// lets BOTH Core blocks (max-width via SCSS rule) AND third-party blocks
+		// that read `--wp--style--global--content-size` (Blocksify Section's
+		// "Inherit Max Width from Theme") naturally fill the available container
+		// space. Full-Width keeps the 32px container padding each side
+		// (calc(100vw - 64px)); Full-Stretched drops the padding too (100vw).
 		return sprintf(
-			'body.main-layout-content{--wp--style--global--content-size:%1$s}'
+			'body.main-layout-content{--wp--style--global--content-size:%1$s;--wp--style--global--wide-size:%2$s}'
+			. 'body.main-layout-content-sidebar,'
+			. 'body.main-layout-sidebar-content{--wp--style--global--wide-size:%3$s}'
 			. 'body.main-layout-sidebar-content-sidebar,'
 			. 'body.main-layout-sidebar-sidebar-content,'
-			. 'body.main-layout-content-sidebar-sidebar{--wp--style--global--content-size:%2$s}'
-			. '.site-content.content-full-width,'
-			. '.site-content.content-full-stretched{--wp--style--global--content-size:%1$s}',
+			. 'body.main-layout-content-sidebar-sidebar{--wp--style--global--content-size:%4$s;--wp--style--global--wide-size:%4$s}'
+			. '.site-content.content-full-width{--wp--style--global--content-size:calc(100vw - 64px);--wp--style--global--wide-size:calc(100vw - 64px)}'
+			. '.site-content.content-full-stretched{--wp--style--global--content-size:100vw;--wp--style--global--wide-size:100vw}'
+			. '.site-content.content-narrow{--wp--style--global--content-size:%5$s;--wp--style--global--wide-size:%6$s}',
 			esc_attr( $sizes['no_sidebar'] ),
-			esc_attr( $sizes['two_sidebars'] )
+			esc_attr( $no_sidebar_wide ),
+			esc_attr( $sizes['one_sidebar'] ),
+			esc_attr( $sizes['two_sidebars'] ),
+			esc_attr( $narrow ),
+			esc_attr( $narrow_wide )
 		);
+	}
+}
+
+if ( ! function_exists( 'customify_layout_content_size_value_plus' ) ) {
+	/**
+	 * Add a pixel delta to a CSS length string, preserving the unit. Used to
+	 * compute wide-size = content-size + 400px without manually parsing every
+	 * caller. Returns the input unchanged if the unit isn't `px` (no other unit
+	 * is in use today — guard is here so future em/rem use doesn't silently
+	 * miscompute).
+	 *
+	 * @param string $value  CSS length (e.g. "1184px").
+	 * @param int    $delta  Pixels to add.
+	 * @return string New CSS length (e.g. "1584px").
+	 */
+	function customify_layout_content_size_value_plus( $value, $delta ) {
+		if ( preg_match( '/^(-?\d+(?:\.\d+)?)px$/', $value, $m ) ) {
+			return ( (float) $m[1] + (int) $delta ) . 'px';
+		}
+		return $value;
 	}
 }
 if ( ! function_exists( 'customify_get_all_image_sizes' ) ) {
@@ -222,7 +418,7 @@ if ( ! function_exists( 'customify_force_no_sidebar_for_full_content_layout' ) )
 			return $layout;
 		}
 		$content_layout = get_post_meta( $post_id, '_customify_content_layout', true );
-		if ( in_array( $content_layout, array( 'full-width', 'full-stretched' ), true ) ) {
+		if ( in_array( $content_layout, array( 'full-width', 'full-stretched', 'narrow' ), true ) ) {
 			return 'content';
 		}
 		return $layout;

--- a/src/backend/page-settings/index.js
+++ b/src/backend/page-settings/index.js
@@ -11,7 +11,7 @@ import './style.scss';
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { useEntityProp } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { useSelect, dispatch, select, subscribe } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
@@ -34,7 +34,10 @@ const TWO_SIDEBAR_LAYOUTS = [
 
 // Content Layout values that disable the sidebar entirely — both visually
 // (we hide the dropdown) and for contentSize purposes (force no_sidebar).
-const NO_SIDEBAR_CONTENT_LAYOUTS = [ 'full-width', 'full-stretched' ];
+// `narrow` joins this list because narrow content is a focused-reading layout
+// — combining it with a sidebar looks lopsided. PHP's
+// customify_force_no_sidebar_for_full_content_layout() applies the same gate.
+const NO_SIDEBAR_CONTENT_LAYOUTS = [ 'full-width', 'full-stretched', 'narrow' ];
 
 function isNoSidebarContentLayout( contentLayout ) {
 	return NO_SIDEBAR_CONTENT_LAYOUTS.includes( contentLayout );
@@ -74,22 +77,34 @@ function injectStyle( doc, id, css ) {
 }
 
 /**
- * Inject the layout-driven --wp--style--global--content-size into both the
- * outer document and the editor canvas iframe (post-WP 6.3 layout).
- *
- * Uses `body` + `!important` because theme.json emits `body { ... }` for
- * global CSS variables — a `:root` rule loses to that within body's scope.
- */
-/**
  * Build the inline CSS payload for a given size + content_layout combo.
- * Full-stretched additionally drops max-width on root blocks so they fill
- * the container, matching inc/admin/editor.php.
+ *
+ * The `max-width: none` override for full-width / full-stretched layouts lives
+ * here (not in PHP editor.php) so toggling content_layout in the metabox can
+ * actually undo it. A PHP-emitted static override would stay applied even
+ * after JS removes it from this style block.
+ *
+ * No !important on the body rule — custom-property inheritance lets the
+ * body-scoped declaration override the theme.json :root baseline for
+ * everything inside body without needing to win specificity. Matches the
+ * frontend cascade in customify_layout_content_size_css().
  */
 function buildContentSizeCss( size, contentLayout ) {
 	let css = '';
 	if ( size ) {
-		css += `body{--wp--style--global--content-size:${ size } !important;}`;
+		css += `body{--wp--style--global--content-size:${ size };}`;
 	}
+	// full-width: block fills canvas with a 32px gap each side, mirroring
+	// the frontend's `.customify-container { padding: 2em }` breathing room.
+	// In the editor there is no .customify-container wrapper, so we subtract
+	// the padding from the block's max-width explicitly.
+	if ( contentLayout === 'full-width' ) {
+		css +=
+			'.editor-styles-wrapper > .is-root-container > *:not(.alignfull):not(.alignwide){max-width:calc(100% - 64px);}';
+	}
+	// full-stretched: block fills canvas edge-to-edge — frontend version sets
+	// `.content-full-stretched > .customify-container { padding: 0 }`, so the
+	// editor matches by removing the cap entirely.
 	if ( contentLayout === 'full-stretched' ) {
 		css +=
 			'.editor-styles-wrapper > .is-root-container > *:not(.alignfull):not(.alignwide){max-width:none;}';
@@ -103,6 +118,50 @@ function applyContentSizeCss( css ) {
 	if ( iframe && iframe.contentDocument ) {
 		injectStyle( iframe.contentDocument, CONTENT_SIZE_STYLE_ID, css );
 	}
+}
+
+/**
+ * Push runtime contentSize + wideSize into the block-editor settings store so
+ * block toolbar dropdown hints (e.g., "None — Max 863px wide") reflect what the
+ * CSS variable actually resolves to. Without this the labels read from
+ * theme.json's static value (`contentSize: "863px"`) regardless of the
+ * runtime override we inject via CSS, which misleads authors.
+ *
+ * The canonical write target is `__experimentalFeatures.layout` — that's what
+ * core blocks AND third-party blocks (Blocksify Section, etc.) read when
+ * rendering the alignment dropdown. Updating the top-level `layout` key alone
+ * is not enough; both must move in lockstep to stay self-consistent.
+ *
+ * Bailing-out semantics: only write when values actually changed, to avoid
+ * triggering a no-op re-render of every component that selects from settings.
+ */
+function syncEditorLayoutSettings( contentSize, wideSize ) {
+	const store = select( 'core/block-editor' );
+	if ( ! store ) return;
+	const settings = store.getSettings();
+	const expFeatures = settings.__experimentalFeatures || {};
+	const expLayout = expFeatures.layout || {};
+	const topLayout = settings.layout || {};
+
+	const nextContent = contentSize || expLayout.contentSize;
+	const nextWide = wideSize || expLayout.wideSize;
+
+	if (
+		expLayout.contentSize === nextContent &&
+		expLayout.wideSize === nextWide &&
+		topLayout.contentSize === nextContent &&
+		topLayout.wideSize === nextWide
+	) {
+		return;
+	}
+
+	dispatch( 'core/block-editor' ).updateSettings( {
+		layout: { ...topLayout, contentSize: nextContent, wideSize: nextWide },
+		__experimentalFeatures: {
+			...expFeatures,
+			layout: { ...expLayout, contentSize: nextContent, wideSize: nextWide },
+		},
+	} );
 }
 
 /**
@@ -127,11 +186,67 @@ function ContentSizeSync() {
 	const layout = isNoSidebarContentLayout( contentLayout )
 		? 'content'
 		: sidebarMeta || config.fallbackLayout || 'content-sidebar';
-	const size = layoutToContentSize( layout );
+	const layoutSize = layoutToContentSize( layout );
+
+	// Resolution priority (highest wins):
+	//   1. Full-Width / Full-Stretched Content Layout — viewport-bound, mirrors
+	//      .site-content.content-full-{width,stretched} frontend rule.
+	//   2. Narrow Content Layout — uses Customizer narrow_width regardless of layout.
+	//      Mirrors .site-content.content-narrow frontend rule.
+	//   3. Single-post override — for post type, single_blog_post_content_width wins.
+	//      Mirrors body.single-post frontend rule.
+	//   4. Layout-derived size from sidebar layout map.
+	let size;
+	if ( contentLayout === 'full-width' ) {
+		size = 'calc(100vw - 64px)';
+	} else if ( contentLayout === 'full-stretched' ) {
+		size = '100vw';
+	} else if ( contentLayout === 'narrow' && config.narrowWidth ) {
+		size = config.narrowWidth;
+	} else if ( config.postType === 'post' && config.postContentSize ) {
+		size = config.postContentSize;
+	} else {
+		size = layoutSize;
+	}
 	const css = buildContentSizeCss( size, contentLayout );
+
+	// Dynamic wide-size per layout (matches PHP customify_layout_content_size_css):
+	//   - Full-Width / Full-Stretched (size is calc() or 100vw) → wide = content
+	//     (alignwide visually = align=none — viewport-bound layouts don't break out)
+	//   - No-sidebar / Narrow (numeric px size) → size + 400 (200px breakout each side)
+	//   - Sidebar layouts → wide = content (parent-constrained, no overlap)
+	// Used to push into __experimentalFeatures.layout.wideSize so alignment
+	// dropdown labels show the right "Max Xpx wide" hint.
+	const isViewportBoundSize =
+		typeof size === 'string' && /calc|vw/.test( size );
+	const sizeNum =
+		size && ! isViewportBoundSize ? parseInt( size, 10 ) : null;
+	const isNoSidebarFamily =
+		isNoSidebarContentLayout( contentLayout ) || layout === 'content';
+	let wideSize;
+	if ( isViewportBoundSize ) {
+		wideSize = size;
+	} else if ( sizeNum && isNoSidebarFamily ) {
+		wideSize = `${ sizeNum + 400 }px`;
+	} else {
+		wideSize = size || config.wideSize;
+	}
 
 	useEffect( () => {
 		applyContentSizeCss( css );
+
+		// Keep block-editor settings.layout in lockstep with the CSS variable so
+		// alignment dropdown labels (e.g., "None — Max 863px wide") reflect the
+		// resolved size, not theme.json's static one. The initial dispatch can
+		// be overwritten by editor bootstrap loading theme.json after our mount,
+		// so subscribe and re-apply on every settings change — syncEditor-
+		// LayoutSettings has internal bail-out so it's a no-op once our values
+		// have stuck. Subscription is scoped to core/block-editor so we don't
+		// fire on unrelated store updates.
+		const applyLayoutSync = () =>
+			syncEditorLayoutSettings( size, wideSize );
+		applyLayoutSync();
+		const unsubscribeSync = subscribe( applyLayoutSync, 'core/block-editor' );
 
 		// Editor canvas iframe mounts asynchronously and may reload (e.g.
 		// when toggling device preview). Watch for its load event so we
@@ -140,12 +255,18 @@ function ContentSizeSync() {
 		if ( ! iframe ) {
 			// Iframe may not exist yet — retry once after it likely mounts.
 			const timer = setTimeout( () => applyContentSizeCss( css ), 500 );
-			return () => clearTimeout( timer );
+			return () => {
+				clearTimeout( timer );
+				unsubscribeSync();
+			};
 		}
 		const onLoad = () => applyContentSizeCss( css );
 		iframe.addEventListener( 'load', onLoad );
-		return () => iframe.removeEventListener( 'load', onLoad );
-	}, [ css ] );
+		return () => {
+			iframe.removeEventListener( 'load', onLoad );
+			unsubscribeSync();
+		};
+	}, [ css, size, wideSize ] );
 
 	return null;
 }
@@ -158,6 +279,7 @@ const CONTENT_LAYOUT_OPTIONS = [
 	{ label: __( 'Default', 'customify' ),                 value: '' },
 	{ label: __( 'Full Width', 'customify' ),               value: 'full-width' },
 	{ label: __( 'Full Width – Stretched', 'customify' ),   value: 'full-stretched' },
+	{ label: __( 'Narrow', 'customify' ),                   value: 'narrow' },
 ];
 
 const SIDEBAR_OPTIONS = [

--- a/src/frontend/scss/base/_blocks.scss
+++ b/src/frontend/scss/base/_blocks.scss
@@ -8,12 +8,13 @@
 	margin-right: auto;
 }
 
-// Default blocks are constrained to --wp--style--global--content-size, which is set by
-// theme.json on body and overridden per layout via customify_layout_content_size_css()
-// (inc/template-functions.php). Skip when `.site-content.content-full-stretched` is
-// the context — stretched mode disables content-width constraints so blocks expand
-// to fit the container.
-.site-content:not(.content-full-stretched)
+// Default blocks are constrained to --wp--style--global--content-size, which is
+// set per layout by customify_layout_content_size_css() (inc/template-functions.php):
+//   - reading-column layouts (default no-sidebar, single sidebars, two sidebars) →
+//     fixed-px value capped at the typography readability target
+//   - full-width / full-stretched / narrow → viewport-bound or Customizer-driven
+// No exclusion list needed here — the content-size var itself adapts to context.
+.site-content
 	.entry-content
 	> *:not(.alignwide):not(.alignfull) {
 	max-width: var(--wp--style--global--content-size, 863px);
@@ -26,11 +27,28 @@
 
 // alignwide / alignfull — modern margin-based approach (no transform hack).
 // Works for all layouts. Uses CSS vars from theme.json when available.
+//
+// alignwide: dynamic breakout (per Customizer narrow_width / container_width).
+//   - --wp--style--global--wide-size is set per layout by customify_layout_content_size_css()
+//     (no-sidebar = content+400, narrow = narrow_width+400, sidebar = content).
+//   - The block is centered via negative margin when wider than its parent.
+//   - max() floor at 100% ensures wide is never narrower than the parent content
+//     column (so a narrow viewport never makes alignwide visually shrink BELOW
+//     align=none — keeps cascade intent: "wide ≥ none, always").
+//   - min() ceiling at (100vw - 32px) prevents the breakout from overflowing the
+//     viewport — the block dynamically shrinks the breakout (down to 0/side at
+//     tiny viewports) instead of triggering horizontal scroll.
+//   - Negative inline margins center the over-wide box back across the parent's
+//     midline. Same approach as alignfull's calc(50% - 50vw) but bounded.
 .entry-content > .alignwide {
-	max-width: var(--wp--style--global--wide-size, 1200px);
-	width: 100%;
+	--customify-alignwide-actual: max(
+		100%,
+		min(var(--wp--style--global--wide-size, 1200px), calc(100vw - 32px))
+	);
+	width: var(--customify-alignwide-actual);
+	margin-left: calc((100% - var(--customify-alignwide-actual)) / 2);
+	margin-right: calc((100% - var(--customify-alignwide-actual)) / 2);
 	box-sizing: border-box;
-	// margin-left/right: auto is already inherited from `.entry-content > *` above.
 }
 
 .entry-content > .alignfull {


### PR DESCRIPTION
## Summary

Block alignment sizes scale with Customizer values (container_width, narrow_width) and the active layout instead of being hardcoded. Editor canvas mirrors frontend WYSIWYG.

## What changed

### Customizer
- New **"Narrow Content Width"** slider (Global Layouts, under Container Width, default 800)
- `container_width` drives the typography readability cap proportionally, anchored per-site at upgrade time (zero rendered diff on 30K production sites)

### Per Content Layout dynamic values

| Layout | content-size | wide-size |
|---|---|---|
| Default no-sidebar | 1184px (scaled) | content + 400 |
| 1-sidebar | 863px (scaled) | content (no breakout into sidebar) |
| 2-sidebar | 542px (scaled) | content |
| **Narrow** (new) | narrow_width Customizer | narrow + 400 |
| Full Width | calc(100vw - 64px) | calc(100vw - 64px) |
| Full Stretched | 100vw | 100vw |

### Narrow content_layout (new)
- Added to `_customify_content_layout` meta options alongside full-width / full-stretched
- Forces no-sidebar layout
- Available in block editor metabox + classic editor metabox

### Frontend SCSS
- `.alignwide` breaks out via negative margin, capped at `max(100%, min(wide-size, 100vw - 32px))`
- No horizontal scroll on small viewports — breakout shrinks dynamically

### Editor (block editor JS)
- `ContentSizeSync` pushes runtime content + wide-size into `__experimentalFeatures.layout` so alignment dropdown labels match visible rendering
- Drop `!important` from body content-size (was shadowing user's saved `single_blog_post_content_width`)
- Toggle Content Layout in Document panel → editor canvas live-updates
- Full Width gets 32px gap each side (mirrors frontend container padding)
- Full Stretched goes edge-to-edge

## 30K-site safety

`customify_migrate_layout_content_size_anchor()` runs at `after_setup_theme:5`, captures current container_width as anchor. Sites with unsaved Customizer → anchor = 1248 (SCSS-rendered default), factor = 1.0 immediately after upgrade. Zero rendered diff.

Sites that have container_width saved explicitly get their saved value as anchor, so existing rendered sizes are preserved.

## Test plan

- [x] Customizer Global Layouts shows new "Narrow Content Width" field under Container Width
- [x] Page editor metabox shows new "Narrow" option in Content Layout dropdown
- [x] Frontend default no-sidebar: align=none 1184, align=wide 1584 (breakout 200/side), align=full viewport
- [x] Frontend 1-sidebar: align=none/wide stay in column, no breakout into sidebar
- [x] Frontend Narrow: align=none 800, align=wide 1200, align=full viewport
- [x] Frontend Full Width: align=none/wide fill container content-box (32px viewport gap each side), align=full viewport
- [x] Frontend Full Stretched: all alignments span viewport edge-to-edge
- [x] Frontend alignwide on small viewport: breakout shrinks dynamically, no horizontal scroll
- [x] Editor canvas matches frontend visual width per layout
- [x] Editor toggle Content Layout in metabox → live update without reload
- [x] Editor toggle Sidebar in metabox → live update content-size
- [x] Single post + `single_blog_post_content_width` Customizer saved → editor shows user value (not layout-derived)
- [x] Block toolbar dropdown labels ("Max Xpx wide") reflect runtime values, not theme.json static
- [x] 30K-safety: unsaved Customizer → migration anchor = 1248 → factor 1.0 → existing rendered sizes preserved

## Known limitations (out of scope)

1. Customizer live preview slider drag for `container_width`: content-size body rules don't re-render during drag (only wide-size + container max-width update live). Publish + reload to see full effect.
2. theme.json `wideSize: 1200px` static — Site Editor reads this directly. Edge case for classic theme flow.
3. Blocksify Section + "Inherit Max Width from Theme" + Full Stretched: inner overflows by 64px (Blocksify-side limitation — separate task spawned to Blocksify repo).
4. Editor dropdown labels for Full Width / Stretched show "calc(100vw - 64px)" / "100vw" instead of numeric. Cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)