### PR TITLE
fix(layouts): align Customizer container_width default 1200 → 1248 with SCSS

### DIFF
--- a/inc/customizer/configs/layouts.php
+++ b/inc/customizer/configs/layouts.php
@@ -83,12 +83,20 @@ if ( ! function_exists( 'customify_customizer_layouts_config' ) ) {
 			),
 			/**
 			 * @since 0.2.6 Change css_format and selector.
+			 *
+			 * Default 1248 matches the SCSS hardcode in
+			 * src/frontend/scss/layouts/_layouts.scss `.customify-container, .layout-contained { max-width: 1248px }`.
+			 * Auto-CSS skips emission when the saved value equals the field default,
+			 * so when the Customizer is unsaved the SCSS hardcode is what actually
+			 * renders. Aligning the default avoids a visual mismatch between the
+			 * Customizer slider position and the rendered container outer width.
+			 * Saved-explicit values are unaffected — they still persist as-is.
 			 */
 			array(
 				'name'            => 'container_width',
 				'type'            => 'slider',
 				'device_settings' => false,
-				'default'         => 1200,
+				'default'         => 1248,
 				'min'             => 700,
 				'step'            => 10,
 				'max'             => 2000,


### PR DESCRIPTION
## Summary

Aligns the `container_width` Customizer slider default with the SCSS hardcoded `.customify-container { max-width: 1248px }`, eliminating a visual inconsistency between slider position and rendered container width on sites that haven't saved the Customizer setting.

## Problem

Pre-fix:
- Customizer slider field default = **1200**
- SCSS `.customify-container, .layout-contained { max-width: 1248px }`
- Auto-CSS pipeline skips emission when the saved value equals the field default
- Result: unsaved sites render at **1248px** but the Customizer slider position shows **1200** — confusing

## Fix

Change `container_width` field default `1200` → `1248` in `inc/customizer/configs/layouts.php`. Slider now matches what's actually rendered.

## 30K-site safety

Zero rendered diff for all existing sites:
- **Saved-explicit values** (1200 / 1300 / 1500 / etc) persist regardless of default change — saved value always wins over default
- **Unsaved sites** already rendered 1248px via SCSS hardcode. The slider just shows the correct number now.
- Anchor migration helper `customify_get_container_width_value()` already uses 1248 fallback — no migration needed

## Test plan

- [x] Customizer Layouts → Container Width: slider default shows 1248 (was 1200)
- [x] Unsaved theme_mod: frontend `.customify-container` max-width = 1248 (unchanged from before fix)
- [x] Saved-explicit value (e.g., 1200): slider shows saved value, frontend max-width = saved value

🤖 Generated with [Claude Code](https://claude.com/claude-code)