### PR TITLE
Release 0.4.17 + 0.4.18

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 = 0.4.16 =
 * NEW: Fallback bridge wires legacy Customify Pro (< 0.4.16) into the new dashboard — module toggles and per-module settings work without modifying the Pro plugin.
+* FIXED: Theme button styling leaking into WP default block chrome (Search, File, Embed, etc.) in editor + frontend.
 * FIXED: Page Header "Cover" and background image disappearing when "Disable Title" is on (0.4.15 regression).
 * FIXED: Customizer pencil edit-shortcut not opening the matching header/footer builder item section.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,11 +1,11 @@
 = 0.4.17 =
-* NEW: Two extra Footer Builder row-layout presets for 4-column mode — 40/20/20/20 (wider first column) and 2×2 grid (items wrap onto two rows at 50/50).
-* FIXED: Pro Bridge settings screen failing to load metabox JS/CSS (404 on legacy /assets/ paths — now points at /build/).
-* FIXED: Nested lists inside core blocks (Quote, Pullquote, Cover, etc.) inheriting extra .entry-content margin/spacing; selector now excludes any descendant of [class*="wp-block-"], not just .wp-block-navigation.
-* IMPROVED: Removed orphaned "Shop Buttons" color control from the WooCommerce customizer config (was unreachable since the unified Colors section refactor in 0.4.15).
-* FIXED: WooCommerce mobile-only styles (table-cell stacking, 2-column product grid, hidden product thumbnail in cart, etc.) were leaking onto desktop viewports — now correctly scoped inside a @media (max-width: 560px) query. Likely the root cause of the cart row appearing oversized on desktop after upgrading from 0.4.13.
-* IMPROVED: WooCommerce cart "remove item" column constrained to 20px so the row layout stays tight.
-* IMPROVED: WooCommerce quantity picker (+/− buttons) now square via aspect-ratio and uses the muted text token; selector scoped under .woocommerce so the picker styling no longer leaks to non-WC contexts.
+* NEW: Two extra Footer Builder row-layout presets for 4-column mode — 40/20/20/20 and 2×2 grid.
+* FIXED: Header Search Icon — Icon Size, Icon Padding, and Icon Styling controls now apply to the rendered icon.
+* FIXED: WooCommerce mobile-only styles (stacked cart cells, 2-column product grid, hidden cart thumbnails) were leaking onto desktop — now scoped to @media (max-width: 560px). Likely root cause of oversized cart rows after upgrading from 0.4.13.
+* FIXED: Pro Bridge settings screen 404 on metabox JS/CSS (legacy /assets/ paths replaced with /build/).
+* FIXED: Nested lists inside core blocks (Quote, Pullquote, Cover, etc.) inheriting extra .entry-content margin; list-block styling unified under .wp-block-list for editor + frontend parity.
+* IMPROVED: WooCommerce cart — "remove item" column narrower, quantity picker (+/−) now square via aspect-ratio and uses the muted text token, scoped under .woocommerce.
+* IMPROVED: Removed orphaned "Shop Buttons" color control from the customizer (unreachable since the unified Colors section in 0.4.15).
 
 = 0.4.16 =
 * NEW: Fallback bridge wires legacy Customify Pro (< 0.4.16) into the new dashboard — module toggles and per-module settings work without modifying the Pro plugin.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+= 0.4.17 =
+* FIXED: Pro Bridge settings screen failing to load metabox JS/CSS (404 on legacy /assets/ paths — now points at /build/).
+* FIXED: Nested lists inside core blocks (Quote, Pullquote, Cover, etc.) inheriting extra .entry-content margin/spacing; selector now excludes any descendant of [class*="wp-block-"], not just .wp-block-navigation.
+* IMPROVED: Removed orphaned "Shop Buttons" color control from the WooCommerce customizer config (was unreachable since the unified Colors section refactor in 0.4.15).
+* FIXED: WooCommerce mobile-only styles (table-cell stacking, 2-column product grid, hidden product thumbnail in cart, etc.) were leaking onto desktop viewports — now correctly scoped inside a @media (max-width: 560px) query. Likely the root cause of the cart row appearing oversized on desktop after upgrading from 0.4.13.
+* IMPROVED: WooCommerce cart "remove item" column constrained to 20px so the row layout stays tight.
+* IMPROVED: WooCommerce quantity picker (+/− buttons) now square via aspect-ratio and uses the muted text token; selector scoped under .woocommerce so the picker styling no longer leaks to non-WC contexts.
+
 = 0.4.16 =
 * NEW: Fallback bridge wires legacy Customify Pro (< 0.4.16) into the new dashboard — module toggles and per-module settings work without modifying the Pro plugin.
 * FIXED: Theme button styling leaking into WP default block chrome (Search, File, Embed, etc.) in editor + frontend.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 = 0.4.18 =
 * IMPROVED: Footer builder rows made fully generic — Pro's `top` row and any extension-added row now work identically to built-in main/bottom.
+* IMPROVED: Dropped unnecessary `!important` on `.alignfull` margins so child themes and user CSS can override the full-bleed behavior through normal cascade.
 
 = 0.4.17 =
 * NEW: Two extra Footer Builder row-layout presets for 4-column mode — 40/20/20/20 and 2×2 grid.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 = 0.4.16 =
 * FIXED: Page Header "Cover" display and cover background image disappearing on pages that have the "Disable Title" toggle enabled (regression introduced in 0.4.15). The toggle now hides only the title text, as it did before, while the cover wrapper and background image continue to render.
+* FIXED: Selective refresh edit-shortcut (pencil icon) in the Customizer preview not opening the matching section for header/footer builder items such as footer copyright text, logo and menus. Clicks now expand the hidden builder item section and scroll the sidebar to the corresponding control.
 
 = 0.4.15 =
 * IMPROVED: Remove "Footer Widget X" placeholder shown to admins in empty footer sidebar columns.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,13 @@
 = 0.4.17 =
 * NEW: Two extra Footer Builder row-layout presets for 4-column mode — 40/20/20/20 and 2×2 grid.
 * FIXED: Header Search Icon — Icon Size, Icon Padding, and Icon Styling controls now apply to the rendered icon.
-* FIXED: WooCommerce mobile-only styles (stacked cart cells, 2-column product grid, hidden cart thumbnails) were leaking onto desktop — now scoped to @media (max-width: 560px). Likely root cause of oversized cart rows after upgrading from 0.4.13.
+* FIXED: Header Search submit button (magnifying glass) vertical alignment with the search input field.
+* FIXED: Container width default 1248 + dynamic content-size/wide-size for Narrow layout.
+* FIXED: WooCommerce mobile-only styles leaking onto desktop — now scoped to @media (max-width: 560px).
 * FIXED: Pro Bridge settings screen 404 on metabox JS/CSS (legacy /assets/ paths replaced with /build/).
 * FIXED: Nested lists inside core blocks (Quote, Pullquote, Cover, etc.) inheriting extra .entry-content margin; list-block styling unified under .wp-block-list for editor + frontend parity.
-* IMPROVED: WooCommerce cart — "remove item" column narrower, quantity picker (+/−) now square via aspect-ratio and uses the muted text token, scoped under .woocommerce.
+* IMPROVED: Updated color palette customizer settings — live preview without page reload.
+* IMPROVED: WooCommerce cart — narrower "remove" column + square quantity picker.
 * IMPROVED: Removed orphaned "Shop Buttons" color control from the customizer (unreachable since the unified Colors section in 0.4.15).
 
 = 0.4.16 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+= 0.4.18 =
+* IMPROVED: Footer builder rows made fully generic — Pro's `top` row and any extension-added row now work identically to built-in main/bottom.
+
 = 0.4.17 =
 * NEW: Two extra Footer Builder row-layout presets for 4-column mode — 40/20/20/20 and 2×2 grid.
 * FIXED: Header Search Icon — Icon Size, Icon Padding, and Icon Styling controls now apply to the rendered icon.

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,12 +5,12 @@
 * FIXED: Customizer pencil edit-shortcut not opening the matching header/footer builder item section.
 
 = 0.4.15 =
-* IMPROVED: Remove "Footer Widget X" placeholder shown to admins in empty footer sidebar columns.
 * NEW: Transparent header feature.
 * NEW: Footer Builder V2 with row layout control, gap/padding slider controls and center column grid alignment.
 * NEW: Block editor Page Settings panel; modernize Gutenberg support and fix #page-cover visibility.
 * NEW: has-page-cover body class; scope transparent header styles.
 * NEW: WordPress Font Library and theme.json fonts in the typography picker.
+* IMPROVED: Remove "Footer Widget X" placeholder shown to admins in empty footer sidebar columns.
 * IMPROVED: WordPress 7.0 ready.
 * IMPROVED: Editor style now support customizer settings.
 * IMPROVED: Header/footer builder UI — sizing, title display, popover width and column layout.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 = 0.4.17 =
+* NEW: Two extra Footer Builder row-layout presets for 4-column mode — 40/20/20/20 (wider first column) and 2×2 grid (items wrap onto two rows at 50/50).
 * FIXED: Pro Bridge settings screen failing to load metabox JS/CSS (404 on legacy /assets/ paths — now points at /build/).
 * FIXED: Nested lists inside core blocks (Quote, Pullquote, Cover, etc.) inheriting extra .entry-content margin/spacing; selector now excludes any descendant of [class*="wp-block-"], not just .wp-block-navigation.
 * IMPROVED: Removed orphaned "Shop Buttons" color control from the WooCommerce customizer config (was unreachable since the unified Colors section refactor in 0.4.15).

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+= 0.4.16 =
+* FIXED: Page Header "Cover" display and cover background image disappearing on pages that have the "Disable Title" toggle enabled (regression introduced in 0.4.15). The toggle now hides only the title text, as it did before, while the cover wrapper and background image continue to render.
+
 = 0.4.15 =
 * IMPROVED: Remove "Footer Widget X" placeholder shown to admins in empty footer sidebar columns.
 * NEW: Transparent header feature.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 = 0.4.16 =
-* FIXED: Page Header "Cover" display and cover background image disappearing on pages that have the "Disable Title" toggle enabled (regression introduced in 0.4.15). The toggle now hides only the title text, as it did before, while the cover wrapper and background image continue to render.
-* FIXED: Selective refresh edit-shortcut (pencil icon) in the Customizer preview not opening the matching section for header/footer builder items such as footer copyright text, logo and menus. Clicks now expand the hidden builder item section and scroll the sidebar to the corresponding control.
+* NEW: Fallback bridge wires legacy Customify Pro (< 0.4.16) into the new dashboard — module toggles and per-module settings work without modifying the Pro plugin.
+* FIXED: Page Header "Cover" and background image disappearing when "Disable Title" is on (0.4.15 regression).
+* FIXED: Customizer pencil edit-shortcut not opening the matching header/footer builder item section.
 
 = 0.4.15 =
 * IMPROVED: Remove "Footer Widget X" placeholder shown to admins in empty footer sidebar columns.

--- a/docs/SPEC-editor-style.md
+++ b/docs/SPEC-editor-style.md
@@ -1,0 +1,404 @@
+# SPEC — Editor Style: content-size + wide-size + Content Layout
+
+Drives block alignment widths (`align=none`, `alignwide`, `alignfull`) across the frontend AND the block editor canvas, so authors see the rendered widths their visitors will see. Built on `--wp--style--global--content-size` + `--wp--style--global--wide-size` CSS variables, plus a per-post `_customify_content_layout` meta with values `''` (default) / `full-width` / `full-stretched` / `narrow`.
+
+Related references:
+- [`SPEC-customizer.md`](SPEC-customizer.md) §12 — Customizer → editor bridge (architectural view)
+- [`SPEC-block-editor.md`](SPEC-block-editor.md) §4 — `Customify_Editor` class
+- [`../AGENTS.md`](../AGENTS.md) §4.11 — container_width must sync to wide-size CSS var
+
+This file is permanent. For transient session notes, use `docs/handoffs/`.
+
+---
+
+## 1. Overview
+
+The system has **three input sources** that resolve to **two CSS variables** that block-layout SCSS + theme block consumers read. The variables are layout-driven (per body class) and content-layout-driven (per `.site-content` class), with editor JS mirroring the resolved values into the block-editor settings store so toolbar alignment dropdowns stay in sync.
+
+| Surface | Role |
+|---|---|
+| `container_width` Customizer slider | Scales the typography readability cap proportionally per-site |
+| `narrow_width` Customizer slider | Width used by the "Narrow" Content Layout option (default 800px) |
+| `single_blog_post_content_width` Customizer slider | User override for single posts only |
+| `_customify_content_layout` post meta | Per-post override: `''` / `full-width` / `full-stretched` / `narrow` |
+| `--wp--style--global--content-size` | Block max-width for `align=none` (also read by Blocksify Section "Inherit ON") |
+| `--wp--style--global--wide-size` | Block max-width for `alignwide` |
+| Frontend SCSS (`_blocks.scss`) | Applies the vars + alignwide breakout |
+| Editor PHP (`editor.php`) | Initial body var + per-post sidebar resolution |
+| Editor JS (`page-settings/index.js::ContentSizeSync`) | Live updates body var + block-editor settings store |
+| Anchor option (`customify_layout_content_size_anchor`) | Per-site upgrade-time snapshot for 30K zero-diff |
+
+---
+
+## 2. File map
+
+| File | Lines | Responsibility |
+|---|---|---|
+| [`inc/template-functions.php`](../inc/template-functions.php) | ~21-296 | `customify_get_container_width_value()`, `customify_get_layout_content_sizes()`, `customify_get_narrow_width_value()`, `customify_layout_content_size_css()`, anchor migration |
+| [`inc/customizer/configs/layouts.php`](../inc/customizer/configs/layouts.php) | ~85-125 | `container_width` + `narrow_width` slider fields |
+| [`inc/customizer/configs/single-blog-post.php`](../inc/customizer/configs/single-blog-post.php) | ~22-40 | `single_blog_post_content_width` slider |
+| [`inc/admin/editor.php`](../inc/admin/editor.php) | ~178-240 | `Customify_Editor::css()` — emits body content-size + alignwide breakout for editor canvas |
+| [`inc/admin/page-settings.php`](../inc/admin/page-settings.php) | ~131-200 | Localizes config (`contentSizeMap`, `postType`, `postContentSize`, `narrowWidth`, `wideSize`) |
+| [`inc/class-metabox.php`](../inc/class-metabox.php) | ~60-72 | Classic editor Content Layout dropdown |
+| [`src/backend/page-settings/index.js`](../src/backend/page-settings/index.js) | ~25-260 | `ContentSizeSync` + `syncEditorLayoutSettings` |
+| [`src/frontend/scss/base/_blocks.scss`](../src/frontend/scss/base/_blocks.scss) | ~16-50 | Frontend alignwide breakout |
+
+---
+
+## 3. Storage shape & data contract
+
+### 3.1 `theme_mod` keys
+
+| Key | Stored type | Default | Notes |
+|---|---|---|---|
+| `container_width` | array `{ value: int, unit: 'px' }` | unsaved → falls back to 1248 (SCSS hardcode) | Slider, range 700–2000 |
+| `narrow_width` | array `{ value: int, unit: 'px' }` | unsaved → 800 | Slider, range 400–1000 |
+| `single_blog_post_content_width` | array `{ value: int, unit: 'px' }` | unsaved → 863 | Slider, range 400–1200 |
+
+### 3.2 `wp_options` keys
+
+| Option | Stored type | Notes |
+|---|---|---|
+| `customify_layout_content_size_anchor` | int | Per-site anchor for proportional scaling (= container_width snapshot at upgrade). Default 1248. |
+| `customify_layout_anchor_migrated_v1` | string `'1'` | Idempotency flag for `customify_migrate_layout_content_size_anchor()` |
+
+### 3.3 `post_meta` keys
+
+| Meta key | Post type | Stored type | Possible values |
+|---|---|---|---|
+| `_customify_content_layout` | any | string | `''` (default) / `'full-width'` / `'full-stretched'` / `'narrow'` |
+
+### 3.4 Anchor migration
+
+`customify_migrate_layout_content_size_anchor()` hooked at `after_setup_theme:5`. Captures current `container_width` (or 1248 fallback when unsaved) into `customify_layout_content_size_anchor`. Idempotent via the `_v1` flag. See [`migration-guide.md`](migration-guide.md) §2.
+
+**Why per-site**: a global anchor (e.g. hardcoded 1248) would silently scale content-size on sites that had explicitly saved `container_width = 1500`. Per-site capture means `factor = 1.0` immediately after upgrade — zero rendered diff for every existing site regardless of their saved values. Scaling only kicks in when the user moves the slider AFTER the upgrade.
+
+### 3.5 Defaults
+
+| Setting | Default at unsaved state | What renders |
+|---|---|---|
+| `container_width` | unsaved | SCSS hardcoded 1248 wins (Customizer Auto-CSS skips emission for default values) |
+| `narrow_width` | 800 | `.site-content.content-narrow` rule emits this fallback |
+| `single_blog_post_content_width` | 863 | `body.single-post` rule emits this fallback |
+| anchor | first run → captured from container_width | factor = 1.0 |
+
+---
+
+## 4. Render pipeline
+
+### 4.1 Resolution priority for `--wp--style--global--content-size` on body
+
+Cascade order (later wins for same selector):
+
+1. **`theme.json`** (static, loaded as `:root { --wp--style--global--content-size: 863px }`)
+2. **`body.main-layout-<layout>`** — emitted by `customify_layout_content_size_css()` (inline CSS on `customify-style` handle):
+   - `.main-layout-content` → no_sidebar formula
+   - 1-sidebar variants → falls through to theme.json (no body rule), wide-size body rule sets wide explicitly
+   - 2-sidebar variants → two_sidebars formula
+3. **`body.single-post`** — emitted by `single_blog_post_content_width` field's `css_format` (auto-CSS pipeline). Wins for single posts over the layout rule by source order.
+4. **`.site-content.content-<layout>`** — closer ancestor than body, overrides for per-post Content Layout:
+   - `.content-narrow` → narrow_width Customizer value
+   - `.content-full-width` → `calc(100vw - 64px)`
+   - `.content-full-stretched` → `100vw`
+
+### 4.2 Per-layout sizes (matrix)
+
+At default state (`container_width` unsaved → anchor 1248):
+
+| Layout / Content Layout | `--wp--style--global--content-size` | `--wp--style--global--wide-size` |
+|---|---|---|
+| Default no-sidebar (`.main-layout-content`) | **1184px** (= no_sidebar, scaled) | **1584px** (= content + 400) |
+| 1-sidebar (content-sidebar, sidebar-content) | 863px (theme.json fallback, scaled cap) | **863px** (explicit body rule, no breakout into sidebar) |
+| 2-sidebar (3 variants) | **542px** (scaled cap) | **542px** (= content) |
+| `.content-narrow` | **800px** (Customizer narrow_width) | **1200px** (= narrow + 400) |
+| `.content-full-width` | **calc(100vw - 64px)** (container content-box at 100% with 2em padding each side) | **calc(100vw - 64px)** |
+| `.content-full-stretched` | **100vw** (no container padding) | **100vw** |
+
+When `container_width` is saved away from anchor, the **scaled cap** scales proportionally: `value = round(default * container_width / anchor)`.
+
+### 4.3 Formula: `customify_get_layout_content_sizes()`
+
+```
+cw     = customify_get_container_width_value()       // 1248 fallback when unsaved
+anchor = get_option( 'customify_layout_content_size_anchor', 1248 )
+factor = cw / anchor
+
+cap_no_sidebar   = round( 1184 * factor )
+cap_one_sidebar  = round(  863 * factor )
+cap_two_sidebars = round(  542 * factor )
+
+inner = max(0, cw - 64)        // .customify-container content-box (after 2em*2 padding)
+grid  = inner + 32             // gridlex grid (negative 1em margin each side)
+
+parent_no_sidebar   = grid - 32           // col padding only
+parent_one_sidebar  = round(grid * 0.75) - 32 - 16   // col + 1-side content-inner pad
+parent_two_sidebars = round(grid * 0.5)  - 32 - 32   // col + 2-side content-inner pad
+
+return min(cap, parent)  per layout
+```
+
+**Why `min(cap, parent)`**: the cap is a typography readability target (~60–80 chars/line). The parent is the actual frontend column geometry. Returning the smaller value gives the width blocks actually reach on the frontend — which the editor canvas can then use directly (no nesting structure to constrain editor blocks naturally). Keeps editor WYSIWYG honest.
+
+### 4.4 Frontend SCSS — alignwide breakout
+
+[`_blocks.scss:29-58`](../src/frontend/scss/base/_blocks.scss):
+
+```scss
+.entry-content > .alignwide {
+    --customify-alignwide-actual: max(
+        100%,
+        min(var(--wp--style--global--wide-size, 1200px), calc(100vw - 32px))
+    );
+    width: var(--customify-alignwide-actual);
+    margin-left:  calc((100% - var(--customify-alignwide-actual)) / 2);
+    margin-right: calc((100% - var(--customify-alignwide-actual)) / 2);
+    box-sizing: border-box;
+}
+```
+
+- **`max(100%, ...)`** — floor at parent width so a narrow viewport never makes alignwide visually smaller than `align=none`. Cascade intent: "wide ≥ none, always".
+- **`min(wide-size, 100vw - 32px)`** — ceiling at viewport-32 so breakout never causes horizontal scroll. The breakout dynamically shrinks (down to 0/side on tiny viewports).
+- **Negative inline margins** center the over-wide box across the parent's midline, same approach as alignfull's `calc(50% - 50vw)` but bounded.
+
+### 4.5 Editor canvas mirror
+
+[`editor.php::css()`](../inc/admin/editor.php):
+1. Resolves layout from post sidebar meta + force-no-sidebar overrides
+2. Resolves `$size` based on content_layout / post type:
+   - `narrow` → narrow_width
+   - `full-width` → `calc(100vw - 64px)`
+   - `full-stretched` → `100vw`
+   - post type `post` + saved single_blog_post_content_width → user value
+   - else → layout-derived
+3. Emits `body { --wp--style--global--content-size: $size; }` (no `!important`)
+4. Emits `.editor-styles-wrapper > .is-root-container > .alignwide` rule (same formula as frontend SCSS)
+
+[`page-settings/index.js::ContentSizeSync`](../src/backend/page-settings/index.js):
+1. Watches `_customify_sidebar` + `_customify_content_layout` meta via `useEntityProp`
+2. Computes `size` (priority: full-width/stretched calc, narrow, post override, layout)
+3. Computes `wideSize` (size + 400 for no-sidebar family, same as size for viewport-bound or sidebar layouts)
+4. `buildContentSizeCss()` → injects `<style id="customify-layout-content-size">` into editor iframe head with body content-size + per-layout max-width override on root blocks
+5. `syncEditorLayoutSettings()` → dispatches `updateSettings({ layout, __experimentalFeatures })` so block-toolbar dropdown labels match runtime values
+6. Subscribes to `core/block-editor` store to re-apply after WP overwrites settings during bootstrap
+
+---
+
+## 5. Design decisions
+
+### 5.1 Per-site anchor migration vs global hardcoded anchor
+
+- **Chose**: capture `container_width` per-site at first `after_setup_theme:5` run after upgrade
+- **Rejected**: hardcoded anchor = 1248 globally
+- **Reason**: a global anchor would shift content-size on sites that explicitly saved non-default container_width. Per-site capture gives `factor=1.0` immediately after migration → zero rendered diff for every existing site. Scaling only kicks in when the user moves the slider AFTER upgrade — which is when they actually want scaling.
+
+### 5.2 `min(cap, parent)` formula for layout content sizes
+
+- **Chose**: return `min(typography_cap, frontend_parent_geometry)` per layout
+- **Rejected**: cap-only OR parent-only
+- **Reason**: cap-only would let editor blocks render at sizes the frontend column can't actually reach (lying about WYSIWYG). Parent-only would let alignment dropdown labels grow without bound on wide containers, ignoring readability. Both bounds, smaller wins.
+
+### 5.3 Viewport-bound content-size for Full Width / Full Stretched
+
+- **Chose**: emit `calc(100vw - 64px)` (Full Width) and `100vw` (Stretched) directly to the CSS variable
+- **Rejected**: keep variable at no_sidebar fallback (1184) and use SCSS exclusions to bypass the cap per layout
+- **Reason**: third-party consumers (Blocksify Section's "Inherit Max Width from Theme") read `--wp--style--global--content-size` directly. If theme keeps it at 1184 even for Full Width, those blocks stay capped at reading-column width even though the section spans viewport. Emitting the variable correctly makes ALL consumers (Core blocks via SCSS, third-party blocks reading the var) naturally fill the available container space without per-block CSS hacks.
+
+### 5.4 Wide-size = content for sidebar layouts (no breakout into sidebar)
+
+- **Chose**: emit `--wp--style--global--wide-size: <content_size>` for 1-sidebar and 2-sidebar layouts
+- **Rejected**: emit wide-size = content + 400 for ALL layouts, let alignwide breakout into sidebar visually
+- **Reason**: alignwide extending into the sidebar area looks broken. User confirmed Q2: "if page has sidebar layout, don't worry — wide stays in content, doesn't overlap sidebar". Setting wide-size = column width lets alignwide visually = align=none in sidebar layouts (which IS the expected behavior).
+
+### 5.5 Editor settings.layout sync via subscribe
+
+- **Chose**: `syncEditorLayoutSettings()` subscribes to `core/block-editor` store, re-applies on every settings change
+- **Rejected**: dispatch once on mount
+- **Reason**: WP editor bootstrap loads theme.json values into settings AFTER plugin mount. A one-shot dispatch gets overwritten. Subscribe + re-apply with internal bail-out (compare current vs desired) keeps values stuck without infinite loop.
+
+### 5.6 PHP no-op for full-width max-width override; JS owns it
+
+- **Chose**: PHP `editor.php` only emits body content-size; JS handles the per-block max-width override for full-width / full-stretched
+- **Rejected**: PHP also emits `max-width: none` based on saved meta
+- **Reason**: PHP CSS is static for the page load. When user toggles content_layout in the metabox, PHP-emitted override stays applied and JS can't undo it (different CSS rules). Letting JS own the dynamic part keeps the metabox toggle responsive — JS `<style>` re-renders on every meta change.
+
+### 5.7 Cap removal via dynamic content-size, not SCSS exclusion
+
+- **Chose**: emit content-size = viewport-bound for full-width/stretched. SCSS rule applies uniformly.
+- **Rejected**: keep content-size at fixed value, use `:not(.content-full-width):not(.content-full-stretched)` to exclude from cap rule
+- **Reason**: dynamic value approach makes ALL consumers adapt automatically (Core blocks via SCSS, third-party blocks via var). The exclusion approach only handles Core blocks via custom SCSS and leaves third-party consumers stuck at 1184.
+
+---
+
+## 6. Adding / extending
+
+### 6.1 Adding a new Content Layout value (similar to Narrow)
+
+```php
+// Step 1 — Add to CONTENT_LAYOUT_OPTIONS in src/backend/page-settings/index.js
+{ label: __( 'My Layout', 'customify' ), value: 'my-layout' }
+
+// Step 2 — If it forces no-sidebar, add to NO_SIDEBAR_CONTENT_LAYOUTS in JS
+const NO_SIDEBAR_CONTENT_LAYOUTS = [ 'full-width', 'full-stretched', 'narrow', 'my-layout' ];
+
+// Step 3 — Add to PHP force-no-sidebar guard in inc/template-functions.php
+if ( in_array( $content_layout, array( 'full-width', 'full-stretched', 'narrow', 'my-layout' ), true ) ) {
+    return 'content';
+}
+
+// Step 4 — If it needs a Customizer width slider, add to inc/customizer/configs/layouts.php
+// (model on narrow_width)
+
+// Step 5 — Emit .site-content.content-my-layout rule in customify_layout_content_size_css()
+
+// Step 6 — Handle in editor.php editor canvas branch:
+elseif ( 'my-layout' === $content_layout ) {
+    $size = '...';
+}
+
+// Step 7 — Handle in JS buildContentSizeCss + size resolution
+
+// Step 8 — Add to classic editor metabox in inc/class-metabox.php
+
+// Step 9 — npm run build
+```
+
+### 6.2 Overriding sizes via filter
+
+```php
+// Override content-size values per layout (frontend + editor consume same function)
+add_filter( 'customify/layout_content_sizes', function ( $sizes ) {
+    $sizes['no_sidebar'] = '1400px';
+    return $sizes;
+} );
+```
+
+### 6.3 Reading the resolved sizes programmatically
+
+```php
+$sizes = customify_get_layout_content_sizes();
+// array( 'no_sidebar' => '1184px', 'one_sidebar' => '863px', 'two_sidebars' => '542px' )
+
+$narrow = customify_get_narrow_width_value();
+// '800px' (CSS length string)
+
+$cw = customify_get_container_width_value();
+// 1248 (int, px)
+```
+
+---
+
+## 7. Hooks & filters catalog
+
+### 7.1 Filters
+
+| Hook | Type | Payload | Purpose |
+|---|---|---|---|
+| `customify/layout_content_sizes` | filter | `array{ no_sidebar:string, one_sidebar:string, two_sidebars:string }` | Override per-layout content-size values |
+| `customify_get_layout` | filter | `string|null $layout` | Force no-sidebar for full-width/full-stretched/narrow content_layout (priority via `customify_force_no_sidebar_for_full_content_layout`) |
+
+### 7.2 Actions
+
+| Hook | Type | Purpose |
+|---|---|---|
+| `after_setup_theme` (priority 5) | action | `customify_migrate_layout_content_size_anchor()` — one-time anchor capture |
+
+---
+
+## 8. Known issues / edge cases
+
+### Issue #1 — Customizer live preview slider drag doesn't re-render content-size body rules
+
+When the user moves the `container_width` slider in Customizer live preview, only the field's own `css_format` re-renders (container max-width + wide-size). The static `customify_layout_content_size_css()` output (body content-size rules) is NOT in the auto-CSS rebuild pipeline.
+
+**Effect**: live preview shows container max-width + wide-size updating; content-size body rules stay at page-load values until publish + reload.
+
+**Workaround**: publish, then refresh the preview iframe.
+
+### Issue #2 — theme.json `wideSize` is static (1200px)
+
+Site Editor (if enabled) reads theme.json directly. Customizer changes don't propagate. Edge case for classic theme flow.
+
+### Issue #3 — Blocksify Section + Inherit ON + Full Stretched overflows 64px
+
+When Blocksify Section is set to alignfull with "Inherit Max Width from Theme" enabled, the inner uses `calc(var(content-size) + section_inner_padding * 2)`. In Full Stretched mode, content-size = 100vw → inner = 100vw + 64 → overflows viewport by 64px.
+
+**Workaround**: turn OFF "Inherit Max Width from Theme" for Stretched sections, OR avoid Stretched layout when using Blocksify Section with inherit.
+
+**Root cause**: Blocksify-side — they add inner padding to the content-size cap regardless of whether the section provides padding itself. Fix belongs in Blocksify CSS rule.
+
+### Issue #4 — Editor dropdown labels for Full Width / Stretched are non-numeric
+
+The toolbar alignment dropdown labels read settings.__experimentalFeatures.layout.contentSize. For Full Width / Stretched we push the calc-string `'calc(100vw - 64px)'` / `'100vw'` to keep CSS behaviour aligned. Labels display "Max calc(100vw - 64px) wide" instead of a numeric "Max 1780px wide".
+
+**Cosmetic**: functional behavior is correct. Could be improved by computing a viewport-aware numeric snapshot for the settings push while keeping the body var as calc.
+
+---
+
+## 9. Pro plugin handoff
+
+`Customify_Pro_Module_<Editor>` doesn't exist — this is theme-side only. If a future Pro module wants to extend, it must:
+
+- Honor the `customify/layout_content_sizes` filter and pass through the array shape `{ no_sidebar, one_sidebar, two_sidebars }`
+- Honor the `--wp--style--global--content-size` / `--wp--style--global--wide-size` CSS variable contract on body + `.site-content.content-<layout>`
+- Honor the `_customify_content_layout` meta values (`'' / full-width / full-stretched / narrow`) and the body class derivation `.site-content.content-<value>`
+
+See [`SPEC-pro-integration.md`](SPEC-pro-integration.md) for the full contract.
+
+---
+
+## 10. Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Editor block widths don't match frontend | Outdated browser cache → hard reload (Cmd+Shift+R). Also check `getSettings().__experimentalFeatures.layout.contentSize` in console matches `getComputedStyle(body).getPropertyValue('--wp--style--global--content-size')`. |
+| Container width slider doesn't visibly change content area on existing sites | Site has `container_width` saved at a value that produces `factor=1.0` against the captured anchor. Expected — anchor migration zero-diff design. |
+| Narrow Content Layout dropdown doesn't appear | Build outdated. Run `npm run build` and reload editor. |
+| Block toolbar dropdown shows "Max 100vw wide" or "Max calc(...) wide" | Expected for Full Width / Stretched. Cosmetic — see Issue #4. |
+| `_customify_content_layout = narrow` but sidebar still renders | Sidebar meta took precedence over theme support meta lookup. Check `customify_force_no_sidebar_for_full_content_layout` filter ran (`'narrow' in array`). |
+| Blocksify Section inner doesn't fill section in alignfull | Either: (a) section is in Stretched mode → Issue #3 (Blocksify-side); (b) "Inherit Max Width from Theme" is OFF (per-block custom max-width set). |
+| Single post `single_blog_post_content_width` doesn't show in editor | Customizer hasn't been saved (still default). OR post is being edited as `page` post type (single_blog_post_content_width is post-only). |
+
+---
+
+## 11. Quick reference — how do I…?
+
+| I want to… | Code |
+|---|---|
+| Read resolved layout content sizes (PHP) | `customify_get_layout_content_sizes()` |
+| Read resolved narrow_width (PHP) | `customify_get_narrow_width_value()` |
+| Read resolved container_width (PHP) | `customify_get_container_width_value()` |
+| Override content-sizes for a child theme | `add_filter( 'customify/layout_content_sizes', fn ($s) => [ ... ] );` |
+| Detect Narrow content_layout (PHP, post context) | `get_post_meta( $post_id, '_customify_content_layout', true ) === 'narrow'` |
+| Detect Narrow content_layout (JS, editor) | `wp.data.select( 'core/editor' ).getEditedPostAttribute( 'meta' )._customify_content_layout === 'narrow'` |
+| Force a content_layout via REST | `POST /wp-json/wp/v2/pages/<id>` with `{ meta: { _customify_content_layout: 'narrow' } }` |
+
+---
+
+## 12. Where to look next
+
+**PHP**
+- [`inc/template-functions.php`](../inc/template-functions.php) — helpers + `customify_layout_content_size_css()` + migration
+- [`inc/customizer/configs/layouts.php`](../inc/customizer/configs/layouts.php) — Customizer fields
+- [`inc/customizer/configs/single-blog-post.php`](../inc/customizer/configs/single-blog-post.php) — `single_blog_post_content_width`
+- [`inc/admin/editor.php`](../inc/admin/editor.php) — `Customify_Editor` class, editor canvas inline CSS
+- [`inc/admin/page-settings.php`](../inc/admin/page-settings.php) — block editor metabox + JS config localize
+- [`inc/class-metabox.php`](../inc/class-metabox.php) — classic editor metabox
+
+**JavaScript**
+- [`src/backend/page-settings/index.js`](../src/backend/page-settings/index.js) — `ContentSizeSync` + `syncEditorLayoutSettings`
+
+**SCSS**
+- [`src/frontend/scss/base/_blocks.scss`](../src/frontend/scss/base/_blocks.scss) — `.entry-content > .alignwide` breakout, `> *` content-size cap
+- [`src/frontend/scss/layouts/_layouts.scss`](../src/frontend/scss/layouts/_layouts.scss) — `.customify-container` padding, `.content-full-{width,stretched}` container overrides, per-sidebar `.content-inner` padding
+
+**Related specs**
+- [`SPEC-customizer.md`](SPEC-customizer.md) §12 — Customizer → editor bridge
+- [`SPEC-block-editor.md`](SPEC-block-editor.md) §4 — `Customify_Editor` overview
+- [`SPEC-data-migration-policy.md`](SPEC-data-migration-policy.md) — anchor migration pattern
+
+**Conventions**
+- [`../AGENTS.md`](../AGENTS.md) §4.1 — 30k-site safety (migration design rationale)
+- [`../AGENTS.md`](../AGENTS.md) §4.7 — CSS handle must be `customify-style`
+- [`../AGENTS.md`](../AGENTS.md) §4.11 — container_width sync to wide-size var
+- [`../AGENTS.md`](../AGENTS.md) §4.13 — alignwide / alignfull modern pattern

--- a/inc/admin/editor.php
+++ b/inc/admin/editor.php
@@ -82,11 +82,15 @@ class Customify_Editor {
 			'background',                       // Page bg composite — re-scoped to .editor-styles-wrapper below
 			'site_content_styling',
 			'content_background',
-			'single_blog_post_content_width',
 			'global_typography_heading_h1',
 			'global_typography_base_heading',
 			'global_styling_color_heading',
 		);
+		// `single_blog_post_content_width` intentionally NOT in $keys: a :root rule
+		// emitted via the standard pipeline would be shadowed by the body-scoped
+		// content-size rule the layout-driven block below emits. The user value is
+		// folded into that branch when editing a single post, mirroring how the
+		// frontend `body.single-post` rule wins by cascade source-order.
 
 		foreach ( $keys as $k ) {
 			$f = Customify()->customizer->get_field_setting( $k );
@@ -112,19 +116,6 @@ class Customify_Editor {
 			// Sync wide-size CSS var into editor so theme.json + customizer stay in sync.
 			$fields['container_width']['selector']   = ':root';
 			$fields['container_width']['css_format'] = '--wp--style--global--wide-size: {{value}};';
-		}
-
-		if ( $fields['single_blog_post_content_width'] ) {
-			// Sync content-size CSS var only when editing a post (setting is single-post scoped);
-			// pages and other post types keep theme.json's default to match frontend behavior.
-			$screen            = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-			$editing_post_type = $screen ? $screen->post_type : '';
-			if ( 'post' === $editing_post_type ) {
-				$fields['single_blog_post_content_width']['selector']   = ':root';
-				$fields['single_blog_post_content_width']['css_format'] = '--wp--style--global--content-size: {{value}};';
-			} else {
-				unset( $fields['single_blog_post_content_width'] );
-			}
 		}
 
 		if ( $fields['global_typography_base_heading'] ) {
@@ -172,6 +163,17 @@ class Customify_Editor {
 		.editor-styles-wrapper > .is-root-container > *:not(.alignfull):not(.alignwide) {
 			max-width: var(--wp--style--global--content-size, 780px);
 		}
+		.editor-styles-wrapper > .is-root-container > .alignwide {
+			--customify-alignwide-actual: max(
+				100%,
+				min(var(--wp--style--global--wide-size, 1200px), calc(100vw - 32px))
+			);
+			width: var(--customify-alignwide-actual);
+			margin-left: calc((100% - var(--customify-alignwide-actual)) / 2);
+			margin-right: calc((100% - var(--customify-alignwide-actual)) / 2);
+			max-width: none;
+			box-sizing: border-box;
+		}
 		';
 
 		$post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0;
@@ -182,31 +184,63 @@ class Customify_Editor {
 
 		// Layout-driven contentSize: keep block max-width in sync with the active
 		// sidebar layout so what the user sees in the editor matches the frontend
-		// column width. Applied last so it wins over single_blog_post_content_width
-		// and theme.json. Targets `body` with `!important` because theme.json emits
-		// the variable on `body` — a `:root` rule loses to that within body's scope.
+		// column width. Targets `body` (no !important): the variable is custom-
+		// property-inheritable, so the closer-ancestor body rule overrides the
+		// theme.json :root baseline for any element inside body without needing
+		// to win specificity.
 		//
 		// Content Layout meta (full-width / full-stretched) overrides the sidebar
 		// layout to the no-sidebar size — these modes hide the sidebar regardless
 		// of the per-post sidebar setting.
 		//
+		// Single-post override: when editing a post, the user's
+		// single_blog_post_content_width Customizer setting (if saved) wins over
+		// the layout-derived size. Mirrors the frontend `body.single-post` rule
+		// (inc/customizer/configs/single-blog-post.php) so editor matches render.
+		//
 		// Live-reactive counterpart lives in src/backend/page-settings/index.js.
 		if ( $post_id ) {
 			$content_layout = get_post_meta( $post_id, '_customify_content_layout', true );
-			if ( in_array( $content_layout, array( 'full-width', 'full-stretched' ), true ) ) {
+			if ( in_array( $content_layout, array( 'full-width', 'full-stretched', 'narrow' ), true ) ) {
 				$layout = 'content';
 			} else {
 				$layout = self::resolve_post_sidebar_layout( $post_id );
 			}
 			$size = customify_get_content_size_for_layout( $layout );
-			$css .= "body { --wp--style--global--content-size: {$size} !important; }";
 
-			// Full-stretched additionally drops the max-width so blocks fill the
-			// container, matching the frontend `.site-content.content-full-stretched`
-			// rule in src/frontend/scss/base/_blocks.scss.
-			if ( 'full-stretched' === $content_layout ) {
-				$css .= '.editor-styles-wrapper > .is-root-container > *:not(.alignfull):not(.alignwide) { max-width: none; }';
+			// Content Layout overrides for content-size — match the per-layout
+			// rules emitted by customify_layout_content_size_css() so the editor
+			// canvas matches the frontend. Full-Width uses calc(100vw - 64px)
+			// (container content-box at 100% with 2em padding each side);
+			// Full-Stretched uses 100vw (no container padding); Narrow uses the
+			// Customizer narrow_width value.
+			if ( 'narrow' === $content_layout ) {
+				$size = customify_get_narrow_width_value();
+			} elseif ( 'full-width' === $content_layout ) {
+				$size = 'calc(100vw - 64px)';
+			} elseif ( 'full-stretched' === $content_layout ) {
+				$size = '100vw';
 			}
+
+			$screen            = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+			$editing_post_type = $screen ? $screen->post_type : '';
+			if ( 'post' === $editing_post_type ) {
+				$user_cw = Customify()->get_setting( 'single_blog_post_content_width' );
+				if ( is_array( $user_cw ) && isset( $user_cw['value'] ) && '' !== $user_cw['value'] ) {
+					$unit = ! empty( $user_cw['unit'] ) ? $user_cw['unit'] : 'px';
+					$size = $user_cw['value'] . $unit;
+				}
+			}
+
+			$css .= "body { --wp--style--global--content-size: {$size}; }";
+
+			// Block max-width override for full-width / full-stretched is emitted
+			// from JS (src/backend/page-settings/index.js::buildContentSizeCss), NOT
+			// here. PHP-emitted CSS is static for the page load — if it included the
+			// override based on the saved meta, toggling content_layout in the
+			// editor sidebar wouldn't be able to undo it because the PHP rule keeps
+			// applying. Letting JS own the dynamic override keeps the metabox
+			// toggle responsive.
 		}
 
 		$css .= '.editor-styles-wrapper ul,

--- a/inc/admin/editor.php
+++ b/inc/admin/editor.php
@@ -243,56 +243,6 @@ class Customify_Editor {
 			// toggle responsive.
 		}
 
-		$css .= '.editor-styles-wrapper ul,
-		.editor-styles-wrapper ol {
-			margin: 1.5em auto;
-			list-style-position: outside;
-		}
-
-		.editor-styles-wrapper .wp-block-list,
-		.editor-styles-wrapper .wp-block-categories__list,
-		.editor-styles-wrapper .wp-block-archives-list {
-			padding-left: 2.5em;
-		}
-
-		.editor-styles-wrapper ul ul:not(.wp-block-navigation ul),
-		.editor-styles-wrapper ol ol,
-		.editor-styles-wrapper ul ol,
-		.editor-styles-wrapper ol ul:not(.wp-block-navigation ul) {
-			margin-bottom: 0;
-			margin-top: 0;
-			margin-left: 2.5em;
-		}
-
-		.editor-styles-wrapper .wp-block-table table,
-		.editor-styles-wrapper .wp-block-table tr,
-		.editor-styles-wrapper .wp-block-table th,
-		.editor-styles-wrapper .wp-block-table td {
-			border: 0;
-		}
-
-		.editor-styles-wrapper .wp-block-quote {
-			border-left-width: 4px;
-			border-left-style: solid;
-		}
-
-		.editor-styles-wrapper .wp-block-pullquote {
-			margin-left: auto;
-			margin-right: auto;
-		}
-
-		.editor-styles-wrapper .wp-block-pullquote.alignleft {
-			margin: 0 1.41575em 1em 2.5em;
-		}
-
-		.editor-styles-wrapper .wp-block-pullquote.alignright {
-			margin: 0 2.5em 1em 1.41575em;
-		}
-
-		.editor-styles-wrapper .wp-block-separator.is-style-dots {
-			max-width: 205px;
-		}
-		';
 		return $css;
 	}
 

--- a/inc/admin/page-settings.php
+++ b/inc/admin/page-settings.php
@@ -141,15 +141,66 @@ class Customify_Page_Settings {
 			? Customify_Editor::customizer_sidebar_layout_for_post_type( $post_type )
 			: 'content-sidebar';
 
+		// Single-post user override: matches the frontend body.single-post rule
+		// from inc/customizer/configs/single-blog-post.php — when editing a post,
+		// the user's saved single_blog_post_content_width takes precedence over
+		// the layout-derived size. Scoped to post_type === 'post' only; other
+		// post types fall through to the layout map. Sent as the normalized
+		// CSS length string (e.g., "600px") so JS doesn't have to recreate the
+		// {value, unit} → length logic.
+		$post_content_size = null;
+		if ( 'post' === $post_type ) {
+			$pcw = Customify()->get_setting( 'single_blog_post_content_width' );
+			if ( is_array( $pcw ) && isset( $pcw['value'] ) && '' !== $pcw['value'] ) {
+				$pcw_unit          = ! empty( $pcw['unit'] ) ? $pcw['unit'] : 'px';
+				$post_content_size = $pcw['value'] . $pcw_unit;
+			}
+		}
+
+		// wideSize for the editor's layout settings sync — pushed into
+		// getSettings().__experimentalFeatures.layout so block dropdown labels
+		// (e.g., "Wide width — Max 1200px wide") match the runtime CSS variable.
+		//
+		// Resolution mirrors what `--wp--style--global--wide-size` actually
+		// resolves to in the editor iframe:
+		//   - container_width has a saved value → editor.php's container_width
+		//     branch emits `:root { --wp--style--global--wide-size: VALUE }`
+		//     via the auto-CSS pipeline. wideSize === saved value.
+		//   - container_width is unsaved → auto-CSS skips emission; only
+		//     theme.json's static wideSize (1200px) applies. Read it via
+		//     wp_get_global_settings() so any theme.json overrides upstream
+		//     stay authoritative.
+		$wide_size = null;
+		$cw_raw    = get_theme_mod( 'container_width' );
+		if ( is_array( $cw_raw ) && ! empty( $cw_raw['value'] ) ) {
+			$wide_size = (int) $cw_raw['value'] . ( ! empty( $cw_raw['unit'] ) ? $cw_raw['unit'] : 'px' );
+		} elseif ( is_numeric( $cw_raw ) && (int) $cw_raw > 0 ) {
+			$wide_size = (int) $cw_raw . 'px';
+		} else {
+			$global_settings = function_exists( 'wp_get_global_settings' ) ? wp_get_global_settings() : array();
+			$wide_size       = $global_settings['layout']['wideSize'] ?? '1200px';
+		}
+
+		// narrowWidth — used when content_layout meta is 'narrow'. Mirrors
+		// customify_get_narrow_width_value() + the .site-content.content-narrow
+		// frontend rule, so editor + frontend stay in sync.
+		$narrow_width = function_exists( 'customify_get_narrow_width_value' )
+			? customify_get_narrow_width_value()
+			: '800px';
+
 		wp_localize_script(
 			'customify-page-settings',
 			'customifyPageSettings',
 			array(
-				'sidebarLayouts' => customify_get_config_sidebar_layouts(),
-				'hasProFeatures' => (bool) class_exists( 'Customify_Pro' ),
-				'hasBreadcrumb'  => (bool) $has_breadcrumb,
-				'fallbackLayout' => $fallback_layout,
-				'contentSizeMap' => customify_get_layout_content_sizes(),
+				'sidebarLayouts'  => customify_get_config_sidebar_layouts(),
+				'hasProFeatures'  => (bool) class_exists( 'Customify_Pro' ),
+				'hasBreadcrumb'   => (bool) $has_breadcrumb,
+				'fallbackLayout'  => $fallback_layout,
+				'contentSizeMap'  => customify_get_layout_content_sizes(),
+				'postType'        => $post_type,
+				'postContentSize' => $post_content_size,
+				'wideSize'        => $wide_size,
+				'narrowWidth'     => $narrow_width,
 			)
 		);
 

--- a/inc/admin/pro-bridge/pro-bridge.css
+++ b/inc/admin/pro-bridge/pro-bridge.css
@@ -1,0 +1,42 @@
+/**
+ * Customify Pro bridge — Settings page styling.
+ *
+ * Mirrors the dashboard-kit hero/card visual treatment so the
+ * legacy-style Pro module settings form sits visually next to the
+ * V2 dashboard surface users come from. CSS variables (`--pmdk-*`)
+ * resolve to dashboard-kit values when its stylesheet is also on
+ * the page; otherwise the inline fallbacks keep the look stable.
+ */
+
+.customify-pro-bridge-settings.wrap {
+	max-width: 1100px;
+	margin: 0 auto;
+	background: var(--pmdk-hero-bg, #fff);
+	border-radius: var(--pmdk-hero-radius, 8px);
+	box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+	padding: var(--pmdk-hero-padding, 48px);
+	box-sizing: border-box;
+}
+
+/* WP's default .wrap top notices area pushes our card flush against
+   the admin bar — give it a small breathing gap so the shadow ring
+   doesn't clip into the wp-admin chrome. */
+.customify-pro-bridge-settings.wrap {
+	margin-top: 24px;
+}
+
+.customify-pro-bridge-settings.wrap h1 {
+	margin: 0 0 16px;
+	padding: 0;
+	font-size: 24px;
+	line-height: 1.3;
+}
+
+.customify-pro-bridge-settings.wrap > p:first-of-type {
+	/* "Back to dashboard" link row. */
+	margin: 0 0 24px;
+}
+
+.customify-pro-bridge-settings.wrap form {
+	margin-top: 8px;
+}

--- a/inc/admin/pro-bridge/pro-bridge.js
+++ b/inc/admin/pro-bridge/pro-bridge.js
@@ -1,0 +1,179 @@
+/**
+ * Customify Pro <-> Dashboard V2 bridge (client side).
+ *
+ * Enqueued by inc/admin/pro-bridge/pro-bridge.php only when the active
+ * Customify Pro build is older than 0.4.16 (the version that ships its own
+ * V2 integration). Hooks into the dashboard's Pro extension filters:
+ *
+ *   customify.dashboard.pro.modules  — enrich the catalogue with classKey
+ *                                      + enabled state from boot.proModules
+ *   customify.dashboard.pro.toggle   — handler that POSTs to Pro's legacy
+ *                                      `customify_pro_module` AJAX action
+ *
+ * Plus a tiny hashchange listener: when the user clicks the Settings link
+ * for a Pro module, the dashboard navigates to `#settings/<id>` which has
+ * no matching theme panel; we redirect to the bridge-hosted settings page
+ * (`admin.php?page=customify-pro-module-settings&module=<class>`) so the
+ * form fields render through the theme's Customify_Form_Fields pipeline.
+ */
+
+( function ( wp ) {
+	if ( ! wp || ! wp.hooks ) {
+		return;
+	}
+	var boot = window.customifyDashboard;
+	if ( ! boot || ! Array.isArray( boot.proModules ) ) {
+		return;
+	}
+
+	var NS = 'customify/pro-bridge';
+	var proList = boot.proModules;
+	var ajax = boot.proAjax || {};
+
+	// Index by kebab id for O(1) lookups inside the filter callbacks. The
+	// catalogue is small (~17 rows) but the filters fire on every render.
+	var byId = {};
+	proList.forEach( function ( mod ) {
+		if ( mod && mod.id ) {
+			byId[ mod.id ] = mod;
+		}
+	} );
+
+	/**
+	 * Merge a Pro payload row into a catalogue base row. Base provides the
+	 * marketing copy + docs link (curated text); Pro overrides with the
+	 * live class/enabled/canToggle state.
+	 */
+	function mergePro( base, p ) {
+		return Object.assign( {}, base, {
+			classKey: p.classKey,
+			enabled: p.enabled,
+			canToggle: p.canToggle,
+			toggleDisableNotice: p.toggleDisableNotice,
+			hasSettings: p.hasSettings,
+			settingsHref: p.settingsHref,
+			parent: p.parent || base.parent || null,
+			subModules:
+				p.subModules && p.subModules.length
+					? p.subModules
+					: base.subModules,
+		} );
+	}
+
+	// Build a catalogue row from scratch when Pro registers a module the
+	// theme's static catalogue doesn't know about (forward-compat).
+	function rowFromPro( p ) {
+		return {
+			id: p.id,
+			name: p.name,
+			description: p.description,
+			docHref: p.docHref,
+			classKey: p.classKey,
+			enabled: p.enabled,
+			canToggle: p.canToggle,
+			toggleDisableNotice: p.toggleDisableNotice,
+			hasSettings: p.hasSettings,
+			settingsHref: p.settingsHref,
+			parent: p.parent || null,
+			subModules: p.subModules || [],
+		};
+	}
+
+	wp.hooks.addFilter(
+		'customify.dashboard.pro.modules',
+		NS,
+		function ( base ) {
+			if ( ! Array.isArray( base ) ) {
+				return base;
+			}
+			var baseIds = {};
+			var merged = base.map( function ( m ) {
+				baseIds[ m.id ] = true;
+				var p = byId[ m.id ];
+				return p ? mergePro( m, p ) : m;
+			} );
+			// Append Pro-only modules (id not in base catalogue).
+			proList.forEach( function ( p ) {
+				if ( ! baseIds[ p.id ] ) {
+					merged.push( rowFromPro( p ) );
+				}
+			} );
+			return merged;
+		}
+	);
+
+	// Toggle handler. Returns a Promise<{ enabled }> as required by
+	// ProModulesSection's contract; reject path triggers the section's
+	// optimistic-revert + error snackbar.
+	wp.hooks.addFilter(
+		'customify.dashboard.pro.toggle',
+		NS,
+		function () {
+			return function ( id, nextEnabled ) {
+				var mod = byId[ id ];
+				if ( ! mod || ! mod.classKey || ! ajax.url ) {
+					return Promise.reject(
+						new Error( 'Unknown Pro module: ' + id )
+					);
+				}
+
+				var body = new URLSearchParams();
+				body.set( 'action', ajax.action );
+				body.set( '_nonce', ajax.nonce );
+				body.set( 'doing', 'toggle_module' );
+				body.set( 'name', mod.classKey );
+				body.set( 'enable', nextEnabled ? '1' : '0' );
+
+				return fetch( ajax.url, {
+					method: 'POST',
+					credentials: 'same-origin',
+					headers: {
+						'Content-Type':
+							'application/x-www-form-urlencoded; charset=UTF-8',
+					},
+					body: body.toString(),
+				} )
+					.then( function ( res ) {
+						if ( ! res.ok ) {
+							throw new Error( 'HTTP ' + res.status );
+						}
+						return res.json();
+					} )
+					.then( function ( json ) {
+						if ( ! json || ! json.success ) {
+							throw new Error( 'Toggle rejected by server' );
+						}
+						mod.enabled = !! nextEnabled;
+						if ( mod.reload ) {
+							// Pro flags some modules as "reload required"
+							// (e.g. modules that register Customizer panels
+							// at boot). Defer slightly so the success
+							// snackbar paints before the page tears down.
+							setTimeout( function () {
+								window.location.reload();
+							}, 250 );
+						}
+						return { enabled: !! nextEnabled };
+					} );
+			};
+		}
+	);
+
+	// Redirect #settings/<pro-module-id> to Pro's legacy module-settings
+	// page. The hash fires before React renders the (empty) Settings panel
+	// for the missing id, so the user lands on the legacy form without a
+	// flash of "No settings registered yet".
+	function maybeRedirectSettings() {
+		var hash = window.location.hash || '';
+		var m = hash.match( /^#settings\/([^/]+)$/ );
+		if ( ! m ) {
+			return;
+		}
+		var mod = byId[ m[ 1 ] ];
+		if ( mod && mod.settingsHref ) {
+			window.location.replace( mod.settingsHref );
+		}
+	}
+	window.addEventListener( 'hashchange', maybeRedirectSettings );
+	maybeRedirectSettings();
+} )( window.wp );

--- a/inc/admin/pro-bridge/pro-bridge.php
+++ b/inc/admin/pro-bridge/pro-bridge.php
@@ -331,7 +331,6 @@ function customify_pro_bridge_enqueue_settings_assets( string $hook ): void {
 		return;
 	}
 
-	$theme_suffix  = Customify()->get_asset_suffix();
 	$theme_version = Customify::$version ? (string) Customify::$version : (string) wp_get_theme()->get( 'Version' );
 	$pro_version   = customify_pro_bridge_get_pro_version();
 	$pro_url       = Customify_Pro::$url;
@@ -339,14 +338,14 @@ function customify_pro_bridge_enqueue_settings_assets( string $hook ): void {
 	wp_enqueue_media();
 	wp_enqueue_script(
 		'customify-metabox',
-		get_template_directory_uri() . '/assets/js/admin/metabox' . $theme_suffix . '.js',
+		esc_url( get_template_directory_uri() ) . '/build/js/backend/admin/metabox.js',
 		array( 'jquery' ),
 		$theme_version,
 		true
 	);
 	wp_enqueue_style(
 		'customify-metabox',
-		get_template_directory_uri() . '/assets/css/admin/metabox' . $theme_suffix . '.css',
+		esc_url( get_template_directory_uri() ) . '/build/css/backend/admin/metabox.css',
 		array(),
 		$theme_version
 	);

--- a/inc/admin/pro-bridge/pro-bridge.php
+++ b/inc/admin/pro-bridge/pro-bridge.php
@@ -1,0 +1,497 @@
+<?php
+/**
+ * Customify Pro <-> Dashboard V2 bridge (fallback for legacy Pro builds).
+ *
+ * Customify Pro >= 0.4.16 wires its own V2 hooks. This bridge fills the gap
+ * for OLDER Pro builds (< 0.4.16) that only know the legacy
+ * `appearance_page_customify` dashboard — without it, the V2 Welcome tab
+ * keeps showing the marketing list even when Pro is active.
+ *
+ * The bridge bails entirely when Pro is missing OR Pro is >= 0.4.16, so
+ * future Pro builds own the integration without conflict.
+ *
+ * Pro module Settings pages are HOSTED HERE (not redirected to the legacy
+ * `customify-legacy` page) because:
+ *   - The legacy menu registration is commented out
+ *     (inc/admin/dashboard.php) — the URL 404s.
+ *   - Even when re-registered, Pro's legacy module_settings_page() builds
+ *     the form action from a hardcoded `admin.php?page=customify` URL,
+ *     which now points at the SPA shell that won't process the POST.
+ * Self-hosting reuses the public Pro module API (`settings()`, `save()`,
+ * `get_settings()`) + theme's `Customify_Form_Fields` renderer, so we
+ * don't touch the Pro plugin and we don't depend on Pro's URL plumbing.
+ *
+ * @package Customify
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Bridge is a fallback only — bail BEFORE defining any constants,
+// functions, or hooks so a newer Pro build sees an inert bridge file
+// (zero symbols leaked into global scope, zero filters registered).
+//
+//   1. No Customify_Pro class → Pro plugin missing/disabled.
+//   2. Pro version >= 0.4.16  → Pro ships its own V2 integration.
+//
+// Version detection runs in a one-shot closure so its symbols never
+// outlive the guard; the resolved string is captured into a file-scope
+// var and re-exposed via customify_pro_bridge_get_pro_version() below
+// (defined only after the guard passes).
+if ( ! class_exists( 'Customify_Pro' ) ) {
+	return;
+}
+
+$customify_pro_bridge_version = ( static function (): string {
+	if ( ! function_exists( 'get_plugin_data' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+	try {
+		$ref  = new ReflectionClass( 'Customify_Pro' );
+		$file = $ref->getFileName();
+		if ( $file && is_readable( $file ) ) {
+			$data = get_plugin_data( $file, false, false );
+			if ( ! empty( $data['Version'] ) ) {
+				return (string) $data['Version'];
+			}
+		}
+	} catch ( \Throwable $e ) {
+		// Fall through to the static-property fallback below.
+	}
+	if ( isset( Customify_Pro::$version ) ) {
+		return (string) Customify_Pro::$version;
+	}
+	return '';
+} )();
+
+if ( '' === $customify_pro_bridge_version ) {
+	return;
+}
+if ( version_compare( $customify_pro_bridge_version, '0.4.16', '>=' ) ) {
+	return;
+}
+
+// === Past the guard. Bridge is active for Pro < 0.4.16 only. ===
+
+const CUSTOMIFY_PRO_BRIDGE_HANDLE        = 'customify-dashboard-pro-bridge';
+const CUSTOMIFY_PRO_BRIDGE_SETTINGS_SLUG = 'customify-pro-module-settings';
+
+// pro-bridge.php is `require_once`d from inside Customify::admin_includes(),
+// so $customify_pro_bridge_version lives in *that method's* local scope —
+// it disappears as soon as admin_includes() returns and isn't visible to
+// the named functions defined below. Export to $GLOBALS so the getter can
+// hand the resolved version to filter/action callbacks at request time.
+$GLOBALS['customify_pro_bridge_pro_version'] = $customify_pro_bridge_version;
+
+/**
+ * Return the resolved Pro version captured during the guard above.
+ * Used by boot-data injection + asset cache busts.
+ *
+ * @return string
+ */
+function customify_pro_bridge_get_pro_version(): string {
+	return (string) ( $GLOBALS['customify_pro_bridge_pro_version'] ?? '' );
+}
+
+/**
+ * Map a Pro module class name to the kebab id used by data/proModules.js.
+ * Mirrors Customify_Pro_Module_Base::get_id() so bridge ids line up with
+ * the ids modules use internally.
+ *
+ * @param string $class_name e.g. "Customify_Pro_Module_Header_Sticky".
+ * @return string e.g. "header-sticky".
+ */
+function customify_pro_bridge_class_to_id( string $class_name ): string {
+	$tail = str_replace( 'Customify_Pro_Module_', '', $class_name );
+	return strtolower( str_replace( '_', '-', $tail ) );
+}
+
+/**
+ * Build the URL of the bridge-hosted Settings page for a Pro module.
+ *
+ * @param string $class_name Pro module class.
+ * @return string Admin URL.
+ */
+function customify_pro_bridge_settings_url( string $class_name ): string {
+	return add_query_arg(
+		array(
+			'page'   => CUSTOMIFY_PRO_BRIDGE_SETTINGS_SLUG,
+			'module' => rawurlencode( $class_name ),
+		),
+		admin_url( 'admin.php' )
+	);
+}
+
+/**
+ * Flip boot.proActive so the V2 shell switches to the Pro-active rendering
+ * path (hides "Upgrade now", swaps the version label, etc.).
+ */
+add_filter( 'customify_dashboard_pro_active', '__return_true' );
+
+/**
+ * Inject Pro module catalogue + AJAX wiring into the dashboard boot payload.
+ *
+ * @param array  $boot    Boot data.
+ * @param string $context Context (always 'dashboard' for this hook).
+ * @return array
+ */
+function customify_pro_bridge_localize( array $boot, string $context ): array {
+	if ( 'dashboard' !== $context ) {
+		return $boot;
+	}
+
+	$pro = Customify_Pro();
+
+	$boot['proVersion'] = customify_pro_bridge_get_pro_version();
+
+	$boot['proAjax'] = array(
+		'url'    => admin_url( 'admin-ajax.php' ),
+		'action' => 'customify_pro_module',
+		'nonce'  => wp_create_nonce( 'customify_pro_module' ),
+	);
+
+	$modules = array();
+	foreach ( $pro->modules as $class_name => $args ) {
+		$has_settings = method_exists( $class_name, 'settings' );
+		$parent       = ! empty( $args['parent'] ) ? customify_pro_bridge_class_to_id( $args['parent'] ) : null;
+
+		$sub_modules = array();
+		if ( ! empty( $args['sub_modules'] ) && is_array( $args['sub_modules'] ) ) {
+			foreach ( $args['sub_modules'] as $sub_class ) {
+				if ( is_string( $sub_class ) ) {
+					$sub_modules[] = customify_pro_bridge_class_to_id( $sub_class );
+				}
+			}
+		}
+
+		$row = array(
+			'id'                  => customify_pro_bridge_class_to_id( $class_name ),
+			'classKey'            => $class_name,
+			'name'                => isset( $args['name'] ) ? (string) $args['name'] : '',
+			'description'         => isset( $args['desc'] ) ? (string) $args['desc'] : '',
+			'enabled'             => (bool) $pro->is_enabled_module( $class_name ),
+			'canToggle'           => isset( $args['can_toggle'] ) ? (bool) $args['can_toggle'] : true,
+			'toggleDisableNotice' => isset( $args['toggle_disable_notice'] ) ? (string) $args['toggle_disable_notice'] : '',
+			'hasSettings'         => (bool) $has_settings,
+			'docHref'             => isset( $args['doc_link'] ) ? (string) $args['doc_link'] : '',
+			'parent'              => $parent,
+			'subModules'          => $sub_modules,
+			'reload'              => ! empty( $args['reload'] ),
+		);
+
+		if ( $has_settings ) {
+			$row['settingsHref'] = customify_pro_bridge_settings_url( $class_name );
+		}
+
+		$modules[] = $row;
+	}
+
+	$boot['proModules'] = $modules;
+
+	return $boot;
+}
+add_filter( 'customify_dashboard_localize', 'customify_pro_bridge_localize', 10, 2 );
+
+/**
+ * Enqueue the bridge JS on the V2 dashboard page only. Depends on the
+ * dashboard handle so `window.customifyDashboard` is already localized
+ * when the bridge runs.
+ *
+ * @param string $hook Current admin page hook.
+ */
+function customify_pro_bridge_enqueue( string $hook ): void {
+	if ( 'toplevel_page_' . CUSTOMIFY_DASHBOARD_V2_SLUG !== $hook ) {
+		return;
+	}
+
+	$rel  = 'inc/admin/pro-bridge/pro-bridge.js';
+	$path = get_theme_file_path( $rel );
+	if ( ! is_readable( $path ) ) {
+		return;
+	}
+
+	wp_enqueue_script(
+		CUSTOMIFY_PRO_BRIDGE_HANDLE,
+		get_theme_file_uri( $rel ),
+		array( 'wp-hooks', CUSTOMIFY_DASHBOARD_V2_HANDLE ),
+		(string) filemtime( $path ),
+		true
+	);
+}
+add_action( 'admin_enqueue_scripts', 'customify_pro_bridge_enqueue', 20 );
+
+/**
+ * Register the bridge-hosted Settings page as a child of the Customify
+ * top-level menu.
+ *
+ * We register under the `customify` parent (the V2 dashboard's top-level
+ * slug) so:
+ *   - WP's `get_admin_page_title()` can resolve the title from `$submenu`
+ *     (avoids the `strip_tags( null )` deprecation in admin-header.php
+ *     that orphan-parent pages trigger on PHP 8.1+).
+ *   - The admin sidebar reads as "we're inside the Customify section"
+ *     while editing a module (`parent_file` filter pins the highlight).
+ *
+ * The auto-added submenu row is removed immediately (priority 999) so
+ * the page doesn't appear as a permanent sidebar link — users only
+ * reach it via the "Settings" affordance on the Welcome tab.
+ */
+function customify_pro_bridge_register_settings_page(): void {
+	if ( ! defined( 'CUSTOMIFY_DASHBOARD_V2_SLUG' ) ) {
+		// dashboard-v2.php is loaded before this file, but bail defensively
+		// so a partial theme load doesn't fatal.
+		return;
+	}
+
+	$page_title = __( 'Customify Pro module settings', 'customify' );
+
+	$hook = add_submenu_page(
+		CUSTOMIFY_DASHBOARD_V2_SLUG,
+		$page_title,
+		$page_title,
+		'manage_options',
+		CUSTOMIFY_PRO_BRIDGE_SETTINGS_SLUG,
+		'customify_pro_bridge_render_settings_page'
+	);
+
+	if ( ! $hook ) {
+		return;
+	}
+
+	// Belt-and-suspenders for older WP versions where title resolution
+	// can still leave $title empty for hidden submenu rows.
+	add_action(
+		'load-' . $hook,
+		static function () use ( $page_title ): void {
+			global $title;
+			if ( empty( $title ) ) {
+				$title = $page_title;
+			}
+		}
+	);
+}
+add_action( 'admin_menu', 'customify_pro_bridge_register_settings_page' );
+
+/**
+ * Hide the bridge settings row from the visible Customify submenu via
+ * CSS — but leave it in `$submenu`.
+ *
+ * Why CSS, not `remove_submenu_page()`: WP's admin.php resolves the page
+ * hook from `$submenu` (`get_plugin_page_hookname()` walks the menu tree
+ * to find a parent). Removing our row causes the resolution to fall
+ * back to `admin_page_<slug>`, but our callback was registered against
+ * `customify_page_<slug>` — `has_action()` misses it and the URL
+ * 403s with "Sorry, you are not allowed to access this page."
+ *
+ * Keeping the row registered also means WP derives `$parent_file` =
+ * 'customify' on its own, so the Customify top-level menu highlights +
+ * stays expanded without an extra `parent_file`/`submenu_file` filter.
+ *
+ * The CSS target is the submenu anchor's href so we don't depend on the
+ * row's position within `$submenu`.
+ */
+function customify_pro_bridge_hide_settings_submenu_css(): void {
+	if ( ! defined( 'CUSTOMIFY_DASHBOARD_V2_SLUG' ) ) {
+		return;
+	}
+	?>
+<style>
+#adminmenu #toplevel_page_<?php echo esc_attr( CUSTOMIFY_DASHBOARD_V2_SLUG ); ?> .wp-submenu a[href*="page=<?php echo esc_attr( CUSTOMIFY_PRO_BRIDGE_SETTINGS_SLUG ); ?>"] {
+	display: none !important;
+}
+</style>
+	<?php
+}
+add_action( 'admin_head', 'customify_pro_bridge_hide_settings_submenu_css' );
+
+/**
+ * Enqueue the metabox-field assets that Customify_Form_Fields needs to
+ * render — these live in the theme already and Pro's legacy dashboard
+ * does the same thing on its own settings screen.
+ *
+ * @param string $hook Current admin page hook.
+ */
+function customify_pro_bridge_enqueue_settings_assets( string $hook ): void {
+	// Parent slug 'customify' is registered via add_menu_page in
+	// dashboard-v2.php, so get_plugin_page_hookname() derives the hook as
+	// `<parent_slug>_page_<this_slug>`.
+	if ( ! defined( 'CUSTOMIFY_DASHBOARD_V2_SLUG' ) ) {
+		return;
+	}
+	if ( CUSTOMIFY_DASHBOARD_V2_SLUG . '_page_' . CUSTOMIFY_PRO_BRIDGE_SETTINGS_SLUG !== $hook ) {
+		return;
+	}
+
+	if ( ! class_exists( 'Customify' ) || ! class_exists( 'Customify_Pro' ) ) {
+		// Bridge already guards on Customify_Pro at file load, but admin
+		// hooks fire later — re-verify before touching either class.
+		return;
+	}
+
+	$theme_suffix  = Customify()->get_asset_suffix();
+	$theme_version = Customify::$version ? (string) Customify::$version : (string) wp_get_theme()->get( 'Version' );
+	$pro_version   = customify_pro_bridge_get_pro_version();
+	$pro_url       = Customify_Pro::$url;
+
+	wp_enqueue_media();
+	wp_enqueue_script(
+		'customify-metabox',
+		get_template_directory_uri() . '/assets/js/admin/metabox' . $theme_suffix . '.js',
+		array( 'jquery' ),
+		$theme_version,
+		true
+	);
+	wp_enqueue_style(
+		'customify-metabox',
+		get_template_directory_uri() . '/assets/css/admin/metabox' . $theme_suffix . '.css',
+		array(),
+		$theme_version
+	);
+
+	// Some Pro modules' settings fields hook into the Customify Pro admin
+	// JS/CSS for their own widgets — load those too so the form behaves
+	// the same as on Pro's own settings screen.
+	if ( $pro_url ) {
+		wp_enqueue_script( 'customify-pro-admin', $pro_url . '/assets/js/admin/customify-admin.js', array( 'jquery' ), $pro_version, true );
+		wp_enqueue_style( 'customify-pro-admin', $pro_url . '/assets/css/admin/admin.css', array(), $pro_version );
+	}
+
+	// Bridge-owned hero/card styling so the legacy form visually matches
+	// the V2 dashboard the user arrived from.
+	$css_rel  = 'inc/admin/pro-bridge/pro-bridge.css';
+	$css_path = get_theme_file_path( $css_rel );
+	if ( is_readable( $css_path ) ) {
+		wp_enqueue_style(
+			CUSTOMIFY_PRO_BRIDGE_HANDLE,
+			get_theme_file_uri( $css_rel ),
+			array(),
+			(string) filemtime( $css_path )
+		);
+	}
+}
+add_action( 'admin_enqueue_scripts', 'customify_pro_bridge_enqueue_settings_assets', 20 );
+
+/**
+ * Render the bridge-hosted Settings page for a single Pro module. Reuses
+ * the public Pro module API (`settings()`, `save()`, `get_settings()`)
+ * and the theme's `Customify_Form_Fields` renderer — same building blocks
+ * Pro's own class-dashboard.php uses. The form posts back to the same URL.
+ */
+function customify_pro_bridge_render_settings_page(): void {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'Sorry, you are not allowed to access this page.', 'customify' ) );
+	}
+
+	$class_name = isset( $_GET['module'] ) ? sanitize_text_field( wp_unslash( $_GET['module'] ) ) : '';
+	$pro        = Customify_Pro();
+
+	// Module must be registered, enabled, AND expose a settings() method.
+	// Matches Pro's own setup() guard in class-dashboard.php so users land
+	// on a coherent error rather than a half-rendered form.
+	if (
+		'' === $class_name
+		|| ! isset( $pro->modules[ $class_name ] )
+		|| ! $pro->is_enabled_module( $class_name )
+		|| ! isset( $pro->installed_modules[ $class_name ] )
+		|| ! method_exists( $class_name, 'settings' )
+	) {
+		echo '<div class="wrap"><h1>' . esc_html__( 'Module settings unavailable', 'customify' ) . '</h1>';
+		echo '<p>' . esc_html__( 'This module is not registered, not enabled, or does not expose any settings.', 'customify' ) . '</p>';
+		printf(
+			'<p><a class="button" href="%1$s">%2$s</a></p>',
+			esc_url( admin_url( 'admin.php?page=' . CUSTOMIFY_DASHBOARD_V2_SLUG ) ),
+			esc_html__( 'Back to dashboard', 'customify' )
+		);
+		echo '</div>';
+		return;
+	}
+
+	$module = $pro->installed_modules[ $class_name ];
+	$info   = $pro->modules[ $class_name ];
+
+	$fields_class_path = get_template_directory() . '/inc/class-metabox-fields.php';
+	if ( ! file_exists( $fields_class_path ) ) {
+		wp_die( esc_html__( 'Form fields class missing.', 'customify' ) );
+	}
+	require_once $fields_class_path;
+
+	$field_builder = new Customify_Form_Fields();
+	$field_builder->set_group_name( 'customify_module_settings' );
+	$field_builder->add_fields( $module->settings() );
+	$field_builder->using_tabs( false );
+
+	$action_url = customify_pro_bridge_settings_url( $class_name );
+	$saved      = false;
+
+	if ( isset( $_POST['customify_pro_bridge_form_submit'] ) ) {
+		check_admin_referer( 'customify_pro_bridge_save_' . $class_name );
+		$values = $field_builder->get_submitted_values();
+		$module->save( $values );
+		$saved = true;
+
+		if ( method_exists( $module, 'after_save' ) ) {
+			// Pro's class-dashboard passes the dashboard instance here; the
+			// modules that consume it (if any) treat it as opaque, so null
+			// is safe.
+			$module->after_save( null );
+		}
+		do_action( 'customify-pro/after-module-saved', null );
+
+		// Re-build fields against the new saved state so default-derived
+		// fields refresh (matches Pro's flow).
+		$fresh = $module->settings();
+		$field_builder->reset_fields();
+		$field_builder->add_fields( $fresh );
+	}
+
+	$field_builder->set_values( $module->get_settings() );
+
+	$back_url    = admin_url( 'admin.php?page=' . CUSTOMIFY_DASHBOARD_V2_SLUG );
+	$module_name = isset( $info['name'] ) ? (string) $info['name'] : $class_name;
+	?>
+	<div class="wrap customify-pro-bridge-settings">
+		<h1>
+			<?php
+			printf(
+				/* translators: %s: Pro module name. */
+				esc_html__( '%s Settings', 'customify' ),
+				esc_html( $module_name )
+			);
+			?>
+		</h1>
+		<p>
+			<a class="button button-secondary" href="<?php echo esc_url( $back_url ); ?>">
+				<?php esc_html_e( '← Back to dashboard', 'customify' ); ?>
+			</a>
+		</p>
+
+		<?php if ( $saved ) : ?>
+			<div class="notice notice-success is-dismissible">
+				<p><?php esc_html_e( 'Settings saved.', 'customify' ); ?></p>
+			</div>
+		<?php endif; ?>
+
+		<?php
+		if ( method_exists( $module, 'before_form' ) ) {
+			$module->before_form();
+		}
+		?>
+
+		<form method="post" action="<?php echo esc_url( $action_url ); ?>">
+			<?php wp_nonce_field( 'customify_pro_bridge_save_' . $class_name ); ?>
+			<?php $field_builder->render(); ?>
+			<input type="hidden" name="customify_pro_bridge_form_submit" value="1">
+			<?php submit_button(); ?>
+		</form>
+
+		<?php
+		if ( method_exists( $module, 'after_form' ) ) {
+			$module->after_form();
+		}
+		?>
+	</div>
+	<?php
+}

--- a/inc/class-customify.php
+++ b/inc/class-customify.php
@@ -530,6 +530,7 @@ class Customify
 			'/inc/admin/editor.php',       // Block editor style integration.
 			'/inc/admin/dashboard.php',    // Legacy PHP dashboard (Appearance → Customify Options (Legacy)).
 			'/inc/admin/dashboard-v2.php', // New SPA dashboard (top-level Customify) — @pressmaximum/dashboard-kit.
+			'/inc/admin/pro-bridge/pro-bridge.php', // Fallback bridge for Customify Pro < 0.4.16 (self-disables on newer Pro).
 		);
 
 		foreach ($files as $file) {

--- a/inc/class-metabox.php
+++ b/inc/class-metabox.php
@@ -66,6 +66,7 @@ class Customify_MetaBox {
 				'choices'      => array(
 					'full-width'     => __( 'Full Width', 'customify' ),
 					'full-stretched' => __( 'Full Width - Stretched', 'customify' ),
+					'narrow'         => __( 'Narrow', 'customify' ),
 				),
 				'show_default' => true,
 			)

--- a/inc/compatibility/woocommerce/config/colors.php
+++ b/inc/compatibility/woocommerce/config/colors.php
@@ -6,6 +6,7 @@ class Customify_WC_Colors {
 	}
 
 	function config( $configs ) {
+		
 		$section = 'global_styling';
 
 		$configs[] = array(
@@ -13,30 +14,6 @@ class Customify_WC_Colors {
 			'type'    => 'heading',
 			'section' => $section,
 			'title'   => __( 'Shop Colors', 'customify' ),
-		);
-
-		$configs[] = array(
-			'name'        => "{$section}_shop_primary",
-			'type'        => 'color',
-			'section'     => $section,
-			'title'       => __( 'Shop Buttons', 'customify' ),
-			'placeholder' => '#c3512f',
-			'default'     => '#c3512f',
-			'description' => __( 'Color for add to cart, checkout buttons. Default is Secondary Color.', 'customify' ),
-			'css_format'  => apply_filters(
-				'customify/styling/shop-buttons',
-				'
-					.woocommerce .button.add_to_cart_button, 
-					.woocommerce .button.alt,
-					.woocommerce .button.added_to_cart, 
-					.woocommerce .button.checkout, 
-					.woocommerce .button.product_type_variable,
-					.item--wc_cart .cart-icon .cart-qty .customify-wc-total-qty
-					{
-					    background-color: {{value}};
-					}'
-			),
-			'selector'    => 'format',
 		);
 
 		$configs[] = array(

--- a/inc/compatibility/woocommerce/woocommerce.php
+++ b/inc/compatibility/woocommerce/woocommerce.php
@@ -53,12 +53,14 @@ class Customify_WC {
 			 */
 			add_action( 'wp', array( $this, 'wp' ) );
 
-			// Custom styling.
-			add_filter( 'customify/styling/primary-color', array( $this, 'styling_primary' ) );
-			add_filter( 'customify/styling/secondary-color', array( $this, 'styling_secondary' ) );
-			add_filter( 'customify/styling/link-color', array( $this, 'styling_linkcolor' ) );
-			add_filter( 'customify/styling/color-border', array( $this, 'styling_border_color' ) );
-			add_filter( 'customify/styling/color-meta', array( $this, 'styling_meta_color' ) );
+			// Custom styling filters removed in the colors→SCSS migration.
+			// Every WC-specific selector that styling_primary / styling_secondary /
+			// styling_linkcolor / styling_border_color / styling_meta_color used to
+			// append to the inline color templates now lives in the bundled WC
+			// SCSS (src/frontend/scss/compatibility/wc/*.scss) consuming the same
+			// `$color_primary` / `$color_secondary` / `$color_link` / `$color_border`
+			// / `$color_meta` variables, which resolve through the `--customify-*`
+			// :root tokens emitted by inc/colors-palette.php.
 
 			// Shopping Cart.
 			require_once get_template_directory() . '/inc/compatibility/woocommerce/config/header/cart.php';
@@ -368,79 +370,6 @@ class Customify_WC {
 		$cart_fragments['.customify-wc-total-qty'] = '<span class="' . $class . '">' . $qty . '</span>';
 
 		return $cart_fragments;
-	}
-
-	function styling_primary( $selector ) {
-		$selector .= ' 
-        
-        .wc-svg-btn.active,
-        .woocommerce-tabs.wc-tabs-horizontal ul.tabs li.active,
-        #review_form {
-            border-color: {{value}};
-        }
-        
-        .wc-svg-btn.active,
-        .wc-single-tabs ul.tabs li.active a,
-        .wc-single-tabs .tab-section.active .tab-section-heading a {
-            color: {{value}};
-        }';
-
-		return $selector;
-	}
-
-	function styling_secondary( $selector ) {
-		$selector .= ' 
-        
-        .add_to_cart_button
-        {
-            background-color: {{value}};
-        }';
-
-		return $selector;
-	}
-
-	function styling_linkcolor( $selector ) {
-		$selector .= '
-		 
-		.woocommerce-account .woocommerce-MyAccount-navigation ul li.is-active a,
-        .woocommerce-account .woocommerce-MyAccount-navigation ul li a:hover {
-            color: {{value}};
-        }';
-
-		return $selector;
-	}
-
-	function styling_border_color( $selector ) {
-		$selector .= '
-		.widget_price_filter .price_slider_wrapper .ui-widget-content {
-		    background-color: {{value}};
-		}
-		.product_list_widget li,
-		#reviews #comments ol.commentlist li .comment-text,
-		.woocommerce-tabs.wc-tabs-vertical .wc-tabs li,
-		.product_meta > span,
-		.woocommerce-tabs.wc-tabs-horizontal ul.tabs,
-		.woocommerce-tabs.wc-tabs-vertical .wc-tabs li:first-child {
-            border-color: {{value}};
-        }';
-
-		return $selector;
-	}
-
-	function styling_meta_color( $selector ) {
-		$selector .= '
-		.widget_price_filter .ui-slider .ui-slider-handle {
-		    border-color: {{value}};
-		}
-		.wc-product-inner .wc-product__category a {
-		    color: {{value}};
-		}
-		.widget_price_filter .ui-slider .ui-slider-range,
-		.widget_price_filter .price_slider_amount .button {
-            background-color: {{value}};
-        }';
-
-		return $selector;
 	}
 
 	function wp() {

--- a/inc/compatibility/woocommerce/woocommerce.php
+++ b/inc/compatibility/woocommerce/woocommerce.php
@@ -433,7 +433,11 @@ class Customify_WC {
 
 	function show_shop_footer( $show = true ) {
 		if ( $this->is_shop_pages() ) {
-			$rows    = array( 'main', 'bottom' );
+			// Mirror customify_is_footer_display() — use the filtered
+			// row list so Pro/child-theme rows are counted too.
+			$rows    = function_exists( 'customify_get_footer_row_ids' )
+				? customify_get_footer_row_ids()
+				: array( 'main', 'bottom' );
 			$count   = 0;
 			$shop_id = wc_get_page_id( 'shop' );
 			foreach ( $rows as $row_id ) {

--- a/inc/customizer/class-customizer.php
+++ b/inc/customizer/class-customizer.php
@@ -250,6 +250,13 @@ class  Customify_Customizer {
 					'devices'        => $this->devices,
 					'typo_fields'    => $this->get_typo_fields(),
 					'styling_config' => $this->get_styling_config(),
+					// Filtered footer row IDs (top/main/bottom + 3rd-party
+					// additions). customizer.js iterates this to bind a
+					// live-preview handler on every footer row's
+					// col_layout setting.
+					'footer_rows'    => function_exists( 'customify_get_footer_row_ids' )
+						? customify_get_footer_row_ids()
+						: array( 'main', 'bottom' ),
 				)
 			);
 		}

--- a/inc/customizer/configs/colors.php
+++ b/inc/customizer/configs/colors.php
@@ -37,13 +37,20 @@ if ( ! function_exists( 'customify_customizer_colors_config' ) ) {
 		// the same theme_mod via customify_color_get_slots(), so they render the
 		// identical hex. Safe for 30K sites; refactor lets future slot edits
 		// propagate to every primary-themed selector via :root only.
+		// `[class*="wp-block-"]` negation in every button/input slot below
+		// mirrors src/frontend/scss/base/_base.scss button rules — keeps the
+		// primary-color background off WP default-block chrome buttons
+		// (Search submit, File download, Embed "Try again", etc.) both on
+		// the frontend and inside the block editor canvas. `.wp-block-button__link`
+		// stays themed because it isn't matched here — Button-block color
+		// comes from theme.json + the explicit rule in _base.scss.
 		$primary_css = apply_filters(
 			'customify/styling/primary-color',
 			'
 			.header-top .header--row-inner,
-			body:not(.fl-builder-edit) :is(.button, button:not(.menu-mobile-toggle, .components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, .wp-block-navigation__submenu-icon), input[type="button"]:not(.ed_button)),
-			button.button,
-			:is(input[type="button"]:not(.ed_button), input[type="reset"], input[type="submit"]):not(.components-button, .customize-partial-edit-shortcut-button),
+			body:not(.fl-builder-edit) :is(.button:not([class*="wp-block-"]), button:not(.menu-mobile-toggle, .components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"]), input[type="button"]:not(.ed_button, [class*="wp-block-"])),
+			button.button:not([class*="wp-block-"]),
+			:is(input[type="button"]:not(.ed_button), input[type="reset"], input[type="submit"]):not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
 			.pagination .nav-links span,
 			.pagination .nav-links > *:hover,
 			.nav-menu-desktop.style-full-height .primary-menu-ul > li:is(.current-menu-item, .current-menu-ancestor) > a,

--- a/inc/customizer/configs/colors.php
+++ b/inc/customizer/configs/colors.php
@@ -28,208 +28,31 @@ if ( ! function_exists( 'customify_customizer_colors_config' ) ) {
 	function customify_customizer_colors_config( $configs ) {
 		$section = 'customify_colors';
 
-		// CSS format strings — copied verbatim from styling.php so byte-equivalent
-		// CSS is emitted on legacy sites with saved values.
-		// Primary CSS: var(--customify-primary, fallback). The fallback hex is the
-		// substituted {{value}} (i.e. the saved theme_mod or its default), so legacy
-		// browsers without CSS-var support render the saved color directly. Modern
-		// browsers read --customify-primary from the :root block — which is fed by
-		// the same theme_mod via customify_color_get_slots(), so they render the
-		// identical hex. Safe for 30K sites; refactor lets future slot edits
-		// propagate to every primary-themed selector via :root only.
-		// `[class*="wp-block-"]` negation in every button/input slot below
-		// mirrors src/frontend/scss/base/_base.scss button rules — keeps the
-		// primary-color background off WP default-block chrome buttons
-		// (Search submit, File download, Embed "Try again", etc.) both on
-		// the frontend and inside the block editor canvas. `.wp-block-button__link`
-		// stays themed because it isn't matched here — Button-block color
-		// comes from theme.json + the explicit rule in _base.scss.
-		$primary_css = apply_filters(
-			'customify/styling/primary-color',
-			':root {--customify-primary: {{value}}; }'
-		);
-
-		$secondary_css = apply_filters(
-			'customify/styling/secondary-color',
-			':root {--customify-secondary: {{value}}; }'
-		);
-
-		// Body / ink CSS: var(--customify-body-text, fallback). Body copy
-		// follows slot.text directly via the :root cascade chain
-		// `--customify-body-text: var(--customify-text, ...)`. Pure var()
-		// passthrough — no mix — so user's Text slot value flows through
-		// unchanged (white text on a dark base renders white body copy,
-		// not a desaturated grey). Fresh-install shift from legacy
-		// `#686868` to slot.text `#2b2b2b`. Saved body override locks
-		// the static value.
-		$text_css = apply_filters(
-			'customify/styling/text-color',
-			'
-			body
-			{
-			    color: var(--customify-body-text, {{value}});
-			}
-			abbr, acronym {
-			    border-bottom-color: var(--customify-body-text, {{value}});
-			}'
-		);
-
-		// Link CSS: var(--customify-link, fallback). Link default aligns with
-		// slot.primary so editing the Primary slot cascades to link color.
-		// Saved overrides feed both pipelines identically. See SPEC §8.6.
-		$link_css = apply_filters(
-			'customify/styling/link-color',
-			'
-                a
-                {
-                    color: var(--customify-link, {{value}});
-				}'
-		);
-
-		// Link hover CSS: var(--customify-link-hover, fallback). Hover is a
-		// LIGHTER tint of link (15% white mixed in), not darker — matches
-		// the design intent that hover surfaces the link by raising
-		// luminance against most text contexts.
-		$link_hover_css = apply_filters(
-			'customify/styling/link-color-hover',
-			'
-a:hover,
-a:focus,
-.link-meta:hover, .link-meta a:hover
-{
-    color: var(--customify-link-hover, {{value}});
-}'
-		);
-
-		// Border CSS: var(--customify-border, fallback). The :root token
-		// is emitted UNCONDITIONALLY (Phase 2.13 follow-up), so the
-		// `color-mix(currentcolor 9%, transparent)` fallback only fires
-		// when modern browsers see an inherited token (`unset` / `initial`)
-		// and on legacy browsers without var() support. Token value is
-		// `mix(slot.text, slot.base, 9%)` — fallback + slot mix held at
-		// the SAME 9% so the legacy-browser path renders match modern.
+		// Inline CSS templates intentionally removed in the colors→SCSS migration.
+		// Every per-selector rule that lived in $primary_css / $secondary_css /
+		// $text_css / $link_css / $link_hover_css / $border_css / $meta_css /
+		// $heading_css / $w_title_css now lives in the bundled SCSS, consuming
+		// the same `--customify-*` tokens via the `$color_*` SCSS variables
+		// declared in src/frontend/scss/utils/_vars.scss.
 		//
-		// History: Phase 2.0 used 12% for both paths. Spec §2 bumped slot
-		// mix to 14% (`#e1e1e1`) but left the fallback at 12% — created
-		// drift, and rendered borders perceptibly darker than the original
-		// hardcoded `#eaecee`. PR #398 tuned both paths to 9% so render
-		// (`#ECECEC` on default install) is grayscale-equivalent of legacy
-		// `#eaecee` average — ΔE ≈ 1.1, imperceptible.
-		$border_css = apply_filters(
-			'customify/styling/color-border',
-			'
-h2 + h3,
-.comments-area h2 + .comments-title,
-.h2 + h3,
-.comments-area .h2 + .comments-title,
-.page-breadcrumb {
-    border-top-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-}
-blockquote,
-.site-content .widget-area .menu li.current-menu-item > a:before
-{
-    border-left-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-}
-
-@media screen and (min-width: 64em) {
-    .comment-list .children li.comment {
-        border-left-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-    }
-    .comment-list .children li.comment:after {
-        background-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-    }
-}
-
-.page-titlebar, .page-breadcrumb,
-.posts-layout .entry-inner {
-    border-bottom-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-}
-
-.header-search-form .search-field,
-.entry-content .page-links a,
-.header-search-modal,
-.pagination .nav-links > *,
-.entry-footer .tags-links a, .entry-footer .cat-links a,
-.search .content-area article,
-.site-content .widget-area .menu li.current-menu-item > a,
-.posts-layout .entry-inner,
-.post-navigation .nav-links,
-article.comment .comment-meta,
-.widget-area .widget_pages li a, .widget-area .widget_categories li a, .widget-area .widget_archive li a, .widget-area .widget_meta li a, .widget-area .widget_nav_menu li a, .widget-area .widget_product_categories li a, .widget-area .widget_recent_entries li a, .widget-area .widget_rss li a,
-.widget-area .widget_recent_comments li
-{
-    border-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-}
-
-.header-search-modal::before {
-    border-top-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-    border-left-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-}
-
-@media screen and (min-width: 48em) {
-    .content-sidebar.sidebar_vertical_border .content-area {
-        border-right-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-    }
-    .sidebar-content.sidebar_vertical_border .content-area {
-        border-left-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-    }
-    .sidebar-sidebar-content.sidebar_vertical_border .sidebar-primary {
-        border-right-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-    }
-    .sidebar-sidebar-content.sidebar_vertical_border .sidebar-secondary {
-        border-right-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-    }
-    .content-sidebar-sidebar.sidebar_vertical_border .sidebar-primary {
-        border-left-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-    }
-    .content-sidebar-sidebar.sidebar_vertical_border .sidebar-secondary {
-        border-left-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-    }
-    .sidebar-content-sidebar.sidebar_vertical_border .content-area {
-        border-left-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-        border-right-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-    }
-    .sidebar-content-sidebar.sidebar_vertical_border .content-area {
-        border-left-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-        border-right-color: var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
-    }
-}
-'
-		);
-
-		// Meta CSS: var(--customify-text-muted, fallback). Meta and pagination
-		// text share the same `--customify-text-muted` token as body's
-		// secondary copy. Fresh-install shift `#6d6d6d` → `#6b6b6b`
-		// (2/2/2 RGB) — invisible to the eye.
-		$meta_css = apply_filters(
-			'customify/styling/color-meta',
-			'
-			article.comment .comment-post-author {
-				background: var(--customify-text-muted, {{value}});
-			}
-			.pagination .nav-links > *,
-			.link-meta,
-			.link-meta a,
-			.color-meta,
-			.entry-single .tags-links:before,
-			.entry-single .cats-links:before
-			{
-			    color: var(--customify-text-muted, {{value}});
-			}'
-		);
-
-		// Heading CSS: var(--customify-heading, fallback). Field default `#2b2b2b`
-		// == slot.text default `#2b2b2b` and --customify-heading resolves to
-		// `$ov_heading ?: $slots['text']` — so the fallback hex and the var
-		// resolve to identical values on every fresh install. Saved overrides
-		// (legacy `global_styling_color_heading`) feed both pipelines via the
-		// same theme_mod key. Editing slot.text now also cascades to headings
-		// via the modern-browser var() path.
-		$heading_css   = apply_filters( 'customify/styling/color-heading', 'h1, h2, h3, h4, h5, h6 { color: var(--customify-heading, {{value}});}' );
-		// Widget title CSS: var(--customify-widget-title, fallback). Default
-		// shifts from `#444444` to slot.text `#2b2b2b` on fresh install
-		// (25/25/25 RGB — moderate but documented design call).
-		$w_title_css   = '.site-content .widget-title { color: var(--customify-widget-title, {{value}});}';
+		// :root variables themselves continue to be emitted UNCONDITIONALLY by
+		// inc/colors-palette.php (`:root{--customify-primary: …; --customify-link: …; …}`)
+		// on every page render, so saved theme_mod overrides keep flowing into
+		// the same tokens. Customizer live preview drives the same vars via
+		// document.documentElement.style.setProperty (see colors-palette.php
+		// preview JS at the bottom of that file) — no inline CSS template is
+		// consulted in either path.
+		//
+		// 30K-site safety: storage keys unchanged. Modern browsers read the
+		// `:root` var; legacy browsers without var() support read the
+		// `$color_X = var(--customify-X, fallback_hex)` fallback baked into the
+		// compiled stylesheet. Fallback hexes in _vars.scss were aligned to the
+		// PHP defaults during this migration so the two paths render identical.
+		//
+		// WC selector additions previously hooked via the per-token filters
+		// (customify/styling/{primary-color,secondary-color,link-color,color-border,color-meta})
+		// now live in src/frontend/scss/compatibility/wc/*.scss alongside the
+		// rest of the WooCommerce visual chrome.
 
 		// Composite styling control exclusion list — only expose background-related
 		// subfields; hide text/link/padding/margin/border/shadow.
@@ -290,7 +113,7 @@ article.comment .comment-meta,
 				'description' => __( 'Brand color, CTAs.', 'customify' ),
 				'default'     => '#235787',
 				'placeholder' => '#235787',
-				'css_format'  => $primary_css,
+				'css_format'  => '',
 				'selector'    => 'format',
 			),
 
@@ -304,7 +127,7 @@ article.comment .comment-meta,
 				'description' => __( 'Secondary brand color.', 'customify' ),
 				'default'     => '#c3512f',
 				'placeholder' => '#c3512f',
-				'css_format'  => $secondary_css,
+				'css_format'  => '',
 				'selector'    => 'format',
 			),
 
@@ -395,7 +218,7 @@ article.comment .comment-meta,
 				'description' => __( 'Default: derived from Primary slot.', 'customify' ),
 				'default'     => '#235787',
 				'placeholder' => '#235787',
-				'css_format'  => $link_css,
+				'css_format'  => '',
 				'selector'    => 'format',
 			),
 
@@ -413,7 +236,7 @@ article.comment .comment-meta,
 				'description' => __( 'Default: derived (Link color lighter 15%).', 'customify' ),
 				'default'     => '#406F99',
 				'placeholder' => '#406F99',
-				'css_format'  => $link_hover_css,
+				'css_format'  => '',
 				'selector'    => 'format',
 			),
 
@@ -431,7 +254,7 @@ article.comment .comment-meta,
 				'description' => __( 'Default: derived from Text slot.', 'customify' ),
 				'placeholder' => '#2b2b2b',
 				'default'     => '#2b2b2b',
-				'css_format'  => $heading_css,
+				'css_format'  => '',
 				'selector'    => 'format',
 			),
 
@@ -533,7 +356,7 @@ article.comment .comment-meta,
 				'title'       => __( 'Body text override', 'customify' ),
 				'placeholder' => '#2b2b2b',
 				'default'     => '#2b2b2b',
-				'css_format'  => $text_css,
+				'css_format'  => '',
 				'selector'    => 'format',
 			),
 
@@ -552,7 +375,7 @@ article.comment .comment-meta,
 				// false-flag as dirty.
 				'placeholder' => '#ECECEC',
 				'default'     => '#ECECEC',
-				'css_format'  => $border_css,
+				'css_format'  => '',
 				'selector'    => 'format',
 			),
 
@@ -566,7 +389,7 @@ article.comment .comment-meta,
 				'title'       => __( 'Meta text override', 'customify' ),
 				'placeholder' => '#6b6b6b',
 				'default'     => '#6b6b6b',
-				'css_format'  => $meta_css,
+				'css_format'  => '',
 				'selector'    => 'format',
 			),
 
@@ -583,7 +406,7 @@ article.comment .comment-meta,
 				'title'       => __( 'Widget title override', 'customify' ),
 				'placeholder' => '#2b2b2b',
 				'default'     => '#2b2b2b',
-				'css_format'  => $w_title_css,
+				'css_format'  => '',
 				'selector'    => 'format',
 			),
 
@@ -594,3 +417,87 @@ article.comment .comment-meta,
 }
 
 add_filter( 'customify/customizer/config', 'customify_customizer_colors_config' );
+
+// ──────────────────────────────────────────────────────────────────
+// Customizer preview wiring for the 13 color settings.
+//
+// The Customify framework auto-detects postMessage transport from a
+// field's css_format (class-customizer.php:1199-1211). After the colors→SCSS
+// migration the 13 color controls have `css_format => ''`, leaving transport
+// at the framework default `refresh` — Customizer would reload the whole
+// preview on every picker drag.
+//
+// This function:
+//   1. Forces transport=postMessage on all 13 color settings (idempotent
+//      overlap with customify_color_palette_force_postmessage() in
+//      colors-palette.php which already covers the 4 new slot keys —
+//      re-setting postMessage on the same setting is a no-op).
+//   2. Registers a single selective_refresh partial whose selector is the
+//      `<style id='customify-palette-tokens-inline-css'>` tag printed by
+//      Customify::print_palette_tokens(). Render callback re-runs the same
+//      customify_color_palette_root_css() PHP that generated the initial
+//      block, so every derived/computed token (--customify-on-primary,
+//      --customify-{primary,secondary,accent}-container, container chroma
+//      caps, on-X-container contrast picks, etc.) is recomputed live in the
+//      preview rather than staying stale until save+reload.
+//
+// Pairing with the existing setProperty preview JS in colors-palette.php:
+//   - That JS handles BASE tokens (--customify-primary, --customify-text,
+//     etc.) instantly during drag via document.documentElement.style.
+//   - This partial fires after the setting-change debounce (~250ms) and
+//     replaces the style-tag innerHTML with the full re-rendered :root
+//     block, so PHP-only computed tokens catch up without a save.
+//   - End state is identical regardless of which mechanism wins each frame:
+//     both read the same previewed theme_mod values.
+//
+// `container_inclusive => false` means the partial replaces the inner CSS
+// content of the <style> tag, not the tag itself. customify_color_palette_root_css()
+// returns the CSS body without a <style> wrapper (matches the way
+// class-customify.php prints it).
+//
+// Priority 1100 runs after the framework registration (default 10) and
+// after customify_color_palette_force_postmessage (priority 1000), so all
+// settings exist when this hook fires.
+// ──────────────────────────────────────────────────────────────────
+
+if ( ! function_exists( 'customify_colors_register_preview_refresh' ) ) {
+	function customify_colors_register_preview_refresh( $wp_customize ) {
+		$color_settings = array(
+			// 6 palette slots
+			'global_styling_color_primary',
+			'global_styling_color_secondary',
+			'customify_palette_accent',
+			'customify_palette_text',
+			'customify_palette_surface',
+			'customify_palette_base',
+			// 7 component overrides
+			'global_styling_color_link',
+			'global_styling_color_link_hover',
+			'global_styling_color_heading',
+			'global_styling_color_text',
+			'global_styling_color_meta',
+			'global_styling_color_border',
+			'global_styling_color_w_title',
+		);
+
+		foreach ( $color_settings as $setting_id ) {
+			$setting = $wp_customize->get_setting( $setting_id );
+			if ( $setting ) {
+				$setting->transport = 'postMessage';
+			}
+		}
+
+		if ( isset( $wp_customize->selective_refresh ) && function_exists( 'customify_color_palette_root_css' ) ) {
+			$wp_customize->selective_refresh->add_partial(
+				'customify_palette_tokens',
+				array(
+					'selector'            => '#customify-palette-tokens-inline-css',
+					'settings'            => $color_settings,
+					'render_callback'     => 'customify_color_palette_root_css',
+					'container_inclusive' => false,
+				)
+			);
+		}
+	}
+	add_action( 'customize_register', 'customify_colors_register_preview_refresh', 1100 );
+}

--- a/inc/customizer/configs/colors.php
+++ b/inc/customizer/configs/colors.php
@@ -46,40 +46,12 @@ if ( ! function_exists( 'customify_customizer_colors_config' ) ) {
 		// comes from theme.json + the explicit rule in _base.scss.
 		$primary_css = apply_filters(
 			'customify/styling/primary-color',
-			'
-			.header-top .header--row-inner,
-			:is(.button:not([class*="wp-block-"]), button:not(.menu-mobile-toggle, .components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"]), input[type="button"]:not(.ed_button, [class*="wp-block-"])),
-			button.button:not([class*="wp-block-"]),
-			:is(input[type="button"]:not(.ed_button), input[type="reset"], input[type="submit"]):not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
-			.pagination .nav-links span,
-			.pagination .nav-links > *:hover,
-			.nav-menu-desktop.style-full-height .primary-menu-ul > li:is(.current-menu-item, .current-menu-ancestor) > a,
-			.nav-menu-desktop.style-full-height .primary-menu-ul > li > a:hover,
-			.posts-layout .readmore-button:hover
-			{
-			    background-color: var(--customify-primary, {{value}});
-			}
-			.posts-layout .readmore-button {
-				color: var(--customify-primary, {{value}});
-			}
-			.pagination .nav-links span,
-			.pagination .nav-links > *:hover,
-			.entry-single :is(.tags-links, .cat-links) a:hover,
-			.posts-layout .readmore-button,
-			.posts-layout .readmore-button:hover
-			{
-			    border-color: var(--customify-primary, {{value}});
-			}'
+			':root {--customify-primary: {{value}}; }'
 		);
 
 		$secondary_css = apply_filters(
 			'customify/styling/secondary-color',
-			'
-
-			.customify-builder-btn
-			{
-			    background-color: var(--customify-secondary, {{value}});
-			}'
+			':root {--customify-secondary: {{value}}; }'
 		);
 
 		// Body / ink CSS: var(--customify-body-text, fallback). Body copy

--- a/inc/customizer/configs/colors.php
+++ b/inc/customizer/configs/colors.php
@@ -48,7 +48,7 @@ if ( ! function_exists( 'customify_customizer_colors_config' ) ) {
 			'customify/styling/primary-color',
 			'
 			.header-top .header--row-inner,
-			body:not(.fl-builder-edit) :is(.button:not([class*="wp-block-"]), button:not(.menu-mobile-toggle, .components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"]), input[type="button"]:not(.ed_button, [class*="wp-block-"])),
+			:is(.button:not([class*="wp-block-"]), button:not(.menu-mobile-toggle, .components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"]), input[type="button"]:not(.ed_button, [class*="wp-block-"])),
 			button.button:not([class*="wp-block-"]),
 			:is(input[type="button"]:not(.ed_button), input[type="reset"], input[type="submit"]):not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
 			.pagination .nav-links span,

--- a/inc/customizer/configs/config-default.php
+++ b/inc/customizer/configs/config-default.php
@@ -294,6 +294,17 @@ function customify_layout_builder_config_default( $val, $name ) {
 					),
 				),
 			),
+			// Match DEFAULT_VALUE.count = 4 in
+			// src/backend/footer-row-layout/presets.js so the renderer's
+			// fallback (when nothing is saved) lines up with the React
+			// builder's initial render. Especially relevant for the Pro-
+			// added `top` row, which rarely has explicit col_layout saved.
+			'footer_top_col_layout' => array(
+				'count'   => 4,
+				'desktop' => array( 'fr' => array( 1, 1, 1, 1 ) ),
+				'tablet'  => array( 'fr' => array( 1, 1 ) ),
+				'mobile'  => array( 'fr' => array( 1 ) ),
+			),
 			'footer_main_col_layout' => array(
 				'count'   => 4,
 				'desktop' => array( 'fr' => array( 1, 1, 1, 1 ) ),

--- a/inc/customizer/configs/footer/panel.php
+++ b/inc/customizer/configs/footer/panel.php
@@ -16,6 +16,25 @@ class Customify_Builder_Footer extends Customify_Customize_Builder_Panel {
 	public $id = 'footer';
 
 	function get_config() {
+		// Derive row_layout_keys from the same filtered row list the rest
+		// of the builder pipeline sees — Pro / child theme add rows via
+		// `customify/builder/footer/rows` (e.g. Customify Pro adds `top`),
+		// and the React Builder uses this map to wire one Columns Layout
+		// control per row. Hardcoding the array would silently drop the
+		// control for any extension-added row.
+		//
+		// Inline filter here (instead of customify_get_footer_row_ids())
+		// because this method runs DURING builder registration — the
+		// builder isn't in `$registered_builders` yet, so the helper's
+		// `get_builder()` lookup would return null.
+		$rows            = apply_filters( 'customify/builder/' . $this->id . '/rows', $this->get_rows_config() );
+		$row_layout_keys = array();
+		if ( is_array( $rows ) ) {
+			foreach ( array_keys( $rows ) as $row_id ) {
+				$row_layout_keys[ $row_id ] = "{$this->id}_{$row_id}_col_layout";
+			}
+		}
+
 		return array(
 			'id'         => $this->id,
 			'title'      => __( 'Footer Layout', 'customify' ),
@@ -27,10 +46,7 @@ class Customify_Builder_Footer extends Customify_Customize_Builder_Panel {
 			),
 			'react_control_id'      => 'footer_builder_panel_v2',
 			'panel_items_container' => 'customify-fb-panel-items',
-			'row_layout_keys'       => array(
-				'main'   => 'footer_main_col_layout',
-				'bottom' => 'footer_bottom_col_layout',
-			),
+			'row_layout_keys'       => $row_layout_keys,
 		);
 	}
 
@@ -278,6 +294,37 @@ function customify_footer_layout_settings( $item_id, $section ) {
 Customify_Customize_Layout_Builder()->register_builder( 'footer', new Customify_Builder_Footer() );
 
 /**
+ * Resolve the active footer row IDs in canonical render order.
+ *
+ * Single source of truth for every place that needs to enumerate footer
+ * rows (settings registration, CSS emitters, display gates, renderer).
+ * Pulls the registered builder's base `get_rows_config()` and applies the
+ * `customify/builder/footer/rows` filter so Pro / child theme / 3rd-party
+ * rows (e.g. `top`, or any custom row) are included automatically.
+ *
+ * Returns `['main','bottom']` as a defensive fallback when the builder
+ * hasn't registered yet — should never happen at the call sites this
+ * helper serves (frontend render, customize_register, wp_head CSS) but
+ * keeps the contract a guaranteed non-empty array.
+ *
+ * @return string[] Ordered list of row ids (e.g. ['top','main','bottom']).
+ */
+function customify_get_footer_row_ids() {
+	if ( ! function_exists( 'Customify_Customize_Layout_Builder' ) ) {
+		return array( 'main', 'bottom' );
+	}
+	$builder = Customify_Customize_Layout_Builder()->get_builder( 'footer' );
+	if ( ! $builder || ! method_exists( $builder, 'get_rows_config' ) ) {
+		return array( 'main', 'bottom' );
+	}
+	$rows = apply_filters( 'customify/builder/footer/rows', $builder->get_rows_config() );
+	if ( ! is_array( $rows ) || empty( $rows ) ) {
+		return array( 'main', 'bottom' );
+	}
+	return array_keys( $rows );
+}
+
+/**
  * Enforce footer row ordering: Top → Main → Bottom.
  *
  * The theme's `get_rows_config()` declares only `main` and `bottom`.
@@ -318,6 +365,7 @@ add_filter(
 	}
 );
 
+
 /**
  * Force postMessage transport for footer row col_layout settings so that the
  * preview JS binding (in customizer.js) can apply grid-template-columns live.
@@ -325,8 +373,13 @@ add_filter(
 add_action(
 	'customize_register',
 	function ( $wp_customize ) {
-		foreach ( array( 'footer_main_col_layout', 'footer_bottom_col_layout' ) as $key ) {
-			$setting = $wp_customize->get_setting( $key );
+		// Walk the filtered row list (Pro/child themes can add rows via
+		// `customify/builder/footer/rows`) so any new row's col_layout
+		// setting picks up the same postMessage transport as the built-in
+		// rows. Without this, extension-added rows fall back to the default
+		// `refresh` transport and the live preview can't react to changes.
+		foreach ( customify_get_footer_row_ids() as $row_id ) {
+			$setting = $wp_customize->get_setting( "footer_{$row_id}_col_layout" );
 			if ( $setting ) {
 				$setting->transport = 'postMessage';
 			}
@@ -339,10 +392,14 @@ add_action(
  * Output grid-template-columns CSS for footer rows based on saved col_layout values.
  */
 function customify_footer_row_layout_css() {
-	$rows = array(
-		'footer_main'   => '#cb-row--footer-main',
-		'footer_bottom' => '#cb-row--footer-bottom',
-	);
+	// Build the row → row-selector map from the same filtered row list
+	// the React Builder + Customizer setup use, so every footer row
+	// (built-in OR extension-added via `customify/builder/footer/rows`)
+	// gets its grid-template-columns CSS emitted automatically.
+	$rows = array();
+	foreach ( customify_get_footer_row_ids() as $row_id ) {
+		$rows[ "footer_{$row_id}" ] = "#cb-row--footer-{$row_id}";
+	}
 
 	$css = '';
 	foreach ( $rows as $key => $selector ) {
@@ -355,10 +412,16 @@ function customify_footer_row_layout_css() {
 			continue;
 		}
 
+		// Breakpoints mirror Customify_Customizer_Auto_CSS::$media_queries
+		// (tablet ≤ 1024px, mobile ≤ 568px) so footer col_layout CSS aligns
+		// with every other auto-CSS field across the theme. Mobile cap at
+		// 568 is well below WP's customizer "tablet" preview width (720),
+		// so the two ranges don't overlap inside the preview iframe and
+		// the tablet preset renders the tablet rule (not mobile).
 		$devices = array(
 			'desktop' => '',
 			'tablet'  => '@media (max-width: 1024px)',
-			'mobile'  => '@media (max-width: 767px)',
+			'mobile'  => '@media (max-width: 568px)',
 		);
 
 		// Normalize fr length to the row's column count. Legacy data from

--- a/inc/customizer/configs/footer/panel.php
+++ b/inc/customizer/configs/footer/panel.php
@@ -399,15 +399,20 @@ function customify_footer_row_layout_css() {
 
 			$device_data = $data[ $device ];
 
-			// A length-1 fr is the "stacked" preset's saved shape: one grid
-			// track regardless of count. Use it as-is on every device; only
-			// pad multi-track arrays when they're shorter than count (legacy
-			// data correction).
-			if ( count( $device_data['fr'] ) === 1 ) {
-				$fr = $device_data['fr'];
-			} elseif ( 'mobile' === $device ) {
-				// Mobile multi-track: respect the user's explicit array exactly,
-				// no slice/pad to count.
+			$fr_len = count( $device_data['fr'] );
+
+			// Preserve fr as-is when it represents an intentional layout:
+			//   length 1            = stacked preset (one track, items stack)
+			//   length == count     = normal one-row layout
+			//   length divides count = wrap preset (e.g. fr=[1,1] with count=4
+			//                          → 2×2 grid via grid auto-flow)
+			//   mobile device       = respect user's explicit mobile choice
+			// Other lengths are legacy stale data — slice/pad to count.
+			$is_intentional = $fr_len === 1
+				|| $fr_len === $count
+				|| ( $fr_len > 1 && $fr_len < $count && $count % $fr_len === 0 );
+
+			if ( $is_intentional || 'mobile' === $device ) {
 				$fr = $device_data['fr'];
 			} else {
 				$fr = $count > 0 ? array_slice( $device_data['fr'], 0, $count ) : $device_data['fr'];

--- a/inc/customizer/configs/header/search-box.php
+++ b/inc/customizer/configs/header/search-box.php
@@ -224,9 +224,9 @@ class Customify_Builder_Item_Search_Box {
 				//    on light-mode sites — the base `color: $color_meta` from
 				//    _search.scss kept winning.
 				'selector'    => array(
-					'normal' => "body {$selector} .header-search-form button.search-submit",
-					'hover'  => "body {$selector} .header-search-form button.search-submit:hover",
-					'normal_text_color' => "body {$selector} .header-search-form button.search-submit, body .dark-mode {$selector} .header-search-form button.search-submit",
+					'normal' => "{$selector} .header-search-form button.search-submit",
+					'hover'  => "{$selector} .header-search-form button.search-submit:hover",
+					'normal_text_color' => "{$selector} .header-search-form button.search-submit, .dark-mode {$selector} .header-search-form button.search-submit",
 				),
 				'fields'      => array(
 					'normal_fields' => array(

--- a/inc/customizer/configs/header/search-icon.php
+++ b/inc/customizer/configs/header/search-icon.php
@@ -55,7 +55,12 @@ class Customify_Builder_Item_Search_Icon {
 				'min'             => 5,
 				'step'            => 1,
 				'max'             => 100,
-				'selector'        => "$selector svg",
+				// `body` prefix lifts specificity (0,1,1) → (0,1,2) so this
+				// rule beats `.search-icon svg { width:18px; height:18px }`
+				// in src/frontend/scss/header/builder_items/_search.scss:18
+				// which sits at the same (0,1,1) and was winning by source
+				// order, leaving the Icon Size slider with no visible effect.
+				'selector'        => "body $selector svg",
 				'css_format'      => 'height: {{value}}; width: {{value}};',
 				'label'           => __( 'Icon Size', 'customify' ),
 			),
@@ -68,7 +73,11 @@ class Customify_Builder_Item_Search_Icon {
 				'min'             => 0,
 				'step'            => 1,
 				'max'             => 100,
-				'selector'        => "$selector .search-icon",
+				// `body` prefix mirrors the Icon Size + Icon Styling fix in
+				// this file: bump specificity (0,2,0) → (0,2,1) so the
+				// padding slider wins against any same-specificity rule
+				// targeting `.search-icon` (skin/base sheets).
+				'selector'        => "body $selector .search-icon",
 				'css_format'      => 'padding: {{value}};',
 				'label'           => __( 'Icon Padding', 'customify' ),
 			),
@@ -80,11 +89,18 @@ class Customify_Builder_Item_Search_Icon {
 				'css_format'  => 'styling',
 				'title'       => __( 'Icon Styling', 'customify' ),
 				'description' => __( 'Search icon styling', 'customify' ),
+				// `body` prefix lifts specificity from (0,2,0) to (0,2,1) so
+				// the user-saved values beat the light/dark-mode skin rules
+				// in base/_skins.scss:40, :139 — `.dark-mode .search-icon`
+				// and `.light-mode .search-icon` both sit at (0,2,0) and,
+				// at equal specificity, source order leaves the skin
+				// stylesheet winning. Mirrors the same fix applied to
+				// header/search-box.php's icon styling (commit c66fa299).
 				'selector'    => array(
-					'normal'            => "{$selector} .search-icon",
-					'hover'             => "{$selector} .search-icon:hover",
-					'normal_box_shadow' => "{$selector} .search-icon",
-					'normal_text_color' => "{$selector} .search-icon",
+					'normal'            => "body {$selector} .search-icon",
+					'hover'             => "body {$selector} .search-icon:hover",
+					'normal_box_shadow' => "body {$selector} .search-icon",
+					'normal_text_color' => "body {$selector} .search-icon",
 				),
 				'fields'      => array(
 					'normal_fields' => array(

--- a/inc/customizer/configs/layouts.php
+++ b/inc/customizer/configs/layouts.php
@@ -83,12 +83,20 @@ if ( ! function_exists( 'customify_customizer_layouts_config' ) ) {
 			),
 			/**
 			 * @since 0.2.6 Change css_format and selector.
+			 *
+			 * Default 1248 matches the SCSS hardcode in
+			 * src/frontend/scss/layouts/_layouts.scss `.customify-container, .layout-contained { max-width: 1248px }`.
+			 * Auto-CSS skips emission when the saved value equals the field default,
+			 * so when the Customizer is unsaved the SCSS hardcode is what actually
+			 * renders. Aligning the default avoids a visual mismatch between the
+			 * Customizer slider position and the rendered container outer width.
+			 * Saved-explicit values are unaffected — they still persist as-is.
 			 */
 			array(
 				'name'            => 'container_width',
 				'type'            => 'slider',
 				'device_settings' => false,
-				'default'         => 1200,
+				'default'         => 1248,
 				'min'             => 700,
 				'step'            => 10,
 				'max'             => 2000,

--- a/inc/customizer/configs/layouts.php
+++ b/inc/customizer/configs/layouts.php
@@ -99,6 +99,33 @@ if ( ! function_exists( 'customify_customizer_layouts_config' ) ) {
 				'css_format'      => ':root { --wp--style--global--wide-size: {{value}}; } .customify-container, .layout-contained, .site-framed .site, .site-boxed .site { max-width: {{value}}; }',
 			),
 
+			// Narrow content width — paired with the "Narrow" Content Layout
+			// option (per-post metabox). Mirrors the Full Width / Full Width –
+			// Stretched pattern: a content_layout value that overrides sidebar
+			// layout to no-sidebar and constrains content-size to this value.
+			// .site-content.content-narrow CSS rule consumes the saved value;
+			// see customify_layout_content_size_css() in inc/template-functions.php.
+			//
+			// Wide-size for narrow = narrow_width + 400 (200px breakout each side)
+			// per the dynamic wide-size design — see the same SPEC in
+			// customify_layout_content_size_css(). `calc({{value}} + 400px)` lets
+			// the Customizer live-preview auto-CSS rebuild keep wide-size in sync
+			// without a separate handler.
+			array(
+				'name'            => 'narrow_width',
+				'type'            => 'slider',
+				'device_settings' => false,
+				'default'         => 800,
+				'min'             => 400,
+				'step'            => 10,
+				'max'             => 1000,
+				'section'         => 'global_layout_section',
+				'title'           => __( 'Narrow Content Width', 'customify' ),
+				'description'     => __( 'Max width when a post uses the "Narrow" Content Layout option in the Page Settings panel.', 'customify' ),
+				'selector'        => 'format',
+				'css_format'      => '.site-content.content-narrow { --wp--style--global--content-size: {{value}}; --wp--style--global--wide-size: calc({{value}} + 400px); }',
+			),
+
 			// Site content layout.
 			array(
 				'name'       => 'site_content_layout',

--- a/inc/customizer/configs/page-header.php
+++ b/inc/customizer/configs/page-header.php
@@ -966,7 +966,7 @@ class Customify_Page_Header {
 				<?php
 				do_action( 'customify/page-cover/before' );
 
-				if ( Customify()->get_setting( 'header_cover_show_title' ) ) {
+				if ( Customify()->get_setting( 'header_cover_show_title' ) && 'hide' !== $args['force_display_single_title'] ) {
 					if ( $args['title'] ) {
 						// WPCS: XSS ok.
 						echo '<' . $args['title_tag'] . ' class="page-cover-title">' . apply_filters( 'customify_the_title', wp_kses_post( $args['title'] ) ) . '</' . $args['title_tag'] . '>';
@@ -1000,7 +1000,7 @@ class Customify_Page_Header {
 		do_action( 'customify/titlebar/before' );
 
 		// WPCS: XSS ok.
-		if ( Customify()->get_setting( 'titlebar_show_title' ) ) {
+		if ( Customify()->get_setting( 'titlebar_show_title' ) && 'hide' !== $args['force_display_single_title'] ) {
 			if ( $args['title'] ) {
 				echo '<' . $args['title_tag'] . ' class="titlebar-title h4">' . apply_filters( 'customify_the_title', wp_kses_post( $args['title'] ) ) . '</' . $args['title_tag'] . '>';
 			}
@@ -1048,13 +1048,12 @@ class Customify_Page_Header {
 			return '';
 		}
 
-		if ( is_singular() ) {
-			$disable = get_post_meta( get_the_ID(), '_customify_disable_page_title', true );
-			if ( '1' === $disable ) {
-				return '';
-			}
-		}
-
+		// `_customify_disable_page_title` hides the title TEXT only, not the
+		// whole #page-cover / #page-titlebar wrapper. get_settings() already
+		// translates that meta into `force_display_single_title='hide'`, and
+		// render_cover()/render_titlebar() honour it to suppress just the
+		// title echo. Returning '' here would also hide the cover background
+		// image, which is a separate Customizer feature.
 		if ( in_array( $args['display'], array( 'cover', 'titlebar', 'shortcode' ), true ) ) {
 			// Titlebar mode bails when there's no resolved title text. The
 			// titlebar buffer also collects auxiliary content via the

--- a/inc/element-classes.php
+++ b/inc/element-classes.php
@@ -101,12 +101,30 @@ if ( ! function_exists( 'customify_site_content_classes' ) ) {
 	/**
 	 * Adds custom classes to the array of site content classes.
 	 *
+	 * Mirrors the header builder pattern: the Customizer field
+	 * `site_content_layout` (radio: `site-content-fullwidth` / `site-content-boxed`)
+	 * uses `css_format = 'html_class'`, which is a no-op marker in the
+	 * auto-CSS pipeline. The class has to be pushed into the element's
+	 * class array manually here — same wiring as `site_layout` above and
+	 * the header `header_main_layout` field.
+	 *
+	 * Was orphaned since the setting first shipped in 2017 (b04c6a44):
+	 * UI saved the value but no handler ever applied the class. The
+	 * paired SCSS rule (`.site-content-fullwidth .customify-container
+	 * { max-width: initial }`) lives in `src/frontend/scss/layouts/_layouts.scss`,
+	 * mirroring the existing `.layout-fullwidth` pattern in the header SCSS.
+	 *
 	 * @param array $classes Classes for the site content element.
 	 *
 	 * @return array
 	 */
 	function customify_site_content_classes( $classes ) {
 		$classes[] = 'site-content';
+
+		$site_content_layout = sanitize_text_field( Customify()->get_setting( 'site_content_layout' ) );
+		if ( $site_content_layout ) {
+			$classes[] = $site_content_layout;
+		}
 
 		return $classes;
 	}

--- a/inc/panel-builder/builder-functions.php
+++ b/inc/panel-builder/builder-functions.php
@@ -153,12 +153,15 @@ function customify_customize_render_footer() {
 	$builder->set_id( 'footer' );
 	$builder->set_control_id( 'footer_builder_panel_v2' );
 	$builder->set_config_items( $list_items );
-	// Row order must match the Customizer (top → main → bottom). `top` is
-	// registered by Customify Pro via the `customify/builder/footer/rows`
-	// filter; the renderer's own isset() guard silently skips it when no
-	// items have been placed in that row, so passing it here is safe in
-	// the Free theme too.
-	$builder->render( array( 'top', 'main', 'bottom' ) );
+	// Derive the render order from the filtered row list so every footer
+	// row (built-in OR added via `customify/builder/footer/rows` by Pro /
+	// child theme) renders without further code changes. The same filter
+	// also runs a PHP_INT_MAX sort callback that pins the canonical order
+	// (top → main → bottom) and appends unknown rows at the end.
+	$row_ids = function_exists( 'customify_get_footer_row_ids' )
+		? customify_get_footer_row_ids()
+		: array( 'top', 'main', 'bottom' );
+	$builder->render( $row_ids );
 
 	echo '</footer>';
 	do_action( 'customify/after-footer' );

--- a/inc/panel-builder/class-layout-builder-frontend-v2.php
+++ b/inc/panel-builder/class-layout-builder-frontend-v2.php
@@ -524,22 +524,33 @@ class Customify_Layout_Builder_Frontend_V2  extends Customify_Abstract_Layout_Fr
 
 	/**
 	 * Returns ordered column keys for a footer row based on the col_layout setting.
-	 * Returns null when the setting is absent (triggers old column-hiding behaviour).
 	 *
-	 * @param string $row_id  Row identifier, e.g. 'main' or 'bottom'.
-	 * @return array|null
+	 * When no value is saved (user dropped items into a row but never opened
+	 * the Columns Layout control), fall back to the SAME default the React
+	 * builder uses — `DEFAULT_VALUE.count = 4` in
+	 * src/backend/footer-row-layout/presets.js. Returning null + letting the
+	 * renderer fall back to all 5 slots makes the frontend render 5 cols
+	 * while the builder shows 4 → items appear dropped or in the wrong
+	 * column. The mismatch was especially visible on the Pro-added `top`
+	 * row, which rarely has explicit col_layout saved.
+	 *
+	 * @param string $row_id  Row identifier, e.g. 'top', 'main', 'bottom'.
+	 * @return array
 	 */
 	protected function get_footer_col_keys( $row_id ) {
 		static $all_cols = array( 'left', 'center', 'right', 'col4', 'col5' );
+		// Mirror DEFAULT_VALUE.count in src/backend/footer-row-layout/presets.js.
+		// Keep in sync if the React default ever changes.
+		static $default_count = 4;
 
 		$raw = Customify()->get_setting( 'footer_' . $row_id . '_col_layout' );
 		if ( ! $raw ) {
-			return null;
+			return array_slice( $all_cols, 0, $default_count );
 		}
 
 		$data = is_array( $raw ) ? $raw : json_decode( $raw, true );
 		if ( ! is_array( $data ) || empty( $data['count'] ) ) {
-			return null;
+			return array_slice( $all_cols, 0, $default_count );
 		}
 
 		$count = max( 1, min( 5, intval( $data['count'] ) ) );

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -524,10 +524,13 @@ if ( ! function_exists( 'customify_is_footer_display' ) ) {
 	function customify_is_footer_display() {
 		$show = true;
 		if ( customify_is_support_meta() ) {
-			$rows  = array( 'main', 'bottom' );
-			if ( class_exists( 'Customify_Pro' ) ) {
-				$rows[] = 'top';
-			}
+			// Derive rows from the same filter the builder pipeline uses so
+			// Pro/child-theme/3rd-party rows count toward "is there anything
+			// to show?". Hardcoding `main + bottom + maybe top` skipped any
+			// other extension row entirely.
+			$rows  = function_exists( 'customify_get_footer_row_ids' )
+				? customify_get_footer_row_ids()
+				: array( 'main', 'bottom' );
 			$count = 0;
 			foreach ( $rows as $row_id ) {
 				if ( ! customify_is_builder_row_display( 'footer', $row_id ) ) {

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -18,6 +18,39 @@ if ( ! function_exists( 'customify_get_config_sidebar_layouts' ) ) {
 	}
 }
 
+if ( ! function_exists( 'customify_get_container_width_value' ) ) {
+	/**
+	 * Resolve the numeric container_width Customizer value in pixels.
+	 *
+	 * The slider control stores its value as either:
+	 *   - array shape: array( 'value' => 1500, 'unit' => 'px' )  — modern
+	 *   - scalar number: 1500                                    — legacy
+	 *   - empty/false: Customizer never saved                    — unsaved
+	 *
+	 * For the unsaved case we return 1248, which is the value 30K production
+	 * sites actually render at — the SCSS `.customify-container { max-width: 1248px }`
+	 * declaration in src/frontend/scss/layouts/_layouts.scss:62 wins because the
+	 * auto-CSS slider pipeline skips emission when the field has no saved value.
+	 *
+	 * @return int Container width in pixels (always > 0).
+	 */
+	function customify_get_container_width_value() {
+		$raw = get_theme_mod( 'container_width' );
+		if ( is_array( $raw ) && ! empty( $raw['value'] ) ) {
+			$value = (int) $raw['value'];
+			if ( $value > 0 ) {
+				return $value;
+			}
+		} elseif ( is_numeric( $raw ) ) {
+			$value = (int) $raw;
+			if ( $value > 0 ) {
+				return $value;
+			}
+		}
+		return 1248;
+	}
+}
+
 if ( ! function_exists( 'customify_get_layout_content_sizes' ) ) {
 	/**
 	 * Single source of truth for the layout-driven block contentSize.
@@ -27,21 +60,109 @@ if ( ! function_exists( 'customify_get_layout_content_sizes' ) ) {
 	 *   - inc/admin/page-settings.php    — localized to JS for live updates
 	 *   - customify_layout_content_size_css() — frontend inline CSS below
 	 *
+	 * The returned size is `min(cap, parent)`:
+	 *
+	 *   - **cap** — a typography-driven readability target (originally 1184/863/542
+	 *     at container_width=1248). Scaled proportionally by `container_width / anchor`,
+	 *     where `anchor` is captured per-site at install / migration time so existing
+	 *     sites see `factor=1` immediately after upgrade (zero rendered diff).
+	 *   - **parent** — the frontend column geometry: container content-box (after
+	 *     2em padding each side), gridlex grid (negative -1em margin each side),
+	 *     gridlex column (col-12/9/6 = 100%/75%/50%), minus col padding (1em each
+	 *     side) and content-inner right padding (16px). Border (1px when
+	 *     sidebar_vertical_border is enabled) is intentionally ignored — sub-pixel.
+	 *
+	 * Returning `min(cap, parent)` produces the value that blocks actually reach
+	 * on the frontend (parent constrains when sliders are at default; the cap
+	 * kicks in when container is widened enough that the readability ceiling
+	 * matters). Editor consumers apply the same value directly because the editor
+	 * iframe has no .customify-container > grid > column nesting — feeding it the
+	 * resolved render-width keeps WYSIWYG honest.
+	 *
 	 * Filterable so a child theme / plugin can override values in one place.
 	 *
 	 * @return array{no_sidebar:string,one_sidebar:string,two_sidebars:string} CSS lengths.
 	 */
 	function customify_get_layout_content_sizes() {
+		$cw     = customify_get_container_width_value();
+		$anchor = (int) get_option( 'customify_layout_content_size_anchor', 1248 );
+		if ( $anchor <= 0 ) {
+			$anchor = 1248;
+		}
+		$factor = $cw / $anchor;
+
+		// Typography readability caps (original hardcoded targets at anchor=1248).
+		$cap_no_sidebar   = (int) round( 1184 * $factor );
+		$cap_one_sidebar  = (int) round(  863 * $factor );
+		$cap_two_sidebars = (int) round(  542 * $factor );
+
+		// Frontend column geometry. See src/frontend/scss/layouts/_layouts.scss
+		// (.customify-container padding 2em) and src/frontend/scss/vendors/gridlex/
+		// (gutter 2em → grid margin -1em, col padding 1em).
+		//
+		// .content-inner padding varies per layout (layouts/_layouts.scss §"Layout: *"):
+		//   - `.content`            (no sidebar)        → no padding (no sidebar to gap from)
+		//   - `.content-sidebar`    (1 right sidebar)   → padding-right: ms(0) ≈ 16px
+		//   - `.sidebar-content`    (1 left sidebar)    → padding-left: ms(0)  ≈ 16px
+		//   - `.sidebar-content-sidebar` (2 sidebars)   → both sides: 32px total
+		//   - `.sidebar-sidebar-content` / `.content-sidebar-sidebar` → only one side: 16px
+		//
+		// Borders from sidebar_vertical_border (1px when enabled) are sub-pixel and
+		// intentionally ignored — they don't drive block layout decisions.
+		//
+		// `two_sidebars` uses the symmetric variant (`sidebar-content-sidebar`) — the most
+		// constrained of the 2-sidebar trio. Asymmetric variants render the same value
+		// (cap-bound, since cap=542 < parent for asymmetric), which is acceptable: editor
+		// is conservative-by-1 rather than divergent.
+		$inner = max( 0, $cw - 64 );
+		$grid  = $inner + 32;
+
+		$parent_no_sidebar   = $grid - 32;                              // col padding only
+		$parent_one_sidebar  = (int) round( $grid * 0.75 ) - 32 - 16;   // col + 1-side content-inner
+		$parent_two_sidebars = (int) round( $grid * 0.5 )  - 32 - 32;   // col + 2-side content-inner
+
+		// Floor at a sane minimum so unusual configs don't produce nonsense like 0px.
+		$no_sidebar   = max( 200, min( $cap_no_sidebar,   $parent_no_sidebar ) );
+		$one_sidebar  = max( 200, min( $cap_one_sidebar,  $parent_one_sidebar ) );
+		$two_sidebars = max( 200, min( $cap_two_sidebars, $parent_two_sidebars ) );
+
 		return apply_filters(
 			'customify/layout_content_sizes',
 			array(
-				'no_sidebar'   => '1184px',
-				'one_sidebar'  => '863px',
-				'two_sidebars' => '542px',
+				'no_sidebar'   => $no_sidebar . 'px',
+				'one_sidebar'  => $one_sidebar . 'px',
+				'two_sidebars' => $two_sidebars . 'px',
 			)
 		);
 	}
 }
+
+if ( ! function_exists( 'customify_migrate_layout_content_size_anchor' ) ) {
+	/**
+	 * One-time migration: capture the per-site anchor for content-size scaling.
+	 *
+	 * Without this, switching customify_get_layout_content_sizes() from hardcoded
+	 * 1184/863/542 to a container_width-driven formula would silently widen the
+	 * content-area on sites that explicitly saved container_width > 1248 (and shrink
+	 * it on sites < 1248). Capturing the anchor at upgrade-time keeps factor=1.0
+	 * immediately after migration — zero rendered diff across the 30K install base.
+	 *
+	 * Subsequent slider changes alter `container_width` but the anchor stays put,
+	 * so the proportional scaling kicks in only when the user actually moves the
+	 * slider after upgrading.
+	 *
+	 * Idempotent via the `customify_layout_anchor_migrated_v1` flag. AGENTS.md §4.1.
+	 */
+	function customify_migrate_layout_content_size_anchor() {
+		if ( get_option( 'customify_layout_anchor_migrated_v1' ) ) {
+			return;
+		}
+		$anchor = customify_get_container_width_value();
+		update_option( 'customify_layout_content_size_anchor', $anchor, false );
+		update_option( 'customify_layout_anchor_migrated_v1', '1', false );
+	}
+}
+add_action( 'after_setup_theme', 'customify_migrate_layout_content_size_anchor', 5 );
 
 if ( ! function_exists( 'customify_get_content_size_for_layout' ) ) {
 	/**
@@ -67,34 +188,109 @@ if ( ! function_exists( 'customify_get_content_size_for_layout' ) ) {
 	}
 }
 
+if ( ! function_exists( 'customify_get_narrow_width_value' ) ) {
+	/**
+	 * Resolve the Customizer narrow_width value as a CSS length string.
+	 *
+	 * Mirrors customify_get_container_width_value() shape handling — slider
+	 * stores either { value, unit } array or scalar, falls back to the field
+	 * default 800px when unsaved.
+	 *
+	 * @return string CSS length (e.g. "800px").
+	 */
+	function customify_get_narrow_width_value() {
+		$raw = get_theme_mod( 'narrow_width' );
+		if ( is_array( $raw ) && isset( $raw['value'] ) && '' !== $raw['value'] ) {
+			$unit = ! empty( $raw['unit'] ) ? $raw['unit'] : 'px';
+			return (int) $raw['value'] . $unit;
+		} elseif ( is_numeric( $raw ) && (int) $raw > 0 ) {
+			return (int) $raw . 'px';
+		}
+		return '800px';
+	}
+}
+
 if ( ! function_exists( 'customify_layout_content_size_css' ) ) {
 	/**
 	 * Frontend CSS that maps body.main-layout-* classes to the matching
-	 * --wp--style--global--content-size, so blocks shrink/expand with the
-	 * active sidebar layout. Kept here (not in SCSS) so all values come
-	 * from customify_get_layout_content_sizes().
+	 * --wp--style--global--content-size and --wp--style--global--wide-size,
+	 * so default-aligned AND wide-aligned blocks both follow the active
+	 * sidebar layout. Kept here (not in SCSS) so all values come from
+	 * customify_get_layout_content_sizes() + customify_get_narrow_width_value().
 	 *
-	 * Per-page Content Layout (.site-content.content-full-{width,stretched})
-	 * forces the no-sidebar size — these rules are scoped to .site-content
-	 * which is closer in the inheritance chain than body, so they win the
-	 * variable resolution regardless of body.main-layout-* specificity.
+	 * Wide-size design (per user spec):
+	 *   - No-sidebar layouts: wide-size = content-size + 400 (200px breakout each side)
+	 *   - Narrow content_layout: wide-size = narrow_width + 400
+	 *   - Sidebar layouts: wide-size = content-size (parent-constrained — wide stays
+	 *     inside the content column, doesn't overlap sidebars per Q2 confirmation)
+	 *
+	 * The visual breakout itself happens in SCSS (.entry-content > .alignwide uses
+	 * negative margins with a max(100%, min(wide-size, 100vw - 32px)) clamp so the
+	 * wide block can't overflow the viewport — see src/frontend/scss/base/_blocks.scss).
+	 *
+	 * Per-page Content Layout (.site-content.content-{full-width,full-stretched,narrow})
+	 * forces a specific content+wide-size — these rules are scoped to .site-content
+	 * which is closer in the inheritance chain than body, so they win the variable
+	 * resolution regardless of body.main-layout-* specificity.
 	 *
 	 * Hooked into customify-style via wp_add_inline_style in class-customify.php.
 	 *
 	 * @return string CSS.
 	 */
 	function customify_layout_content_size_css() {
-		$sizes = customify_get_layout_content_sizes();
+		$sizes  = customify_get_layout_content_sizes();
+		$narrow = customify_get_narrow_width_value();
+
+		// Compute wide-size = content-size + 400 (px) for breakout layouts.
+		// `customify_layout_content_size_value_plus()` keeps unit handling local
+		// so '800px' + 400 stays as '1200px'.
+		$no_sidebar_wide = customify_layout_content_size_value_plus( $sizes['no_sidebar'], 400 );
+		$narrow_wide     = customify_layout_content_size_value_plus( $narrow, 400 );
+
+		// Full-Width / Full-Stretched content_layout: content-size + wide-size are
+		// viewport-bound, not capped at the reading-column no_sidebar value. This
+		// lets BOTH Core blocks (max-width via SCSS rule) AND third-party blocks
+		// that read `--wp--style--global--content-size` (Blocksify Section's
+		// "Inherit Max Width from Theme") naturally fill the available container
+		// space. Full-Width keeps the 32px container padding each side
+		// (calc(100vw - 64px)); Full-Stretched drops the padding too (100vw).
 		return sprintf(
-			'body.main-layout-content{--wp--style--global--content-size:%1$s}'
+			'body.main-layout-content{--wp--style--global--content-size:%1$s;--wp--style--global--wide-size:%2$s}'
+			. 'body.main-layout-content-sidebar,'
+			. 'body.main-layout-sidebar-content{--wp--style--global--wide-size:%3$s}'
 			. 'body.main-layout-sidebar-content-sidebar,'
 			. 'body.main-layout-sidebar-sidebar-content,'
-			. 'body.main-layout-content-sidebar-sidebar{--wp--style--global--content-size:%2$s}'
-			. '.site-content.content-full-width,'
-			. '.site-content.content-full-stretched{--wp--style--global--content-size:%1$s}',
+			. 'body.main-layout-content-sidebar-sidebar{--wp--style--global--content-size:%4$s;--wp--style--global--wide-size:%4$s}'
+			. '.site-content.content-full-width{--wp--style--global--content-size:calc(100vw - 64px);--wp--style--global--wide-size:calc(100vw - 64px)}'
+			. '.site-content.content-full-stretched{--wp--style--global--content-size:100vw;--wp--style--global--wide-size:100vw}'
+			. '.site-content.content-narrow{--wp--style--global--content-size:%5$s;--wp--style--global--wide-size:%6$s}',
 			esc_attr( $sizes['no_sidebar'] ),
-			esc_attr( $sizes['two_sidebars'] )
+			esc_attr( $no_sidebar_wide ),
+			esc_attr( $sizes['one_sidebar'] ),
+			esc_attr( $sizes['two_sidebars'] ),
+			esc_attr( $narrow ),
+			esc_attr( $narrow_wide )
 		);
+	}
+}
+
+if ( ! function_exists( 'customify_layout_content_size_value_plus' ) ) {
+	/**
+	 * Add a pixel delta to a CSS length string, preserving the unit. Used to
+	 * compute wide-size = content-size + 400px without manually parsing every
+	 * caller. Returns the input unchanged if the unit isn't `px` (no other unit
+	 * is in use today — guard is here so future em/rem use doesn't silently
+	 * miscompute).
+	 *
+	 * @param string $value  CSS length (e.g. "1184px").
+	 * @param int    $delta  Pixels to add.
+	 * @return string New CSS length (e.g. "1584px").
+	 */
+	function customify_layout_content_size_value_plus( $value, $delta ) {
+		if ( preg_match( '/^(-?\d+(?:\.\d+)?)px$/', $value, $m ) ) {
+			return ( (float) $m[1] + (int) $delta ) . 'px';
+		}
+		return $value;
 	}
 }
 if ( ! function_exists( 'customify_get_all_image_sizes' ) ) {
@@ -222,7 +418,7 @@ if ( ! function_exists( 'customify_force_no_sidebar_for_full_content_layout' ) )
 			return $layout;
 		}
 		$content_layout = get_post_meta( $post_id, '_customify_content_layout', true );
-		if ( in_array( $content_layout, array( 'full-width', 'full-stretched' ), true ) ) {
+		if ( in_array( $content_layout, array( 'full-width', 'full-stretched', 'narrow' ), true ) ) {
 			return 'content';
 		}
 		return $layout;

--- a/languages/customify.pot
+++ b/languages/customify.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GNU General Public License v2 or later.=!>
 msgid ""
 msgstr ""
-"Project-Id-Version: Customify 0.4.17\n"
+"Project-Id-Version: Customify 0.4.18\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/customify\n"
-"POT-Creation-Date: 2026-05-27 14:31:39+00:00\n"
+"POT-Creation-Date: 2026-05-28 02:25:55+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -204,7 +204,7 @@ msgstr ""
 msgid "Copy now"
 msgstr ""
 
-#: inc/admin/dashboard.php:316 inc/customizer/class-customizer.php:1271
+#: inc/admin/dashboard.php:316 inc/customizer/class-customizer.php:1278
 msgid "Logo & Site Identity"
 msgstr ""
 
@@ -217,8 +217,8 @@ msgstr ""
 msgid "Header Builder"
 msgstr ""
 
-#: inc/admin/dashboard.php:328 inc/customizer/configs/footer/panel.php:58
-#: inc/customizer/configs/footer/panel.php:66
+#: inc/admin/dashboard.php:328 inc/customizer/configs/footer/panel.php:74
+#: inc/customizer/configs/footer/panel.php:82
 msgid "Footer Builder"
 msgstr ""
 
@@ -640,8 +640,8 @@ msgstr ""
 
 #: inc/class-customify.php:305 inc/class-customify.php:316
 #: inc/class-customify.php:330
-#: inc/compatibility/woocommerce/woocommerce.php:579
-#: inc/compatibility/woocommerce/woocommerce.php:590
+#: inc/compatibility/woocommerce/woocommerce.php:583
+#: inc/compatibility/woocommerce/woocommerce.php:594
 msgid "Add widgets here."
 msgstr ""
 
@@ -656,15 +656,15 @@ msgstr ""
 
 #: inc/class-metabox-fields.php:442
 #: inc/compatibility/woocommerce/config/single-product.php:196
-#: inc/customizer/class-customizer.php:565
-#: inc/customizer/class-customizer.php:576
-#: inc/customizer/class-customizer.php:588
-#: inc/customizer/class-customizer.php:673
-#: inc/customizer/class-customizer.php:690
-#: inc/customizer/class-customizer.php:710
-#: inc/customizer/class-customizer.php:727
-#: inc/customizer/class-customizer.php:747
-#: inc/customizer/class-customizer.php:842
+#: inc/customizer/class-customizer.php:572
+#: inc/customizer/class-customizer.php:583
+#: inc/customizer/class-customizer.php:595
+#: inc/customizer/class-customizer.php:680
+#: inc/customizer/class-customizer.php:697
+#: inc/customizer/class-customizer.php:717
+#: inc/customizer/class-customizer.php:734
+#: inc/customizer/class-customizer.php:754
+#: inc/customizer/class-customizer.php:849
 #: inc/customizer/configs/header/social-icons.php:271
 #: inc/customizer/configs/layouts.php:273
 #: inc/customizer/configs/page-header.php:219
@@ -698,8 +698,8 @@ msgstr ""
 #: inc/compatibility/woocommerce/config/single-product.php:164
 #: inc/compatibility/woocommerce/config/single-product.php:187
 #: inc/customizer/configs/blogs.php:29 inc/customizer/configs/blogs.php:36
-#: inc/customizer/configs/footer/panel.php:135
-#: inc/customizer/configs/footer/panel.php:504
+#: inc/customizer/configs/footer/panel.php:151
+#: inc/customizer/configs/footer/panel.php:567
 #: inc/customizer/configs/header/panel.php:122
 #: inc/customizer/configs/page-header.php:214
 msgid "Layout"
@@ -713,7 +713,7 @@ msgstr ""
 msgid "Content Layout"
 msgstr ""
 
-#: inc/class-metabox.php:67 inc/customizer/configs/footer/panel.php:142
+#: inc/class-metabox.php:67 inc/customizer/configs/footer/panel.php:158
 #: inc/customizer/configs/header/panel.php:129
 #: inc/customizer/configs/layouts.php:42
 #: inc/customizer/configs/page-header.php:221
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Default - inside main content"
 msgstr ""
 
-#: inc/class-metabox.php:90 inc/customizer/class-customizer.php:675
+#: inc/class-metabox.php:90 inc/customizer/class-customizer.php:682
 #: inc/customizer/configs/page-header.php:37
 #: inc/customizer/configs/page-header.php:490
 msgid "Cover"
@@ -1391,19 +1391,19 @@ msgstr ""
 msgid "Your order"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:531
+#: inc/compatibility/woocommerce/woocommerce.php:535
 msgid "Display on product taxonomies (categories/tags,..)"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:539
+#: inc/compatibility/woocommerce/woocommerce.php:543
 msgid "Display on single product"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:577
+#: inc/compatibility/woocommerce/woocommerce.php:581
 msgid "WooCommerce Primary Sidebar"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:588
+#: inc/compatibility/woocommerce/woocommerce.php:592
 msgid "WooCommerce Secondary Sidebar"
 msgstr ""
 
@@ -1455,322 +1455,322 @@ msgstr ""
 msgid "Font Awesome v6"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:520
+#: inc/customizer/class-customizer.php:527
 msgid "Font Family"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:526
+#: inc/customizer/class-customizer.php:533
 msgid "Font Weight"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:532
+#: inc/customizer/class-customizer.php:539
 msgid "Font Languages"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:537
+#: inc/customizer/class-customizer.php:544
 msgid "Font Size"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:546
+#: inc/customizer/class-customizer.php:553
 msgid "Line Height"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:555
+#: inc/customizer/class-customizer.php:562
 msgid "Letter Spacing"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:563
+#: inc/customizer/class-customizer.php:570
 msgid "Font Style"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:566
-#: inc/customizer/class-customizer.php:608
+#: inc/customizer/class-customizer.php:573
+#: inc/customizer/class-customizer.php:615
 #: inc/customizer/configs/header/menus.php:165
 #: inc/customizer/configs/header/social-icons.php:213
 msgid "Normal"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:567
+#: inc/customizer/class-customizer.php:574
 #: inc/customizer/controls/class-control-font-style.php:17
 msgid "Italic"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:568
+#: inc/customizer/class-customizer.php:575
 msgid "Oblique"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:574
+#: inc/customizer/class-customizer.php:581
 msgid "Text Decoration"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:577
+#: inc/customizer/class-customizer.php:584
 #: inc/customizer/controls/class-control-font-style.php:18
 msgid "Underline"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:578
+#: inc/customizer/class-customizer.php:585
 msgid "Overline"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:579
+#: inc/customizer/class-customizer.php:586
 msgid "Line through"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:580
-#: inc/customizer/class-customizer.php:592
-#: inc/customizer/class-customizer.php:748
-#: inc/customizer/class-customizer.php:843
+#: inc/customizer/class-customizer.php:587
+#: inc/customizer/class-customizer.php:599
+#: inc/customizer/class-customizer.php:755
+#: inc/customizer/class-customizer.php:850
 #: inc/customizer/configs/header/social-icons.php:185
 #: inc/customizer/configs/header/social-icons.php:272
 msgid "None"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:586
+#: inc/customizer/class-customizer.php:593
 msgid "Text Transform"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:589
+#: inc/customizer/class-customizer.php:596
 #: inc/customizer/controls/class-control-font-style.php:20
 msgid "Uppercase"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:590
+#: inc/customizer/class-customizer.php:597
 msgid "Lowercase"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:591
+#: inc/customizer/class-customizer.php:598
 msgid "Capitalize"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:609
+#: inc/customizer/class-customizer.php:616
 #: inc/customizer/configs/header/social-icons.php:214
 msgid "Hover"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:615
-#: inc/customizer/class-customizer.php:811
+#: inc/customizer/class-customizer.php:622
+#: inc/customizer/class-customizer.php:818
 #: inc/customizer/configs/header/nav-icon.php:79
 #: inc/customizer/configs/header/social-icons.php:196
 msgid "Color"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:621
-#: inc/customizer/class-customizer.php:817
+#: inc/customizer/class-customizer.php:628
+#: inc/customizer/class-customizer.php:824
 msgid "Link Color"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:635
+#: inc/customizer/class-customizer.php:642
 #: inc/customizer/configs/header/panel.php:432
 msgid "Margin"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:648
+#: inc/customizer/class-customizer.php:655
 #: inc/customizer/configs/header/social-icons.php:158
 msgid "Padding"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:654
-#: inc/customizer/class-customizer.php:823
+#: inc/customizer/class-customizer.php:661
+#: inc/customizer/class-customizer.php:830
 msgid "Background"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:660
-#: inc/customizer/class-customizer.php:828
-#: inc/customizer/configs/footer/panel.php:182
+#: inc/customizer/class-customizer.php:667
+#: inc/customizer/class-customizer.php:835
+#: inc/customizer/configs/footer/panel.php:198
 #: inc/customizer/configs/header/social-icons.php:220
 #: inc/customizer/configs/header/social-icons.php:236
 msgid "Background Color"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:666
+#: inc/customizer/class-customizer.php:673
 #: inc/customizer/configs/page-header.php:480
 msgid "Background Image"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:674
+#: inc/customizer/class-customizer.php:681
 #: inc/customizer/configs/page-header.php:489
 #: inc/customizer/controls/class-control-css-ruler.php:21
 msgid "Auto"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:676
+#: inc/customizer/class-customizer.php:683
 #: inc/customizer/configs/page-header.php:491
 msgid "Contain"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:679
+#: inc/customizer/class-customizer.php:686
 #: inc/customizer/configs/header/social-icons.php:144
 #: inc/customizer/configs/page-header.php:494
 msgid "Size"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:686
+#: inc/customizer/class-customizer.php:693
 #: inc/customizer/configs/page-header.php:502
 msgid "Position"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:691
+#: inc/customizer/class-customizer.php:698
 #: inc/customizer/configs/page-header.php:507
 msgid "Center"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:692
+#: inc/customizer/class-customizer.php:699
 #: inc/customizer/configs/page-header.php:508
 msgid "Top Left"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:693
+#: inc/customizer/class-customizer.php:700
 #: inc/customizer/configs/page-header.php:509
 msgid "Top Right"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:694
+#: inc/customizer/class-customizer.php:701
 #: inc/customizer/configs/page-header.php:510
 msgid "Top Center"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:695
+#: inc/customizer/class-customizer.php:702
 #: inc/customizer/configs/page-header.php:511
 msgid "Bottom Left"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:696
+#: inc/customizer/class-customizer.php:703
 #: inc/customizer/configs/page-header.php:512
 msgid "Bottom Center"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:697
+#: inc/customizer/class-customizer.php:704
 #: inc/customizer/configs/page-header.php:513
 msgid "Bottom Right"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:704
+#: inc/customizer/class-customizer.php:711
 #: inc/customizer/configs/page-header.php:521
 msgid "Repeat"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:711
+#: inc/customizer/class-customizer.php:718
 #: inc/customizer/configs/page-header.php:528
 msgid "No repeat"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:712
+#: inc/customizer/class-customizer.php:719
 #: inc/customizer/configs/page-header.php:529
 msgid "Repeat horizontal"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:713
+#: inc/customizer/class-customizer.php:720
 #: inc/customizer/configs/page-header.php:530
 msgid "Repeat vertical"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:721
+#: inc/customizer/class-customizer.php:728
 #: inc/customizer/configs/page-header.php:539
 msgid "Attachment"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:728
+#: inc/customizer/class-customizer.php:735
 #: inc/customizer/configs/page-header.php:546
 msgid "Scroll"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:729
+#: inc/customizer/class-customizer.php:736
 #: inc/customizer/configs/page-header.php:547
 msgid "Fixed"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:737
-#: inc/customizer/class-customizer.php:834
+#: inc/customizer/class-customizer.php:744
+#: inc/customizer/class-customizer.php:841
 #: inc/customizer/configs/header/social-icons.php:257
 msgid "Border"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:744
-#: inc/customizer/class-customizer.php:839
+#: inc/customizer/class-customizer.php:751
+#: inc/customizer/class-customizer.php:846
 #: inc/customizer/configs/header/social-icons.php:268
 msgid "Border Style"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:749
-#: inc/customizer/class-customizer.php:844
+#: inc/customizer/class-customizer.php:756
+#: inc/customizer/class-customizer.php:851
 #: inc/customizer/configs/header/social-icons.php:273
 msgid "Solid"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:750
-#: inc/customizer/class-customizer.php:845
+#: inc/customizer/class-customizer.php:757
+#: inc/customizer/class-customizer.php:852
 #: inc/customizer/configs/header/social-icons.php:274
 msgid "Dotted"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:751
-#: inc/customizer/class-customizer.php:846
+#: inc/customizer/class-customizer.php:758
+#: inc/customizer/class-customizer.php:853
 #: inc/customizer/configs/header/social-icons.php:275
 msgid "Dashed"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:752
-#: inc/customizer/class-customizer.php:847
+#: inc/customizer/class-customizer.php:759
+#: inc/customizer/class-customizer.php:854
 #: inc/customizer/configs/header/social-icons.php:276
 msgid "Double"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:753
-#: inc/customizer/class-customizer.php:848
+#: inc/customizer/class-customizer.php:760
+#: inc/customizer/class-customizer.php:855
 #: inc/customizer/configs/header/social-icons.php:277
 msgid "Ridge"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:754
-#: inc/customizer/class-customizer.php:849
+#: inc/customizer/class-customizer.php:761
+#: inc/customizer/class-customizer.php:856
 #: inc/customizer/configs/header/social-icons.php:278
 msgid "Inset"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:755
-#: inc/customizer/class-customizer.php:850
+#: inc/customizer/class-customizer.php:762
+#: inc/customizer/class-customizer.php:857
 #: inc/customizer/configs/header/social-icons.php:279
 msgid "Outset"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:763
-#: inc/customizer/class-customizer.php:857
+#: inc/customizer/class-customizer.php:770
+#: inc/customizer/class-customizer.php:864
 #: inc/customizer/configs/header/social-icons.php:288
 msgid "Border Width"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:778
-#: inc/customizer/class-customizer.php:869
+#: inc/customizer/class-customizer.php:785
+#: inc/customizer/class-customizer.php:876
 #: inc/customizer/configs/header/menus.php:108
 #: inc/customizer/configs/header/social-icons.php:301
 msgid "Border Color"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:789
-#: inc/customizer/class-customizer.php:876
+#: inc/customizer/class-customizer.php:796
+#: inc/customizer/class-customizer.php:883
 #: inc/customizer/configs/header/social-icons.php:310
 msgid "Border Radius"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:801
-#: inc/customizer/class-customizer.php:887
+#: inc/customizer/class-customizer.php:808
+#: inc/customizer/class-customizer.php:894
 msgid "Box Shadow"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:1323
+#: inc/customizer/class-customizer.php:1330
 msgid "General Options"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:1331
+#: inc/customizer/class-customizer.php:1338
 #: inc/customizer/configs/layouts.php:21
 msgid "Layouts"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:1340
+#: inc/customizer/class-customizer.php:1347
 msgid "Post Types"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:1350
+#: inc/customizer/class-customizer.php:1357
 msgid "Core & Plugins"
 msgstr ""
 
@@ -2063,40 +2063,40 @@ msgstr ""
 msgid "Copyright Text Typography"
 msgstr ""
 
-#: inc/customizer/configs/footer/panel.php:21
-#: inc/customizer/configs/footer/panel.php:26
+#: inc/customizer/configs/footer/panel.php:40
+#: inc/customizer/configs/footer/panel.php:45
 msgid "Footer Layout"
 msgstr ""
 
-#: inc/customizer/configs/footer/panel.php:39
+#: inc/customizer/configs/footer/panel.php:55
 msgid "Footer Main"
 msgstr ""
 
-#: inc/customizer/configs/footer/panel.php:40
+#: inc/customizer/configs/footer/panel.php:56
 msgid "Footer Bottom"
 msgstr ""
 
-#: inc/customizer/configs/footer/panel.php:51
+#: inc/customizer/configs/footer/panel.php:67
 msgid "Footer"
 msgstr ""
 
-#: inc/customizer/configs/footer/panel.php:95
+#: inc/customizer/configs/footer/panel.php:111
 msgid "Footer Top"
 msgstr ""
 
-#: inc/customizer/configs/footer/panel.php:141
+#: inc/customizer/configs/footer/panel.php:157
 #: inc/customizer/configs/header/panel.php:128
 #: inc/customizer/configs/page-header.php:220
 msgid "Full width - Contained"
 msgstr ""
 
-#: inc/customizer/configs/footer/panel.php:143
+#: inc/customizer/configs/footer/panel.php:159
 #: inc/customizer/configs/header/panel.php:130
 #: inc/customizer/configs/page-header.php:222
 msgid "Contained"
 msgstr ""
 
-#: inc/customizer/configs/footer/panel.php:152
+#: inc/customizer/configs/footer/panel.php:168
 #: inc/customizer/configs/header/panel.php:139
 msgid ""
 "Layout <code>Full width - Contained</code> and <code>Full Width</code> will "
@@ -2105,32 +2105,32 @@ msgid ""
 "<code>Framed</code>"
 msgstr ""
 
-#: inc/customizer/configs/footer/panel.php:164
+#: inc/customizer/configs/footer/panel.php:180
 #: inc/customizer/configs/header/panel.php:182
 #: inc/customizer/configs/header/panel.php:282
 msgid "Skin Mode"
 msgstr ""
 
-#: inc/customizer/configs/footer/panel.php:191
+#: inc/customizer/configs/footer/panel.php:207
 msgid "Columns Layout"
 msgstr ""
 
-#: inc/customizer/configs/footer/panel.php:199
+#: inc/customizer/configs/footer/panel.php:215
 msgid "Columns Gap"
 msgstr ""
 
-#: inc/customizer/configs/footer/panel.php:200
+#: inc/customizer/configs/footer/panel.php:216
 msgid ""
 "Default gap between columns. Per-column gap in Column Settings overrides "
 "this."
 msgstr ""
 
-#: inc/customizer/configs/footer/panel.php:213
+#: inc/customizer/configs/footer/panel.php:229
 #: inc/customizer/configs/header/panel.php:223
 msgid "Column Settings"
 msgstr ""
 
-#: inc/customizer/configs/footer/panel.php:214
+#: inc/customizer/configs/footer/panel.php:230
 #: inc/customizer/configs/header/panel.php:224
 msgid "Per-column direction, align, gap and padding."
 msgstr ""
@@ -3510,7 +3510,7 @@ msgstr ""
 msgid "Content / Sidebar / Sidebar"
 msgstr ""
 
-#: inc/template-functions.php:633
+#: inc/template-functions.php:636
 msgid "Search &hellip;"
 msgstr ""
 
@@ -3730,7 +3730,7 @@ msgstr ""
 #: inc/customizer/configs/header/search-box.php:287
 #: inc/customizer/configs/header/search-icon.php:347
 #: inc/customizer/configs/header/search-icon.php:348
-#: inc/template-functions.php:632 inc/template-functions.php:633
+#: inc/template-functions.php:635 inc/template-functions.php:636
 msgctxt "label"
 msgid "Search for:"
 msgstr ""
@@ -3745,17 +3745,17 @@ msgctxt "customify-font-weight"
 msgid "Bold"
 msgstr ""
 
-#: inc/template-functions.php:611
+#: inc/template-functions.php:614
 msgctxt "yearly archives date format"
 msgid "Y"
 msgstr ""
 
-#: inc/template-functions.php:613
+#: inc/template-functions.php:616
 msgctxt "monthly archives date format"
 msgid "F Y"
 msgstr ""
 
-#: inc/template-functions.php:615
+#: inc/template-functions.php:618
 msgctxt "daily archives date format"
 msgid "F j, Y"
 msgstr ""

--- a/languages/customify.pot
+++ b/languages/customify.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Customify 0.4.16\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/customify\n"
-"POT-Creation-Date: 2026-05-25 12:20:56+00:00\n"
+"POT-Creation-Date: 2026-05-26 16:08:34+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -506,36 +506,36 @@ msgstr ""
 msgid "Customify Pro module settings"
 msgstr ""
 
-#: inc/admin/pro-bridge/pro-bridge.php:385
+#: inc/admin/pro-bridge/pro-bridge.php:384
 msgid "Sorry, you are not allowed to access this page."
 msgstr ""
 
-#: inc/admin/pro-bridge/pro-bridge.php:401
+#: inc/admin/pro-bridge/pro-bridge.php:400
 msgid "Module settings unavailable"
 msgstr ""
 
-#: inc/admin/pro-bridge/pro-bridge.php:402
+#: inc/admin/pro-bridge/pro-bridge.php:401
 msgid "This module is not registered, not enabled, or does not expose any settings."
 msgstr ""
 
-#: inc/admin/pro-bridge/pro-bridge.php:406
+#: inc/admin/pro-bridge/pro-bridge.php:405
 msgid "Back to dashboard"
 msgstr ""
 
-#: inc/admin/pro-bridge/pro-bridge.php:417
+#: inc/admin/pro-bridge/pro-bridge.php:416
 msgid "Form fields class missing."
 msgstr ""
 
-#: inc/admin/pro-bridge/pro-bridge.php:460
+#: inc/admin/pro-bridge/pro-bridge.php:459
 #. translators: %s: Pro module name.
 msgid "%s Settings"
 msgstr ""
 
-#: inc/admin/pro-bridge/pro-bridge.php:467
+#: inc/admin/pro-bridge/pro-bridge.php:466
 msgid "← Back to dashboard"
 msgstr ""
 
-#: inc/admin/pro-bridge/pro-bridge.php:473
+#: inc/admin/pro-bridge/pro-bridge.php:472
 msgid "Settings saved."
 msgstr ""
 
@@ -1139,27 +1139,19 @@ msgstr ""
 msgid "Products per row on mobile"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/colors.php:15
+#: inc/compatibility/woocommerce/config/colors.php:16
 msgid "Shop Colors"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/colors.php:22
-msgid "Shop Buttons"
-msgstr ""
-
-#: inc/compatibility/woocommerce/config/colors.php:25
-msgid "Color for add to cart, checkout buttons. Default is Secondary Color."
-msgstr ""
-
-#: inc/compatibility/woocommerce/config/colors.php:46
+#: inc/compatibility/woocommerce/config/colors.php:23
 msgid "Rating Stars"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/colors.php:47
+#: inc/compatibility/woocommerce/config/colors.php:24
 msgid "Color for rating stars, default is Secondary Color."
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/colors.php:70
+#: inc/compatibility/woocommerce/config/colors.php:47
 msgid "On Sale"
 msgstr ""
 

--- a/languages/customify.pot
+++ b/languages/customify.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Customify 0.4.16\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/customify\n"
-"POT-Creation-Date: 2026-05-26 16:08:34+00:00\n"
+"POT-Creation-Date: 2026-05-27 03:36:45+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -606,18 +606,18 @@ msgid "Feed for all posts filed under %s"
 msgstr ""
 
 #: inc/class-customify.php:199 inc/class-customify.php:261
-#: inc/colors-palette.php:1873 inc/customizer/configs/colors.php:317
+#: inc/colors-palette.php:1873 inc/customizer/configs/colors.php:289
 msgid "Primary"
 msgstr ""
 
 #: inc/class-customify.php:266 inc/colors-palette.php:1885
-#: inc/customizer/configs/colors.php:331
+#: inc/customizer/configs/colors.php:303
 msgid "Secondary"
 msgstr ""
 
 #: inc/class-customify.php:271
 #: inc/compatibility/woocommerce/config/catalog-designer.php:393
-#: inc/customizer/configs/colors.php:359
+#: inc/customizer/configs/colors.php:331
 #: inc/customizer/configs/header/button.php:46
 msgid "Text"
 msgstr ""
@@ -666,7 +666,7 @@ msgstr ""
 #: inc/customizer/class-customizer.php:747
 #: inc/customizer/class-customizer.php:842
 #: inc/customizer/configs/header/social-icons.php:271
-#: inc/customizer/configs/layouts.php:238
+#: inc/customizer/configs/layouts.php:273
 #: inc/customizer/configs/page-header.php:219
 #: inc/customizer/configs/page-header.php:260
 #: inc/customizer/configs/page-header.php:271
@@ -699,7 +699,7 @@ msgstr ""
 #: inc/compatibility/woocommerce/config/single-product.php:187
 #: inc/customizer/configs/blogs.php:29 inc/customizer/configs/blogs.php:36
 #: inc/customizer/configs/footer/panel.php:135
-#: inc/customizer/configs/footer/panel.php:499
+#: inc/customizer/configs/footer/panel.php:504
 #: inc/customizer/configs/header/panel.php:122
 #: inc/customizer/configs/page-header.php:214
 msgid "Layout"
@@ -724,104 +724,108 @@ msgstr ""
 msgid "Full Width - Stretched"
 msgstr ""
 
-#: inc/class-metabox.php:82
+#: inc/class-metabox.php:69
+msgid "Narrow"
+msgstr ""
+
+#: inc/class-metabox.php:83
 msgid "Page Title Layout"
 msgstr ""
 
-#: inc/class-metabox.php:87 inc/class-metabox.php:104 inc/class-metabox.php:177
+#: inc/class-metabox.php:88 inc/class-metabox.php:105 inc/class-metabox.php:178
 msgid "Inherit from customize settings"
 msgstr ""
 
-#: inc/class-metabox.php:88 inc/customizer/configs/page-header.php:36
+#: inc/class-metabox.php:89 inc/customizer/configs/page-header.php:36
 msgid "Default - inside main content"
 msgstr ""
 
-#: inc/class-metabox.php:89 inc/customizer/class-customizer.php:675
+#: inc/class-metabox.php:90 inc/customizer/class-customizer.php:675
 #: inc/customizer/configs/page-header.php:37
 #: inc/customizer/configs/page-header.php:490
 msgid "Cover"
 msgstr ""
 
-#: inc/class-metabox.php:90 inc/customizer/configs/page-header.php:38
+#: inc/class-metabox.php:91 inc/customizer/configs/page-header.php:38
 msgid "Titlebar"
 msgstr ""
 
-#: inc/class-metabox.php:91 inc/class-metabox.php:178
+#: inc/class-metabox.php:92 inc/class-metabox.php:179
 #: inc/customizer/configs/page-header.php:39
 msgid "Hide"
 msgstr ""
 
-#: inc/class-metabox.php:98
+#: inc/class-metabox.php:99
 msgid "Sidebar"
 msgstr ""
 
-#: inc/class-metabox.php:113
+#: inc/class-metabox.php:114
 msgid "Disable Header"
 msgstr ""
 
-#: inc/class-metabox.php:114
+#: inc/class-metabox.php:115
 msgid "Disable Header Top"
 msgstr ""
 
-#: inc/class-metabox.php:115
+#: inc/class-metabox.php:116
 msgid "Disable Header Main"
 msgstr ""
 
-#: inc/class-metabox.php:116
+#: inc/class-metabox.php:117
 msgid "Disable Header Bottom"
 msgstr ""
 
-#: inc/class-metabox.php:117
+#: inc/class-metabox.php:118
 msgid "Disable Title"
 msgstr ""
 
-#: inc/class-metabox.php:122
+#: inc/class-metabox.php:123
 msgid "Disable Content Vertical Padding"
 msgstr ""
 
-#: inc/class-metabox.php:126
+#: inc/class-metabox.php:127
 msgid "Disable Footer Top"
 msgstr ""
 
-#: inc/class-metabox.php:128
+#: inc/class-metabox.php:129
 msgid "Disable Footer Main"
 msgstr ""
 
-#: inc/class-metabox.php:129
+#: inc/class-metabox.php:130
 msgid "Disable Footer Bottom"
 msgstr ""
 
-#: inc/class-metabox.php:132
+#: inc/class-metabox.php:133
 msgid "Disable Elements"
 msgstr ""
 
-#: inc/class-metabox.php:150 inc/customizer/configs/header/transparent.php:168
+#: inc/class-metabox.php:151 inc/customizer/configs/header/transparent.php:168
 msgid "Transparent Header"
 msgstr ""
 
-#: inc/class-metabox.php:155
+#: inc/class-metabox.php:156
 msgid "Inherit from Customizer settings"
 msgstr ""
 
-#: inc/class-metabox.php:156
+#: inc/class-metabox.php:157
 msgid "Force transparent"
 msgstr ""
 
-#: inc/class-metabox.php:157
+#: inc/class-metabox.php:158
 msgid "Force opaque"
 msgstr ""
 
-#: inc/class-metabox.php:166 inc/class-metabox.php:172
+#: inc/class-metabox.php:167 inc/class-metabox.php:173
 #: inc/compatibility/breadcrumb.php:90
 msgid "Breadcrumb"
 msgstr ""
 
-#: inc/class-metabox.php:179
+#: inc/class-metabox.php:180
 #: inc/customizer/controls/class-control-repeater.php:23
 msgid "Show"
 msgstr ""
 
-#: inc/class-metabox.php:232
+#: inc/class-metabox.php:233
 msgid "Customify Settings"
 msgstr ""
 
@@ -833,7 +837,7 @@ msgstr ""
 msgid "Secondary Container"
 msgstr ""
 
-#: inc/colors-palette.php:1895 inc/customizer/configs/colors.php:345
+#: inc/colors-palette.php:1895 inc/customizer/configs/colors.php:317
 msgid "Accent"
 msgstr ""
 
@@ -845,11 +849,11 @@ msgstr ""
 msgid "Body Text"
 msgstr ""
 
-#: inc/colors-palette.php:1924 inc/customizer/configs/colors.php:377
+#: inc/colors-palette.php:1924 inc/customizer/configs/colors.php:349
 msgid "Surface"
 msgstr ""
 
-#: inc/colors-palette.php:1929 inc/customizer/configs/colors.php:391
+#: inc/colors-palette.php:1929 inc/customizer/configs/colors.php:363
 #: inc/customizer/configs/typography.php:29
 msgid "Base"
 msgstr ""
@@ -1183,7 +1187,7 @@ msgstr ""
 #: inc/compatibility/woocommerce/config/header/cart.php:103
 #: inc/customizer/configs/header/button.php:67
 #: inc/customizer/configs/header/search-box.php:131
-#: inc/customizer/configs/header/search-icon.php:229
+#: inc/customizer/configs/header/search-icon.php:245
 msgid "Icon Position"
 msgstr ""
 
@@ -1240,8 +1244,8 @@ msgstr ""
 #: inc/compatibility/woocommerce/config/header/cart.php:225
 #: inc/customizer/configs/header/nav-icon.php:61
 #: inc/customizer/configs/header/search-box.php:103
-#: inc/customizer/configs/header/search-icon.php:60
-#: inc/customizer/configs/header/search-icon.php:202
+#: inc/customizer/configs/header/search-icon.php:65
+#: inc/customizer/configs/header/search-icon.php:218
 msgid "Icon Size"
 msgstr ""
 
@@ -1930,105 +1934,105 @@ msgstr ""
 msgid "Blog"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:293 inc/customizer/configs/colors.php:409
+#: inc/customizer/configs/colors.php:265 inc/customizer/configs/colors.php:381
 msgid "Colors"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:294
+#: inc/customizer/configs/colors.php:266
 msgid "Pick 6 brand colors. The theme derives everything else."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:302
+#: inc/customizer/configs/colors.php:274
 msgid "Palette"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:318
+#: inc/customizer/configs/colors.php:290
 msgid "Brand color, CTAs."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:332
+#: inc/customizer/configs/colors.php:304
 msgid "Secondary brand color."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:346
+#: inc/customizer/configs/colors.php:318
 msgid "Highlight / decorative pop."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:360
+#: inc/customizer/configs/colors.php:332
 msgid "Ink baseline. Headings inherit from this slot by default."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:378
+#: inc/customizer/configs/colors.php:350
 msgid "Card / elevated container background."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:392
+#: inc/customizer/configs/colors.php:364
 msgid "Page background."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:422
+#: inc/customizer/configs/colors.php:394
 msgid "Link color"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:423
+#: inc/customizer/configs/colors.php:395
 msgid "Default: derived from Primary slot."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:440
+#: inc/customizer/configs/colors.php:412
 msgid "Link hover color"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:441
+#: inc/customizer/configs/colors.php:413
 msgid "Default: derived (Link color lighter 15%)."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:458
+#: inc/customizer/configs/colors.php:430
 msgid "Heading color"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:459
+#: inc/customizer/configs/colors.php:431
 msgid "Default: derived from Text slot."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:471
+#: inc/customizer/configs/colors.php:443
 msgid "Backgrounds"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:487
+#: inc/customizer/configs/colors.php:459
 msgid "Page Background"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:507
+#: inc/customizer/configs/colors.php:479
 msgid "Content Area Background"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:526
+#: inc/customizer/configs/colors.php:498
 msgid "Site Content Background"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:546
+#: inc/customizer/configs/colors.php:518
 msgid "Legacy fine-tuning"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:547
+#: inc/customizer/configs/colors.php:519
 msgid ""
 "Per-element color overrides. Beats the Palette cascade when saved. Click to "
 "expand."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:561
+#: inc/customizer/configs/colors.php:533
 msgid "Body text override"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:574
+#: inc/customizer/configs/colors.php:546
 msgid "Border override"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:594
+#: inc/customizer/configs/colors.php:566
 msgid "Meta text override"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:611
+#: inc/customizer/configs/colors.php:583
 msgid "Widget title override"
 msgstr ""
 
@@ -2219,14 +2223,14 @@ msgstr ""
 
 #: inc/customizer/configs/header/logo.php:55
 #: inc/customizer/configs/header/logo.php:69
-#: inc/customizer/configs/layouts.php:54 inc/customizer/configs/layouts.php:163
+#: inc/customizer/configs/layouts.php:54 inc/customizer/configs/layouts.php:198
 msgid "Yes"
 msgstr ""
 
 #: inc/customizer/configs/header/logo.php:56
 #: inc/customizer/configs/header/logo.php:70
 #: inc/customizer/configs/header/panel.php:469
-#: inc/customizer/configs/layouts.php:55 inc/customizer/configs/layouts.php:164
+#: inc/customizer/configs/layouts.php:55 inc/customizer/configs/layouts.php:199
 msgid "No"
 msgstr ""
 
@@ -2462,12 +2466,12 @@ msgid "Search Box"
 msgstr ""
 
 #: inc/customizer/configs/header/search-box.php:62
-#: inc/customizer/configs/header/search-icon.php:124
+#: inc/customizer/configs/header/search-icon.php:140
 msgid "Placeholder"
 msgstr ""
 
 #: inc/customizer/configs/header/search-box.php:63
-#: inc/customizer/configs/header/search-icon.php:125
+#: inc/customizer/configs/header/search-icon.php:141
 msgid "Search ..."
 msgstr ""
 
@@ -2480,35 +2484,35 @@ msgid "Note: The width can not greater than grid width."
 msgstr ""
 
 #: inc/customizer/configs/header/search-box.php:89
-#: inc/customizer/configs/header/search-icon.php:169
+#: inc/customizer/configs/header/search-icon.php:185
 msgid "Input Height"
 msgstr ""
 
 #: inc/customizer/configs/header/search-box.php:141
-#: inc/customizer/configs/header/search-icon.php:188
+#: inc/customizer/configs/header/search-icon.php:204
 msgid "Input Text Typography"
 msgstr ""
 
 #: inc/customizer/configs/header/search-box.php:142
-#: inc/customizer/configs/header/search-icon.php:189
+#: inc/customizer/configs/header/search-icon.php:205
 msgid "Typography for search input"
 msgstr ""
 
 #: inc/customizer/configs/header/search-box.php:151
-#: inc/customizer/configs/header/search-icon.php:237
+#: inc/customizer/configs/header/search-icon.php:253
 msgid "Input Styling"
 msgstr ""
 
 #: inc/customizer/configs/header/search-box.php:152
 #: inc/customizer/configs/header/search-box.php:203
-#: inc/customizer/configs/header/search-icon.php:238
-#: inc/customizer/configs/header/search-icon.php:275
+#: inc/customizer/configs/header/search-icon.php:254
+#: inc/customizer/configs/header/search-icon.php:291
 msgid "Search input styling"
 msgstr ""
 
 #: inc/customizer/configs/header/search-box.php:202
-#: inc/customizer/configs/header/search-icon.php:81
-#: inc/customizer/configs/header/search-icon.php:274
+#: inc/customizer/configs/header/search-icon.php:90
+#: inc/customizer/configs/header/search-icon.php:290
 msgid "Icon Styling"
 msgstr ""
 
@@ -2520,35 +2524,35 @@ msgstr ""
 msgid "Search Icon"
 msgstr ""
 
-#: inc/customizer/configs/header/search-icon.php:73
+#: inc/customizer/configs/header/search-icon.php:82
 msgid "Icon Padding"
 msgstr ""
 
-#: inc/customizer/configs/header/search-icon.php:82
+#: inc/customizer/configs/header/search-icon.php:91
 msgid "Search icon styling"
 msgstr ""
 
-#: inc/customizer/configs/header/search-icon.php:115
+#: inc/customizer/configs/header/search-icon.php:131
 msgid "Modal Settings"
 msgstr ""
 
-#: inc/customizer/configs/header/search-icon.php:133
+#: inc/customizer/configs/header/search-icon.php:149
 msgid "Form Styling"
 msgstr ""
 
-#: inc/customizer/configs/header/search-icon.php:134
+#: inc/customizer/configs/header/search-icon.php:150
 msgid "Form modal styling"
 msgstr ""
 
-#: inc/customizer/configs/header/search-icon.php:179
+#: inc/customizer/configs/header/search-icon.php:195
 msgid "Search Modal Width"
 msgstr ""
 
-#: inc/customizer/configs/header/search-icon.php:317
+#: inc/customizer/configs/header/search-icon.php:333
 msgid "open search tool"
 msgstr ""
 
-#: inc/customizer/configs/header/search-icon.php:334
+#: inc/customizer/configs/header/search-icon.php:350
 msgid "submit search"
 msgstr ""
 
@@ -2682,7 +2686,7 @@ msgstr ""
 msgid "Select global site layout."
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:43 inc/customizer/configs/layouts.php:110
+#: inc/customizer/configs/layouts.php:43 inc/customizer/configs/layouts.php:145
 msgid "Boxed"
 msgstr ""
 
@@ -2698,63 +2702,73 @@ msgstr ""
 msgid "Site framed margin"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:96
+#: inc/customizer/configs/layouts.php:104
 msgid "Container Width"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:97
+#: inc/customizer/configs/layouts.php:105
 msgid "Max width of the site container."
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:107
+#: inc/customizer/configs/layouts.php:131
+msgid "Narrow Content Width"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:132
+msgid ""
+"Max width when a post uses the \"Narrow\" Content Layout option in the Page "
+"Settings panel."
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:142
 msgid "Site content layout"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:109
+#: inc/customizer/configs/layouts.php:144
 msgid "Full width"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:121
+#: inc/customizer/configs/layouts.php:156
 msgid "Site content padding"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:140
+#: inc/customizer/configs/layouts.php:175
 msgid "Sidebars"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:153
+#: inc/customizer/configs/layouts.php:188
 msgid "Default Sidebar Layout"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:161
+#: inc/customizer/configs/layouts.php:196
 msgid "Sidebar with vertical border"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:179
+#: inc/customizer/configs/layouts.php:214
 msgid "Pages"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:188
+#: inc/customizer/configs/layouts.php:223
 msgid "Blog posts"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:197
+#: inc/customizer/configs/layouts.php:232
 msgid "Blog Archive Page"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:206
+#: inc/customizer/configs/layouts.php:241
 msgid "Search Page"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:215
+#: inc/customizer/configs/layouts.php:250
 msgid "404 Page"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:227
+#: inc/customizer/configs/layouts.php:262
 msgid "Post Type Settings"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:236
+#: inc/customizer/configs/layouts.php:271
 msgid "Single %s"
 msgstr ""
 
@@ -3496,7 +3510,7 @@ msgstr ""
 msgid "Content / Sidebar / Sidebar"
 msgstr ""
 
-#: inc/template-functions.php:437
+#: inc/template-functions.php:633
 msgid "Search &hellip;"
 msgstr ""
 
@@ -3714,9 +3728,9 @@ msgstr ""
 
 #: inc/customizer/configs/header/search-box.php:277
 #: inc/customizer/configs/header/search-box.php:287
-#: inc/customizer/configs/header/search-icon.php:331
-#: inc/customizer/configs/header/search-icon.php:332
-#: inc/template-functions.php:436 inc/template-functions.php:437
+#: inc/customizer/configs/header/search-icon.php:347
+#: inc/customizer/configs/header/search-icon.php:348
+#: inc/template-functions.php:632 inc/template-functions.php:633
 msgctxt "label"
 msgid "Search for:"
 msgstr ""
@@ -3731,17 +3745,17 @@ msgctxt "customify-font-weight"
 msgid "Bold"
 msgstr ""
 
-#: inc/template-functions.php:415
+#: inc/template-functions.php:611
 msgctxt "yearly archives date format"
 msgid "Y"
 msgstr ""
 
-#: inc/template-functions.php:417
+#: inc/template-functions.php:613
 msgctxt "monthly archives date format"
 msgid "F Y"
 msgstr ""
 
-#: inc/template-functions.php:419
+#: inc/template-functions.php:615
 msgctxt "daily archives date format"
 msgid "F j, Y"
 msgstr ""

--- a/languages/customify.pot
+++ b/languages/customify.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GNU General Public License v2 or later.=!>
 msgid ""
 msgstr ""
-"Project-Id-Version: Customify 0.4.16\n"
+"Project-Id-Version: Customify 0.4.17\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/customify\n"
-"POT-Creation-Date: 2026-05-27 03:36:45+00:00\n"
+"POT-Creation-Date: 2026-05-27 14:31:39+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -606,18 +606,18 @@ msgid "Feed for all posts filed under %s"
 msgstr ""
 
 #: inc/class-customify.php:199 inc/class-customify.php:261
-#: inc/colors-palette.php:1873 inc/customizer/configs/colors.php:289
+#: inc/colors-palette.php:1873 inc/customizer/configs/colors.php:112
 msgid "Primary"
 msgstr ""
 
 #: inc/class-customify.php:266 inc/colors-palette.php:1885
-#: inc/customizer/configs/colors.php:303
+#: inc/customizer/configs/colors.php:126
 msgid "Secondary"
 msgstr ""
 
 #: inc/class-customify.php:271
 #: inc/compatibility/woocommerce/config/catalog-designer.php:393
-#: inc/customizer/configs/colors.php:331
+#: inc/customizer/configs/colors.php:154
 #: inc/customizer/configs/header/button.php:46
 msgid "Text"
 msgstr ""
@@ -640,8 +640,8 @@ msgstr ""
 
 #: inc/class-customify.php:305 inc/class-customify.php:316
 #: inc/class-customify.php:330
-#: inc/compatibility/woocommerce/woocommerce.php:650
-#: inc/compatibility/woocommerce/woocommerce.php:661
+#: inc/compatibility/woocommerce/woocommerce.php:579
+#: inc/compatibility/woocommerce/woocommerce.php:590
 msgid "Add widgets here."
 msgstr ""
 
@@ -837,7 +837,7 @@ msgstr ""
 msgid "Secondary Container"
 msgstr ""
 
-#: inc/colors-palette.php:1895 inc/customizer/configs/colors.php:317
+#: inc/colors-palette.php:1895 inc/customizer/configs/colors.php:140
 msgid "Accent"
 msgstr ""
 
@@ -849,11 +849,11 @@ msgstr ""
 msgid "Body Text"
 msgstr ""
 
-#: inc/colors-palette.php:1924 inc/customizer/configs/colors.php:349
+#: inc/colors-palette.php:1924 inc/customizer/configs/colors.php:172
 msgid "Surface"
 msgstr ""
 
-#: inc/colors-palette.php:1929 inc/customizer/configs/colors.php:363
+#: inc/colors-palette.php:1929 inc/customizer/configs/colors.php:186
 #: inc/customizer/configs/typography.php:29
 msgid "Base"
 msgstr ""
@@ -1391,19 +1391,19 @@ msgstr ""
 msgid "Your order"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:602
+#: inc/compatibility/woocommerce/woocommerce.php:531
 msgid "Display on product taxonomies (categories/tags,..)"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:610
+#: inc/compatibility/woocommerce/woocommerce.php:539
 msgid "Display on single product"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:648
+#: inc/compatibility/woocommerce/woocommerce.php:577
 msgid "WooCommerce Primary Sidebar"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:659
+#: inc/compatibility/woocommerce/woocommerce.php:588
 msgid "WooCommerce Secondary Sidebar"
 msgstr ""
 
@@ -1934,105 +1934,105 @@ msgstr ""
 msgid "Blog"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:265 inc/customizer/configs/colors.php:381
+#: inc/customizer/configs/colors.php:88 inc/customizer/configs/colors.php:204
 msgid "Colors"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:266
+#: inc/customizer/configs/colors.php:89
 msgid "Pick 6 brand colors. The theme derives everything else."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:274
+#: inc/customizer/configs/colors.php:97
 msgid "Palette"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:290
+#: inc/customizer/configs/colors.php:113
 msgid "Brand color, CTAs."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:304
+#: inc/customizer/configs/colors.php:127
 msgid "Secondary brand color."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:318
+#: inc/customizer/configs/colors.php:141
 msgid "Highlight / decorative pop."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:332
+#: inc/customizer/configs/colors.php:155
 msgid "Ink baseline. Headings inherit from this slot by default."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:350
+#: inc/customizer/configs/colors.php:173
 msgid "Card / elevated container background."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:364
+#: inc/customizer/configs/colors.php:187
 msgid "Page background."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:394
+#: inc/customizer/configs/colors.php:217
 msgid "Link color"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:395
+#: inc/customizer/configs/colors.php:218
 msgid "Default: derived from Primary slot."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:412
+#: inc/customizer/configs/colors.php:235
 msgid "Link hover color"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:413
+#: inc/customizer/configs/colors.php:236
 msgid "Default: derived (Link color lighter 15%)."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:430
+#: inc/customizer/configs/colors.php:253
 msgid "Heading color"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:431
+#: inc/customizer/configs/colors.php:254
 msgid "Default: derived from Text slot."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:443
+#: inc/customizer/configs/colors.php:266
 msgid "Backgrounds"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:459
+#: inc/customizer/configs/colors.php:282
 msgid "Page Background"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:479
+#: inc/customizer/configs/colors.php:302
 msgid "Content Area Background"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:498
+#: inc/customizer/configs/colors.php:321
 msgid "Site Content Background"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:518
+#: inc/customizer/configs/colors.php:341
 msgid "Legacy fine-tuning"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:519
+#: inc/customizer/configs/colors.php:342
 msgid ""
 "Per-element color overrides. Beats the Palette cascade when saved. Click to "
 "expand."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:533
+#: inc/customizer/configs/colors.php:356
 msgid "Body text override"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:546
+#: inc/customizer/configs/colors.php:369
 msgid "Border override"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:566
+#: inc/customizer/configs/colors.php:389
 msgid "Meta text override"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:583
+#: inc/customizer/configs/colors.php:406
 msgid "Widget title override"
 msgstr ""
 

--- a/languages/customify.pot
+++ b/languages/customify.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GNU General Public License v2 or later.=!>
 msgid ""
 msgstr ""
-"Project-Id-Version: Customify 0.4.15\n"
+"Project-Id-Version: Customify 0.4.16\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/customify\n"
-"POT-Creation-Date: 2026-05-25 03:31:29+00:00\n"
+"POT-Creation-Date: 2026-05-25 12:20:56+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -502,6 +502,43 @@ msgstr ""
 msgid "Upgrade Now &rarr;"
 msgstr ""
 
+#: inc/admin/pro-bridge/pro-bridge.php:249
+msgid "Customify Pro module settings"
+msgstr ""
+
+#: inc/admin/pro-bridge/pro-bridge.php:385
+msgid "Sorry, you are not allowed to access this page."
+msgstr ""
+
+#: inc/admin/pro-bridge/pro-bridge.php:401
+msgid "Module settings unavailable"
+msgstr ""
+
+#: inc/admin/pro-bridge/pro-bridge.php:402
+msgid "This module is not registered, not enabled, or does not expose any settings."
+msgstr ""
+
+#: inc/admin/pro-bridge/pro-bridge.php:406
+msgid "Back to dashboard"
+msgstr ""
+
+#: inc/admin/pro-bridge/pro-bridge.php:417
+msgid "Form fields class missing."
+msgstr ""
+
+#: inc/admin/pro-bridge/pro-bridge.php:460
+#. translators: %s: Pro module name.
+msgid "%s Settings"
+msgstr ""
+
+#: inc/admin/pro-bridge/pro-bridge.php:467
+msgid "← Back to dashboard"
+msgstr ""
+
+#: inc/admin/pro-bridge/pro-bridge.php:473
+msgid "Settings saved."
+msgstr ""
+
 #: inc/blog/class-post-entry.php:286
 msgid "Tagged "
 msgstr ""
@@ -569,18 +606,18 @@ msgid "Feed for all posts filed under %s"
 msgstr ""
 
 #: inc/class-customify.php:199 inc/class-customify.php:261
-#: inc/colors-palette.php:1873 inc/customizer/configs/colors.php:310
+#: inc/colors-palette.php:1873 inc/customizer/configs/colors.php:317
 msgid "Primary"
 msgstr ""
 
 #: inc/class-customify.php:266 inc/colors-palette.php:1885
-#: inc/customizer/configs/colors.php:324
+#: inc/customizer/configs/colors.php:331
 msgid "Secondary"
 msgstr ""
 
 #: inc/class-customify.php:271
 #: inc/compatibility/woocommerce/config/catalog-designer.php:393
-#: inc/customizer/configs/colors.php:352
+#: inc/customizer/configs/colors.php:359
 #: inc/customizer/configs/header/button.php:46
 msgid "Text"
 msgstr ""
@@ -796,7 +833,7 @@ msgstr ""
 msgid "Secondary Container"
 msgstr ""
 
-#: inc/colors-palette.php:1895 inc/customizer/configs/colors.php:338
+#: inc/colors-palette.php:1895 inc/customizer/configs/colors.php:345
 msgid "Accent"
 msgstr ""
 
@@ -808,11 +845,11 @@ msgstr ""
 msgid "Body Text"
 msgstr ""
 
-#: inc/colors-palette.php:1924 inc/customizer/configs/colors.php:370
+#: inc/colors-palette.php:1924 inc/customizer/configs/colors.php:377
 msgid "Surface"
 msgstr ""
 
-#: inc/colors-palette.php:1929 inc/customizer/configs/colors.php:384
+#: inc/colors-palette.php:1929 inc/customizer/configs/colors.php:391
 #: inc/customizer/configs/typography.php:29
 msgid "Base"
 msgstr ""
@@ -1901,105 +1938,105 @@ msgstr ""
 msgid "Blog"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:286 inc/customizer/configs/colors.php:402
+#: inc/customizer/configs/colors.php:293 inc/customizer/configs/colors.php:409
 msgid "Colors"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:287
+#: inc/customizer/configs/colors.php:294
 msgid "Pick 6 brand colors. The theme derives everything else."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:295
+#: inc/customizer/configs/colors.php:302
 msgid "Palette"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:311
+#: inc/customizer/configs/colors.php:318
 msgid "Brand color, CTAs."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:325
+#: inc/customizer/configs/colors.php:332
 msgid "Secondary brand color."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:339
+#: inc/customizer/configs/colors.php:346
 msgid "Highlight / decorative pop."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:353
+#: inc/customizer/configs/colors.php:360
 msgid "Ink baseline. Headings inherit from this slot by default."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:371
+#: inc/customizer/configs/colors.php:378
 msgid "Card / elevated container background."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:385
+#: inc/customizer/configs/colors.php:392
 msgid "Page background."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:415
+#: inc/customizer/configs/colors.php:422
 msgid "Link color"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:416
+#: inc/customizer/configs/colors.php:423
 msgid "Default: derived from Primary slot."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:433
+#: inc/customizer/configs/colors.php:440
 msgid "Link hover color"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:434
+#: inc/customizer/configs/colors.php:441
 msgid "Default: derived (Link color lighter 15%)."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:451
+#: inc/customizer/configs/colors.php:458
 msgid "Heading color"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:452
+#: inc/customizer/configs/colors.php:459
 msgid "Default: derived from Text slot."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:464
+#: inc/customizer/configs/colors.php:471
 msgid "Backgrounds"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:480
+#: inc/customizer/configs/colors.php:487
 msgid "Page Background"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:500
+#: inc/customizer/configs/colors.php:507
 msgid "Content Area Background"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:519
+#: inc/customizer/configs/colors.php:526
 msgid "Site Content Background"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:539
+#: inc/customizer/configs/colors.php:546
 msgid "Legacy fine-tuning"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:540
+#: inc/customizer/configs/colors.php:547
 msgid ""
 "Per-element color overrides. Beats the Palette cascade when saved. Click to "
 "expand."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:554
+#: inc/customizer/configs/colors.php:561
 msgid "Body text override"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:567
+#: inc/customizer/configs/colors.php:574
 msgid "Border override"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:587
+#: inc/customizer/configs/colors.php:594
 msgid "Meta text override"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:604
+#: inc/customizer/configs/colors.php:611
 msgid "Widget title override"
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "customify",
-    "version": "0.4.17",
+    "version": "0.4.18",
     "main": "Gruntfile.js",
     "engines": {
         "node": ">= 0.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "customify",
-    "version": "0.4.15",
+    "version": "0.4.16",
     "main": "Gruntfile.js",
     "engines": {
         "node": ">= 0.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "customify",
-    "version": "0.4.16",
+    "version": "0.4.17",
     "main": "Gruntfile.js",
     "engines": {
         "node": ">= 0.10.0"

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: custom-background, custom-logo, custom-menu, custom-logo, featured-images,
 Requires at least: 6.0
 Tested up to: 7.0
 Requires PHP: 8.0
-Stable tag: 0.4.15
+Stable tag: 0.4.16
 
 == Description ==
 

--- a/src/backend/admin/scss/editor.scss
+++ b/src/backend/admin/scss/editor.scss
@@ -1,4 +1,3 @@
-
 @import "../../../frontend/scss/utils/vars";
 @import "../../../frontend/scss/utils/mixins";
 @import "../../../frontend/scss/vendors/vendors";
@@ -29,59 +28,6 @@
 // specificity alone since no inline bottom is set.
 .editor-visual-editor__post-title-wrapper,
 .edit-post-visual-editor__post-title-wrapper {
-    margin-top: 2rem !important;
-    margin-bottom: 2rem;
-}
-
-// Editor equivalents for .entry-content selectors defined in _blocks.scss.
-// Those selectors do not exist inside the block editor canvas; .editor-styles-wrapper
-// is the correct root scope here.
-.editor-styles-wrapper {
-    > * {
-        margin-left: auto;
-        margin-right: auto;
-    }
-
-    > .alignwide {
-        max-width: var(--wp--style--global--wide-size, 1200px);
-        width: 100%;
-        box-sizing: border-box;
-    }
-
-    > .alignfull {
-        width: 100vw;
-        max-width: 100vw;
-        margin-top: 1.5em;
-        margin-bottom: 1.5em;
-        margin-left: calc(50% - 50vw) !important;
-        margin-right: calc(50% - 50vw) !important;
-        box-sizing: border-box;
-    }
-
-    ul,
-    ol {
-        margin: 1.5em auto;
-        list-style-position: outside;
-    }
-
-    li:not(.wp-block-navigation li) {
-        margin-left: 2.5em;
-        margin-bottom: 6px;
-    }
-
-    ul ul:not(.wp-block-navigation ul),
-    ol ol,
-    ul ol,
-    ol ul:not(.wp-block-navigation ul) {
-        margin-bottom: 0;
-        margin-top: 0;
-        margin-left: 2.5em;
-    }
-
-    ul ul li,
-    ol ol li,
-    ul ol li,
-    ol ul li {
-        margin-left: 0;
-    }
+	margin-top: 2rem !important;
+	margin-bottom: 2rem;
 }

--- a/src/backend/customizer/js/customizer.js
+++ b/src/backend/customizer/js/customizer.js
@@ -388,15 +388,18 @@
 				return;
 			}
 			var fr;
-			// A length-1 fr is the "stacked" preset's saved shape: one grid
-			// track regardless of count. Use it as-is on every device; only
-			// pad multi-track arrays when they're shorter than count (legacy
-			// data correction).
-			if (d.fr.length === 1) {
-				fr = d.fr.slice();
-			} else if (device === 'mobile') {
-				// Mobile multi-track: respect the user's explicit array exactly,
-				// no slice/pad to count.
+			var frLen = d.fr.length;
+			// Preserve fr as-is when it represents an intentional layout:
+			//   length 1            = stacked preset
+			//   length == count     = normal one-row layout
+			//   length divides count = wrap preset (e.g. fr=[1,1] with count=4
+			//                          → 2×2 grid via grid auto-flow)
+			//   mobile device       = respect user's explicit mobile choice
+			// Other lengths are legacy stale data — slice/pad to count.
+			var isIntentional = frLen === 1
+				|| frLen === count
+				|| ( frLen > 1 && count > 0 && frLen < count && count % frLen === 0 );
+			if (isIntentional || device === 'mobile') {
 				fr = d.fr.slice();
 			} else {
 				fr = count > 0 ? d.fr.slice(0, count) : d.fr.slice();

--- a/src/backend/customizer/js/customizer.js
+++ b/src/backend/customizer/js/customizer.js
@@ -348,7 +348,10 @@
 			document.head.appendChild(styleEl);
 		}
 
-		var breakpoints = { desktop: '', tablet: '(max-width: 1024px)', mobile: '(max-width: 767px)' };
+		// Breakpoints match Customify_Customizer_Auto_CSS::$media_queries
+		// and PHP customify_footer_row_layout_css() so the live-preview
+		// CSS is byte-equivalent to what ships on the published frontend.
+		var breakpoints = { desktop: '', tablet: '(max-width: 1024px)', mobile: '(max-width: 568px)' };
 		// Normalize fr length to row's column count. Matches the PHP
 		// `customify_footer_row_layout_css()` defensive truncation so legacy
 		// data (fr longer than count after a count reduction) renders the
@@ -419,15 +422,18 @@
 		styleEl.textContent = css;
 	}
 
-	wp.customize('footer_main_col_layout', function(setting) {
-		setting.bind(function(value) {
-			applyFooterColLayout('#cb-row--footer-main', value);
-		});
-	});
-
-	wp.customize('footer_bottom_col_layout', function(setting) {
-		setting.bind(function(value) {
-			applyFooterColLayout('#cb-row--footer-bottom', value);
-		});
-	});
+	// Bind a live-preview handler for every footer row's col_layout
+	// setting. The row list is sourced from Customify_Preview_Config
+	// (PHP customify_get_footer_row_ids()), so Pro / child-theme / 3rd-
+	// party rows added via the `customify/builder/footer/rows` filter
+	// pick up the same live-update treatment without further JS changes.
+	var __footerRows = ( window.Customify_Preview_Config && window.Customify_Preview_Config.footer_rows )
+		|| [ 'main', 'bottom' ];
+	__footerRows.forEach( function ( rowId ) {
+		wp.customize( 'footer_' + rowId + '_col_layout', function ( setting ) {
+			setting.bind( function ( value ) {
+				applyFooterColLayout( '#cb-row--footer-' + rowId, value );
+			} );
+		} );
+	} );
 })(jQuery, wp.customize);

--- a/src/backend/customizer/js/customizer.js
+++ b/src/backend/customizer/js/customizer.js
@@ -270,6 +270,68 @@
 			});
 		}
 	};
+
+	// Builder item sections (logo, copyright, menus, …) are kept inactive by
+	// `_customifyForceHide` so they only surface via the gear icon on the
+	// builder UI. WP's default partial.showControl() → control.focus() path
+	// re-activates the section, but the force-hide binding flips it back to
+	// false before the expand can complete — so the pencil edit-shortcut
+	// silently does nothing. Route those clicks through
+	// customifyBuilderOpenSection (parent window) which unbinds the marker,
+	// expands the section, and re-installs the deferred re-hide listener;
+	// then focus the matching control so the sidebar scrolls to it.
+	var defaultShowControl = wp.customize.selectiveRefresh.Partial.prototype.showControl;
+	wp.customize.selectiveRefresh.Partial.prototype.showControl = function() {
+		var partial    = this;
+		var parentWin  = (window.parent && window.parent !== window) ? window.parent : null;
+		var settingIds = (typeof partial.settings === "function") ? partial.settings() : [];
+		var settingId  = settingIds && settingIds.length ? settingIds[0] : null;
+
+		if (
+			settingId &&
+			parentWin &&
+			parentWin.wp &&
+			parentWin.wp.customize &&
+			typeof parentWin.customifyBuilderOpenSection === "function"
+		) {
+			var matchedControl;
+			parentWin.wp.customize.control.each(function(control) {
+				if (matchedControl) return;
+				var settings = control.settings || {};
+				for (var key in settings) {
+					if (
+						Object.prototype.hasOwnProperty.call(settings, key) &&
+						settings[key] &&
+						settings[key].id === settingId
+					) {
+						matchedControl = control;
+						break;
+					}
+				}
+			});
+			if (matchedControl) {
+				var sectionId = (typeof matchedControl.section === "function")
+					? matchedControl.section()
+					: matchedControl.section;
+				var section   = sectionId && parentWin.wp.customize.section(sectionId);
+				if (section && section._customifyForceHide) {
+					parentWin.customifyBuilderOpenSection(sectionId);
+					// Wait out the section's slide-down before asking WP to
+					// scroll the sidebar to the specific control — focusing
+					// mid-transition leaves the control off-screen.
+					setTimeout(function() {
+						var c = parentWin.wp.customize.control(matchedControl.id);
+						if (c && typeof c.focus === "function") {
+							c.focus();
+						}
+					}, 350);
+					return;
+				}
+			}
+		}
+
+		return defaultShowControl.apply(partial, arguments);
+	};
 	// Live preview for footer row col_layout (postMessage transport).
 	function applyFooterColLayout(rowSelector, valueStr) {
 		var data;

--- a/src/backend/footer-row-layout/RowLayout.jsx
+++ b/src/backend/footer-row-layout/RowLayout.jsx
@@ -26,7 +26,7 @@ function DeviceSwitcher( { device, onChange } ) {
 	);
 }
 
-function LayoutSvg( { fr, stacked, count } ) {
+function LayoutSvg( { fr, stacked, count, rows } ) {
 	const W   = 48;
 	const H   = 30;
 	const GAP = 2;
@@ -45,16 +45,24 @@ function LayoutSvg( { fr, stacked, count } ) {
 		);
 	}
 
-	const total  = fr.reduce( ( a, b ) => a + b, 0 );
-	const totalG = GAP * ( fr.length - 1 );
-	let x        = 0;
+	const total   = fr.reduce( ( a, b ) => a + b, 0 );
+	const totalGX = GAP * ( fr.length - 1 );
+	const nRows   = Math.max( 1, parseInt( rows, 10 ) || 1 );
+	const totalGY = GAP * ( nRows - 1 );
+	const rowH    = ( H - 4 - totalGY ) / nRows;
 
-	const rects = fr.map( ( f, i ) => {
-		const w    = ( f / total ) * ( W - totalG );
-		const rect = <rect key={ i } x={ x } y={ 2 } width={ Math.max( w, 1 ) } height={ H - 4 } rx={ 2 } />;
-		x += w + GAP;
-		return rect;
-	} );
+	const rects = [];
+	for ( let r = 0; r < nRows; r++ ) {
+		let x = 0;
+		const y = 2 + r * ( rowH + GAP );
+		fr.forEach( ( f, i ) => {
+			const w = ( f / total ) * ( W - totalGX );
+			rects.push(
+				<rect key={ `${ r }-${ i }` } x={ x } y={ y } width={ Math.max( w, 1 ) } height={ Math.max( rowH, 1 ) } rx={ 2 } />
+			);
+			x += w + GAP;
+		} );
+	}
 
 	return (
 		<svg width={ W } height={ H } viewBox={ `0 0 ${ W } ${ H }` } fill="currentColor" xmlns="http://www.w3.org/2000/svg">
@@ -231,15 +239,25 @@ export default function RowLayout( { settingKey } ) {
 						const active    = isStacked
 							? fr.length === 1
 							: JSON.stringify( fr ) === JSON.stringify( preset.fr );
+						const title     = isStacked
+							? 'stacked'
+							: preset.rows
+								? `${ preset.rows }×${ preset.fr.length } (${ preset.fr.join( ':' ) })`
+								: preset.fr.join( ':' );
 						return (
 							<button
 								key={ idx }
 								type="button"
 								className={ `cb-row-layout__preset-btn${ active ? ' is-active' : '' }` }
-								title={ isStacked ? 'stacked' : preset.fr.join( ':' ) }
+								title={ title }
 								onClick={ () => handlePreset( preset ) }
 							>
-								<LayoutSvg fr={ preset.fr || [ 1 ] } stacked={ isStacked } count={ count } />
+								<LayoutSvg
+									fr={ preset.fr || [ 1 ] }
+									stacked={ isStacked }
+									count={ count }
+									rows={ preset.rows }
+								/>
 							</button>
 						);
 					} ) }

--- a/src/backend/footer-row-layout/presets.js
+++ b/src/backend/footer-row-layout/presets.js
@@ -38,9 +38,14 @@ export const PRESETS = {
 };
 
 // count is global; fr, gap, padding are per-device.
+// Per-device defaults sync with PHP defaults in
+// inc/customizer/configs/config-default.php — keep both files in step so
+// the React Builder UI's initial render matches what PHP emits on the
+// frontend when no col_layout is saved yet (tablet collapses to 2 cols,
+// mobile stacks to 1 col — sensible defaults for footer-style content).
 export const DEFAULT_VALUE = {
 	count:   4,
 	desktop: { fr: [ 1, 1, 1, 1 ], gap: 0, padding: 0 },
-	tablet:  { fr: [ 1, 1, 1, 1 ], gap: 0, padding: 0 },
+	tablet:  { fr: [ 1, 1 ],       gap: 0, padding: 0 },
 	mobile:  { fr: [ 1 ],          gap: 0, padding: 0 },
 };

--- a/src/backend/footer-row-layout/presets.js
+++ b/src/backend/footer-row-layout/presets.js
@@ -24,7 +24,11 @@ export const PRESETS = {
 	],
 	4: [
 		{ fr: [ 1, 1, 1, 1 ] },
+		{ fr: [ 2, 1, 1, 1 ] },
 		{ fr: [ 1, 2, 2, 1 ] },
+		// fr shorter than count → grid items wrap to a new row.
+		// fr=[1,1] with 4 items renders a 2×2 grid (50/50 on each row).
+		{ fr: [ 1, 1 ], rows: 2 },
 		{ stacked: true },
 	],
 	5: [

--- a/src/backend/page-settings/index.js
+++ b/src/backend/page-settings/index.js
@@ -11,7 +11,7 @@ import './style.scss';
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { useEntityProp } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { useSelect, dispatch, select, subscribe } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
@@ -34,7 +34,10 @@ const TWO_SIDEBAR_LAYOUTS = [
 
 // Content Layout values that disable the sidebar entirely — both visually
 // (we hide the dropdown) and for contentSize purposes (force no_sidebar).
-const NO_SIDEBAR_CONTENT_LAYOUTS = [ 'full-width', 'full-stretched' ];
+// `narrow` joins this list because narrow content is a focused-reading layout
+// — combining it with a sidebar looks lopsided. PHP's
+// customify_force_no_sidebar_for_full_content_layout() applies the same gate.
+const NO_SIDEBAR_CONTENT_LAYOUTS = [ 'full-width', 'full-stretched', 'narrow' ];
 
 function isNoSidebarContentLayout( contentLayout ) {
 	return NO_SIDEBAR_CONTENT_LAYOUTS.includes( contentLayout );
@@ -74,22 +77,34 @@ function injectStyle( doc, id, css ) {
 }
 
 /**
- * Inject the layout-driven --wp--style--global--content-size into both the
- * outer document and the editor canvas iframe (post-WP 6.3 layout).
- *
- * Uses `body` + `!important` because theme.json emits `body { ... }` for
- * global CSS variables — a `:root` rule loses to that within body's scope.
- */
-/**
  * Build the inline CSS payload for a given size + content_layout combo.
- * Full-stretched additionally drops max-width on root blocks so they fill
- * the container, matching inc/admin/editor.php.
+ *
+ * The `max-width: none` override for full-width / full-stretched layouts lives
+ * here (not in PHP editor.php) so toggling content_layout in the metabox can
+ * actually undo it. A PHP-emitted static override would stay applied even
+ * after JS removes it from this style block.
+ *
+ * No !important on the body rule — custom-property inheritance lets the
+ * body-scoped declaration override the theme.json :root baseline for
+ * everything inside body without needing to win specificity. Matches the
+ * frontend cascade in customify_layout_content_size_css().
  */
 function buildContentSizeCss( size, contentLayout ) {
 	let css = '';
 	if ( size ) {
-		css += `body{--wp--style--global--content-size:${ size } !important;}`;
+		css += `body{--wp--style--global--content-size:${ size };}`;
 	}
+	// full-width: block fills canvas with a 32px gap each side, mirroring
+	// the frontend's `.customify-container { padding: 2em }` breathing room.
+	// In the editor there is no .customify-container wrapper, so we subtract
+	// the padding from the block's max-width explicitly.
+	if ( contentLayout === 'full-width' ) {
+		css +=
+			'.editor-styles-wrapper > .is-root-container > *:not(.alignfull):not(.alignwide){max-width:calc(100% - 64px);}';
+	}
+	// full-stretched: block fills canvas edge-to-edge — frontend version sets
+	// `.content-full-stretched > .customify-container { padding: 0 }`, so the
+	// editor matches by removing the cap entirely.
 	if ( contentLayout === 'full-stretched' ) {
 		css +=
 			'.editor-styles-wrapper > .is-root-container > *:not(.alignfull):not(.alignwide){max-width:none;}';
@@ -103,6 +118,50 @@ function applyContentSizeCss( css ) {
 	if ( iframe && iframe.contentDocument ) {
 		injectStyle( iframe.contentDocument, CONTENT_SIZE_STYLE_ID, css );
 	}
+}
+
+/**
+ * Push runtime contentSize + wideSize into the block-editor settings store so
+ * block toolbar dropdown hints (e.g., "None — Max 863px wide") reflect what the
+ * CSS variable actually resolves to. Without this the labels read from
+ * theme.json's static value (`contentSize: "863px"`) regardless of the
+ * runtime override we inject via CSS, which misleads authors.
+ *
+ * The canonical write target is `__experimentalFeatures.layout` — that's what
+ * core blocks AND third-party blocks (Blocksify Section, etc.) read when
+ * rendering the alignment dropdown. Updating the top-level `layout` key alone
+ * is not enough; both must move in lockstep to stay self-consistent.
+ *
+ * Bailing-out semantics: only write when values actually changed, to avoid
+ * triggering a no-op re-render of every component that selects from settings.
+ */
+function syncEditorLayoutSettings( contentSize, wideSize ) {
+	const store = select( 'core/block-editor' );
+	if ( ! store ) return;
+	const settings = store.getSettings();
+	const expFeatures = settings.__experimentalFeatures || {};
+	const expLayout = expFeatures.layout || {};
+	const topLayout = settings.layout || {};
+
+	const nextContent = contentSize || expLayout.contentSize;
+	const nextWide = wideSize || expLayout.wideSize;
+
+	if (
+		expLayout.contentSize === nextContent &&
+		expLayout.wideSize === nextWide &&
+		topLayout.contentSize === nextContent &&
+		topLayout.wideSize === nextWide
+	) {
+		return;
+	}
+
+	dispatch( 'core/block-editor' ).updateSettings( {
+		layout: { ...topLayout, contentSize: nextContent, wideSize: nextWide },
+		__experimentalFeatures: {
+			...expFeatures,
+			layout: { ...expLayout, contentSize: nextContent, wideSize: nextWide },
+		},
+	} );
 }
 
 /**
@@ -127,11 +186,67 @@ function ContentSizeSync() {
 	const layout = isNoSidebarContentLayout( contentLayout )
 		? 'content'
 		: sidebarMeta || config.fallbackLayout || 'content-sidebar';
-	const size = layoutToContentSize( layout );
+	const layoutSize = layoutToContentSize( layout );
+
+	// Resolution priority (highest wins):
+	//   1. Full-Width / Full-Stretched Content Layout — viewport-bound, mirrors
+	//      .site-content.content-full-{width,stretched} frontend rule.
+	//   2. Narrow Content Layout — uses Customizer narrow_width regardless of layout.
+	//      Mirrors .site-content.content-narrow frontend rule.
+	//   3. Single-post override — for post type, single_blog_post_content_width wins.
+	//      Mirrors body.single-post frontend rule.
+	//   4. Layout-derived size from sidebar layout map.
+	let size;
+	if ( contentLayout === 'full-width' ) {
+		size = 'calc(100vw - 64px)';
+	} else if ( contentLayout === 'full-stretched' ) {
+		size = '100vw';
+	} else if ( contentLayout === 'narrow' && config.narrowWidth ) {
+		size = config.narrowWidth;
+	} else if ( config.postType === 'post' && config.postContentSize ) {
+		size = config.postContentSize;
+	} else {
+		size = layoutSize;
+	}
 	const css = buildContentSizeCss( size, contentLayout );
+
+	// Dynamic wide-size per layout (matches PHP customify_layout_content_size_css):
+	//   - Full-Width / Full-Stretched (size is calc() or 100vw) → wide = content
+	//     (alignwide visually = align=none — viewport-bound layouts don't break out)
+	//   - No-sidebar / Narrow (numeric px size) → size + 400 (200px breakout each side)
+	//   - Sidebar layouts → wide = content (parent-constrained, no overlap)
+	// Used to push into __experimentalFeatures.layout.wideSize so alignment
+	// dropdown labels show the right "Max Xpx wide" hint.
+	const isViewportBoundSize =
+		typeof size === 'string' && /calc|vw/.test( size );
+	const sizeNum =
+		size && ! isViewportBoundSize ? parseInt( size, 10 ) : null;
+	const isNoSidebarFamily =
+		isNoSidebarContentLayout( contentLayout ) || layout === 'content';
+	let wideSize;
+	if ( isViewportBoundSize ) {
+		wideSize = size;
+	} else if ( sizeNum && isNoSidebarFamily ) {
+		wideSize = `${ sizeNum + 400 }px`;
+	} else {
+		wideSize = size || config.wideSize;
+	}
 
 	useEffect( () => {
 		applyContentSizeCss( css );
+
+		// Keep block-editor settings.layout in lockstep with the CSS variable so
+		// alignment dropdown labels (e.g., "None — Max 863px wide") reflect the
+		// resolved size, not theme.json's static one. The initial dispatch can
+		// be overwritten by editor bootstrap loading theme.json after our mount,
+		// so subscribe and re-apply on every settings change — syncEditor-
+		// LayoutSettings has internal bail-out so it's a no-op once our values
+		// have stuck. Subscription is scoped to core/block-editor so we don't
+		// fire on unrelated store updates.
+		const applyLayoutSync = () =>
+			syncEditorLayoutSettings( size, wideSize );
+		applyLayoutSync();
+		const unsubscribeSync = subscribe( applyLayoutSync, 'core/block-editor' );
 
 		// Editor canvas iframe mounts asynchronously and may reload (e.g.
 		// when toggling device preview). Watch for its load event so we
@@ -140,12 +255,18 @@ function ContentSizeSync() {
 		if ( ! iframe ) {
 			// Iframe may not exist yet — retry once after it likely mounts.
 			const timer = setTimeout( () => applyContentSizeCss( css ), 500 );
-			return () => clearTimeout( timer );
+			return () => {
+				clearTimeout( timer );
+				unsubscribeSync();
+			};
 		}
 		const onLoad = () => applyContentSizeCss( css );
 		iframe.addEventListener( 'load', onLoad );
-		return () => iframe.removeEventListener( 'load', onLoad );
-	}, [ css ] );
+		return () => {
+			iframe.removeEventListener( 'load', onLoad );
+			unsubscribeSync();
+		};
+	}, [ css, size, wideSize ] );
 
 	return null;
 }
@@ -158,6 +279,7 @@ const CONTENT_LAYOUT_OPTIONS = [
 	{ label: __( 'Default', 'customify' ),                 value: '' },
 	{ label: __( 'Full Width', 'customify' ),               value: 'full-width' },
 	{ label: __( 'Full Width – Stretched', 'customify' ),   value: 'full-stretched' },
+	{ label: __( 'Narrow', 'customify' ),                   value: 'narrow' },
 ];
 
 const SIDEBAR_OPTIONS = [

--- a/src/frontend/scss/base/_base.scss
+++ b/src/frontend/scss/base/_base.scss
@@ -70,6 +70,12 @@ h2,
         border-top: 1px solid $color_border;
         padding-top: ms(-3);
     }
+    // Ported from colors.php $border_css. Comments title (typically `h2.comments-title`)
+    // sibling-after `h2` or `.h2` inside `.comments-area` gets the same divider
+    // pattern as `h2 + h3` above.
+    .comments-area &+.comments-title {
+        border-top-color: $color_border;
+    }
     @include for_device(tablet) {
         font-size: 1.9em;
     }
@@ -960,6 +966,9 @@ article.comment {
     color: $color_meta;
 }
 
+// Ported from colors.php $link_hover_css. Bare `.link-meta:hover`
+// (parent hover) shares the same link-hover token as the anchor child.
+.link-meta:hover,
 .link-meta a:hover {
     color: $color_link_hover;
 }

--- a/src/frontend/scss/base/_base.scss
+++ b/src/frontend/scss/base/_base.scss
@@ -407,12 +407,14 @@ select {
 // `.customize-partial-edit-shortcut-button`, `.lightbox-trigger`,
 // `.ed_button`, `.menu-mobile-toggle`) are not `wp-block-` prefixed,
 // so they still need their own slot.
-.button:not([class*="wp-block-"]),
-button:not(.menu-mobile-toggle, .components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"]),
-input[type="button"]:not(.ed_button, [class*="wp-block-"]),
-.button:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
+.button:not(
+    [class*="wp-block-"],
+    .menu-mobile-toggle,
+    .components-button,
+    .customize-partial-edit-shortcut-button
+),
 button:not(.components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"]),
-input[type="button"]:not(.ed_button, .components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
+input[type="button"]:not(.ed_button, [class*="wp-block-"]),
 input[type="reset"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
 .wc-block-cart__submit .wp-element-button,
 .wp-block-button__link,

--- a/src/frontend/scss/base/_base.scss
+++ b/src/frontend/scss/base/_base.scss
@@ -440,7 +440,7 @@ input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-bu
     align-items: center;
     justify-content: center;
     gap: 0.5em;
-    &:not(.menu-mobile-toggle):hover {
+    &:not(.menu-mobile-toggle, .search-submit):hover {
         box-shadow: inset 0 0 0 120px rgba(0, 0, 0, 0.18);
     }
     &:hover {

--- a/src/frontend/scss/base/_base.scss
+++ b/src/frontend/scss/base/_base.scss
@@ -407,9 +407,9 @@ select {
 // `.customize-partial-edit-shortcut-button`, `.lightbox-trigger`,
 // `.ed_button`, `.menu-mobile-toggle`) are not `wp-block-` prefixed,
 // so they still need their own slot.
-body:not(.fl-builder-edit) .button:not([class*="wp-block-"]),
-body:not(.fl-builder-edit) button:not(.menu-mobile-toggle, .components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"]),
-body:not(.fl-builder-edit) input[type="button"]:not(.ed_button, [class*="wp-block-"]),
+.button:not([class*="wp-block-"]),
+button:not(.menu-mobile-toggle, .components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"]),
+input[type="button"]:not(.ed_button, [class*="wp-block-"]),
 .button:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
 button:not(.components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"]),
 input[type="button"]:not(.ed_button, .components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
@@ -474,9 +474,9 @@ input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-bu
 
 // Same `[class*="wp-block-"]` carve-out as above so WP default-block
 // chrome doesn't inherit the primary-color background fill.
-body:not(.fl-builder-edit) .button:not([class*="wp-block-"]),
-body:not(.fl-builder-edit) button:not(.menu-mobile-toggle, .components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"]),
-body:not(.fl-builder-edit) input[type="button"]:not(.ed_button, [class*="wp-block-"]),
+.button:not([class*="wp-block-"]),
+button:not(.menu-mobile-toggle, .components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"]),
+input[type="button"]:not(.ed_button, [class*="wp-block-"]),
 .button:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
 input[type="button"]:not(.ed_button, .components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
 input[type="reset"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),

--- a/src/frontend/scss/base/_base.scss
+++ b/src/frontend/scss/base/_base.scss
@@ -395,17 +395,29 @@ select {
     }
 }
 
-body:not(.fl-builder-edit) .button,
-body:not(.fl-builder-edit) button:not(.menu-mobile-toggle, .components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, .wp-block-navigation__submenu-icon),
-body:not(.fl-builder-edit) input[type="button"]:not(.ed_button),
-.button:not(.components-button, .customize-partial-edit-shortcut-button),
-button:not(.components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, .wp-block-navigation__submenu-icon),
-input[type="button"]:not(.ed_button, .components-button, .customize-partial-edit-shortcut-button),
-input[type="reset"]:not(.components-button, .customize-partial-edit-shortcut-button),
+// `[class*="wp-block-"]` in the :not() lists peels off ANY element whose
+// class contains a `wp-block-*` token — that's how WP default blocks
+// (Search submit, File download, Embed "Try again", Latest Posts CTA,
+// etc.) render their internal chrome buttons. Editor canvas + frontend
+// both stop applying the broad theme button styling to those, while the
+// intentionally-styled content buttons (`.wp-block-button__link`,
+// `.wp-element-button`, `.wc-block-cart__submit .wp-element-button`)
+// stay listed explicitly so they still pick up the theme look.
+// The single-class exclusions kept below (`.components-button`,
+// `.customize-partial-edit-shortcut-button`, `.lightbox-trigger`,
+// `.ed_button`, `.menu-mobile-toggle`) are not `wp-block-` prefixed,
+// so they still need their own slot.
+body:not(.fl-builder-edit) .button:not([class*="wp-block-"]),
+body:not(.fl-builder-edit) button:not(.menu-mobile-toggle, .components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"]),
+body:not(.fl-builder-edit) input[type="button"]:not(.ed_button, [class*="wp-block-"]),
+.button:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
+button:not(.components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"]),
+input[type="button"]:not(.ed_button, .components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
+input[type="reset"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
 .wc-block-cart__submit .wp-element-button,
 .wp-block-button__link,
 .wp-element-button:not(.components-button),
-input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-button) {
+input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]) {
     border: none;
     cursor: pointer;
     padding: 0px 1.3em;
@@ -460,16 +472,17 @@ input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-bu
     }
 }
 
-body:not(.fl-builder-edit) .button,
-body:not(.fl-builder-edit) button:not(.menu-mobile-toggle, .components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, .wp-block-navigation__submenu-icon),
-body:not(.fl-builder-edit) input[type="button"]:not(.ed_button),
-.button:not(.components-button):not(.customize-partial-edit-shortcut-button),
-input[type="button"]:not(.ed_button),
-input[type="button"]:not(.components-button):not(.customize-partial-edit-shortcut-button),
-input[type="reset"]:not(.components-button):not(.customize-partial-edit-shortcut-button),
+// Same `[class*="wp-block-"]` carve-out as above so WP default-block
+// chrome doesn't inherit the primary-color background fill.
+body:not(.fl-builder-edit) .button:not([class*="wp-block-"]),
+body:not(.fl-builder-edit) button:not(.menu-mobile-toggle, .components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"]),
+body:not(.fl-builder-edit) input[type="button"]:not(.ed_button, [class*="wp-block-"]),
+.button:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
+input[type="button"]:not(.ed_button, .components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
+input[type="reset"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
 .wp-block-button__link,
 .wp-element-button:not(.components-button),
-input[type="submit"]:not(.components-button):not(.customize-partial-edit-shortcut-button) {
+input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]) {
     color: var(--customify-on-primary, #ffffff);
     background: $color_primary;
     &:focus {
@@ -477,10 +490,10 @@ input[type="submit"]:not(.components-button):not(.customize-partial-edit-shortcu
     }
 }
 
-.button[disabled]:not(.components-button):not(.customize-partial-edit-shortcut-button),
-button[disabled]:not(.components-button):not(.customize-partial-edit-shortcut-button),
-button.disabled:not(.components-button):not(.customize-partial-edit-shortcut-button),
-.button.disabled:not(.components-button):not(.customize-partial-edit-shortcut-button) {
+.button[disabled]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
+button[disabled]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
+button.disabled:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
+.button.disabled:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]) {
     opacity: 0.5;
 }
 

--- a/src/frontend/scss/base/_blocks.scss
+++ b/src/frontend/scss/base/_blocks.scss
@@ -57,8 +57,8 @@
 	max-width: 100vw;
 	margin-top: 1.5em;
 	margin-bottom: 1.5em;
-	margin-left: calc(50% - 50vw) !important;
-	margin-right: calc(50% - 50vw) !important;
+	margin-left: calc(50% - 50vw);
+	margin-right: calc(50% - 50vw);
 	box-sizing: border-box;
 }
 

--- a/src/frontend/scss/base/_blocks.scss
+++ b/src/frontend/scss/base/_blocks.scss
@@ -312,25 +312,16 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 	background-color: $surface_medium;
 }
 
-.entry-content li:not([class*="wp-block-"] li) {
-	margin-left: 2.5em;
+.wp-block-list li {
+	margin-left: 1em;
 	margin-bottom: 6px;
-}
-
-.entry-content ul ul:not([class*="wp-block-"] ul),
-.entry-content ol ol,
-.entry-content ul ol,
-.entry-content ol ul:not([class*="wp-block-"] ul) {
-	margin-bottom: 0px;
-	margin-top: 0px;
-	margin-left: 2.5em;
-}
-
-.entry-content ul ul li,
-.entry-content ol ol li,
-.entry-content ul ol li,
-.entry-content ol ul li {
-	margin-left: 0;
+	li {
+		margin-left: 2.5em;
+	}
+	ol, ul {
+		margin-top: 0px;
+		margin-left: 0px;
+	}
 }
 
 .wp-block-embed.is-type-video {

--- a/src/frontend/scss/base/_blocks.scss
+++ b/src/frontend/scss/base/_blocks.scss
@@ -294,15 +294,15 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 	background-color: $surface_medium;
 }
 
-.entry-content li:not(.wp-block-navigation li) {
+.entry-content li:not([class*="wp-block-"] li) {
 	margin-left: 2.5em;
 	margin-bottom: 6px;
 }
 
-.entry-content ul ul:not(.wp-block-navigation ul),
+.entry-content ul ul:not([class*="wp-block-"] ul),
 .entry-content ol ol,
 .entry-content ul ol,
-.entry-content ol ul:not(.wp-block-navigation ul) {
+.entry-content ol ul:not([class*="wp-block-"] ul) {
 	margin-bottom: 0px;
 	margin-top: 0px;
 	margin-left: 2.5em;

--- a/src/frontend/scss/base/_blocks.scss
+++ b/src/frontend/scss/base/_blocks.scss
@@ -8,12 +8,13 @@
 	margin-right: auto;
 }
 
-// Default blocks are constrained to --wp--style--global--content-size, which is set by
-// theme.json on body and overridden per layout via customify_layout_content_size_css()
-// (inc/template-functions.php). Skip when `.site-content.content-full-stretched` is
-// the context — stretched mode disables content-width constraints so blocks expand
-// to fit the container.
-.site-content:not(.content-full-stretched)
+// Default blocks are constrained to --wp--style--global--content-size, which is
+// set per layout by customify_layout_content_size_css() (inc/template-functions.php):
+//   - reading-column layouts (default no-sidebar, single sidebars, two sidebars) →
+//     fixed-px value capped at the typography readability target
+//   - full-width / full-stretched / narrow → viewport-bound or Customizer-driven
+// No exclusion list needed here — the content-size var itself adapts to context.
+.site-content
 	.entry-content
 	> *:not(.alignwide):not(.alignfull) {
 	max-width: var(--wp--style--global--content-size, 863px);
@@ -26,11 +27,28 @@
 
 // alignwide / alignfull — modern margin-based approach (no transform hack).
 // Works for all layouts. Uses CSS vars from theme.json when available.
+//
+// alignwide: dynamic breakout (per Customizer narrow_width / container_width).
+//   - --wp--style--global--wide-size is set per layout by customify_layout_content_size_css()
+//     (no-sidebar = content+400, narrow = narrow_width+400, sidebar = content).
+//   - The block is centered via negative margin when wider than its parent.
+//   - max() floor at 100% ensures wide is never narrower than the parent content
+//     column (so a narrow viewport never makes alignwide visually shrink BELOW
+//     align=none — keeps cascade intent: "wide ≥ none, always").
+//   - min() ceiling at (100vw - 32px) prevents the breakout from overflowing the
+//     viewport — the block dynamically shrinks the breakout (down to 0/side at
+//     tiny viewports) instead of triggering horizontal scroll.
+//   - Negative inline margins center the over-wide box back across the parent's
+//     midline. Same approach as alignfull's calc(50% - 50vw) but bounded.
 .entry-content > .alignwide {
-	max-width: var(--wp--style--global--wide-size, 1200px);
-	width: 100%;
+	--customify-alignwide-actual: max(
+		100%,
+		min(var(--wp--style--global--wide-size, 1200px), calc(100vw - 32px))
+	);
+	width: var(--customify-alignwide-actual);
+	margin-left: calc((100% - var(--customify-alignwide-actual)) / 2);
+	margin-right: calc((100% - var(--customify-alignwide-actual)) / 2);
 	box-sizing: border-box;
-	// margin-left/right: auto is already inherited from `.entry-content > *` above.
 }
 
 .entry-content > .alignfull {

--- a/src/frontend/scss/base/_comments.scss
+++ b/src/frontend/scss/base/_comments.scss
@@ -71,6 +71,10 @@ article.comment {
 		margin: 12px 0px 12px;
 		padding-bottom: 4px;
 		border-bottom: 1px solid $color_border;
+		// Ported from colors.php $border_css. All-sides `border-color`
+		// only takes effect when other rules add border width/style on
+		// the remaining sides; preserves the Border token wiring.
+		border-color: $color_border;
 		.comment-edit-link {
 			margin-left: 10px;
 		}

--- a/src/frontend/scss/compatibility/wc/_wc-cart-checkout.scss
+++ b/src/frontend/scss/compatibility/wc/_wc-cart-checkout.scss
@@ -72,6 +72,9 @@ form.woocommerce-checkout {
 .woocommerce-checkout,
 #add_payment_method {
     table.cart {
+        .product-remove {
+            width: 20px;
+        }
         .product-thumbnail {
             width: 100px;
         }

--- a/src/frontend/scss/compatibility/wc/_wc-elements.scss
+++ b/src/frontend/scss/compatibility/wc/_wc-elements.scss
@@ -28,6 +28,15 @@
 	}
 }
 
+// Ported from WC compat filter `customify/styling/secondary-color`. The
+// `.button.add_to_cart_button` rule above is higher-specificity and includes
+// color+hover; this bare-class rule mirrors the filter declaration exactly
+// (background-color only) for any `.add_to_cart_button` element that lacks
+// the `.button` compound class.
+.add_to_cart_button {
+	background-color: $color_secondary;
+}
+
 .products {
 	.button.add_to_cart_button,
 	.button.added_to_cart,

--- a/src/frontend/scss/compatibility/wc/_wc-loop.scss
+++ b/src/frontend/scss/compatibility/wc/_wc-loop.scss
@@ -146,6 +146,11 @@
     .wc-product__rating {
         line-height: 1;
     }
+    // Ported from WC compat filter `customify/styling/color-meta`.
+    // Category link inside the product card consumes the muted text token.
+    .wc-product__category a {
+        color: $color_meta;
+    }
 }
 
 // Secondary image when hover if exist

--- a/src/frontend/scss/compatibility/wc/_wc-single-product.scss
+++ b/src/frontend/scss/compatibility/wc/_wc-single-product.scss
@@ -102,6 +102,11 @@ Product Slider
         display: block;
         padding: 6px 0px;
         border-top: 1px dotted $color_border;
+        // Ported from WC compat filter `customify/styling/color-border`.
+        // All-sides `border-color` only takes effect when other rules add
+        // border width/style on the remaining sides; preserves the Border
+        // token wiring exactly as the inline filter emitted it.
+        border-color: $color_border;
     }
 }
 
@@ -127,6 +132,9 @@ Product Slider
     &.wc-tabs-horizontal {
         ul.tabs {
             border-bottom: 1px solid $color_border;
+            // Ported from WC compat filter `customify/styling/color-border`.
+            // All-sides preservation; only affects sides with width/style.
+            border-color: $color_border;
             li {
                 border-bottom: 1px solid transparent;
                 display: inline-block;
@@ -148,6 +156,11 @@ Product Slider
                 &.active {
                     z-index: 2;
                     border-bottom-color: $color_primary;
+                    // Ported from WC compat filter `customify/styling/primary-color`.
+                    // All-sides `border-color` takes effect when other rules add
+                    // border width/style on the remaining sides; preserves the
+                    // Primary token wiring for active tabs in all border directions.
+                    border-color: $color_primary;
                     a {
                         color: $color_primary;
                         text-shadow: inherit;
@@ -173,8 +186,15 @@ Product Slider
             }
             li {
                 border-bottom: 1px solid $color_border;
+                // Ported from WC compat filter `customify/styling/color-border`.
+                // All-sides preservation per inline filter declaration.
+                border-color: $color_border;
                 &:first-child {
                     border-top: 1px solid $color_border;
+                    // Same all-sides preservation as parent — filter selector
+                    // `.wc-tabs-vertical .wc-tabs li:first-child` distinct from
+                    // the general `.wc-tabs li` rule above.
+                    border-color: $color_border;
                 }
                 &:after {
                     content: '';
@@ -309,6 +329,16 @@ Section and Toggle
 }
 .tab-section-content {
     padding-top: 1em;
+}
+
+// Ported from WC compat filter `customify/styling/primary-color`. `.wc-single-tabs`
+// is a WC-specific single-product tabs container; active tab anchor and section
+// heading anchor consume the Primary token.
+.wc-single-tabs {
+    ul.tabs li.active a,
+    .tab-section.active .tab-section-heading a {
+        color: $color_primary;
+    }
 }
 
 

--- a/src/frontend/scss/compatibility/wc/_woocommerce-main.scss
+++ b/src/frontend/scss/compatibility/wc/_woocommerce-main.scss
@@ -58,46 +58,49 @@ p.demo_store,
  * Main WooCommerce styles
  */
 
-/**
-* Quantity input
- */
-.input-qty-pm {
-    border-radius: 1px;
-    display: inline-flex;
-    align-items: center;
-    flex-wrap: wrap;
-    border: 1px solid #E5E5E5;
-    background: #f2f2f2;
-    color: inherit;
-    input, input[type="text"] {
-        box-shadow: none !important;
-        border-radius: 0px;
-        border-top: none;
-        border-bottom: none;
-    }
-    .input-pm-act {
-        text-align: center;
-        line-height: 2.2em;
-        min-height: 2.6em;
-        padding: 0px 0.2em;
-        min-width: 1.5em;
-        cursor: pointer;
-        -webkit-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
-        user-select: none;
-        box-shadow: none;
-        font-weight: 400;
-        background: #f9f9f9;
-        &:hover {
-            background: #f0f0f0;
-            color: inherit;
-        }
-    }
-}
 
 
 .woocommerce {
+    /**
+    * Quantity input 
+    */
+    .input-qty-pm {
+        border-radius: 1px;
+        display: inline-flex;
+        align-items: center;
+        flex-wrap: wrap;
+        border: 1px solid #E5E5E5;
+        background-color: #f2f2f2;
+        color: inherit;
+        input, input[type="text"] {
+            box-shadow: none !important;
+            border-radius: 0px;
+            border-top: none;
+            border-bottom: none;
+        }
+        .input-pm-act, input.input-pm-act{
+            text-align: center;
+            line-height: 2.2em;
+            min-height: 2.6em;
+            padding: 0px 0.2em;
+            min-width: 1.5em;
+            cursor: pointer;
+            aspect-ratio: 1/1;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+            box-shadow: none;
+            font-weight: 400;
+            background: #f9f9f9;
+            color: var(--customify-text-muted, #686868);
+            &:hover {
+                background: #f0f0f0;
+                color: inherit;
+            }
+        }
+    }
+
     .blockUI.blockOverlay {
         position: relative;
         z-index: 35 !important;

--- a/src/frontend/scss/compatibility/woocommerce-smallscreen.scss
+++ b/src/frontend/scss/compatibility/woocommerce-smallscreen.scss
@@ -6,207 +6,208 @@
 /**
  * Imports
  */
-@import '../utils/vars';
+@import "../utils/vars";
 @import "../utils/mixins";
 
-/**
+@media (max-width: 560px) {
+	/**
  * Style begins
  */
-.woocommerce,
-.woocommerce-page {
-
-	table.shop_table_responsive {
-		thead {
-			display: none;
-		}
-
-		tbody {
-			tr:first-child {
-				td:first-child {
-					border-top: 0;
-				}
-			}
-
-			th {
+	.woocommerce,
+	.woocommerce-page {
+		table.shop_table_responsive {
+			thead {
 				display: none;
 			}
-		}
 
-		tr {
-			display: block;
+			tbody {
+				tr:first-child {
+					td:first-child {
+						border-top: 0;
+					}
+				}
 
-			td {
+				th {
+					display: none;
+				}
+			}
+
+			tr {
 				display: block;
-				text-align: right !important; // Important to overwrite order status inline styling
 
-				&.order-actions {
-					text-align: left !important; // This must always align left on handheld
-				}
+				td {
+					display: block;
+					text-align: right !important; // Important to overwrite order status inline styling
 
-				&::before {
-					content: attr(data-title) ': ';
-					font-weight: 700;
-					float: left;
-				}
+					&.order-actions {
+						text-align: left !important; // This must always align left on handheld
+					}
 
-				&.product-remove,
-				&.actions {
 					&::before {
-						display: none;
+						content: attr(data-title) ": ";
+						font-weight: 700;
+						float: left;
+					}
+
+					&.product-remove,
+					&.actions {
+						&::before {
+							display: none;
+						}
 					}
 				}
 			}
 		}
-	}
 
-	table.my_account_orders {
-		tr {
-			td {
-				&.order-actions {
-					text-align: left;
+		table.my_account_orders {
+			tr {
+				td {
+					&.order-actions {
+						text-align: left;
 
-					&::before {
-						display: none;
-					}
+						&::before {
+							display: none;
+						}
 
-					.button {
-						float: none;
-						margin: 0.125em 0.25em 0.125em 0;
+						.button {
+							float: none;
+							margin: 0.125em 0.25em 0.125em 0;
+						}
 					}
 				}
 			}
 		}
-	}
 
-	/**
+		/**
 	 * General layout
 	 */
-	.col2-set {
-		.col-1,
-		.col-2 {
-			float: none;
-			width: 100%;
+		.col2-set {
+			.col-1,
+			.col-2 {
+				float: none;
+				width: 100%;
+			}
 		}
-	}
 
-	/**
+		/**
 	 * Products
 	 */
-	ul.products[class*='columns-'] {
-		li.product {
-			width: 48%;
-			float: left;
-			clear: both;
-			margin: 0 0 2.992em;
+		ul.products[class*="columns-"] {
+			li.product {
+				width: 48%;
+				float: left;
+				clear: both;
+				margin: 0 0 2.992em;
 
-			&:nth-child( 2n ) {
-				float: right;
-				clear: none !important; // This should never clear.
+				&:nth-child(2n) {
+					float: right;
+					clear: none !important; // This should never clear.
+				}
 			}
 		}
-	}
 
-	/**
+		/**
 	 * Product Details
 	 */
-	div.product,
-	#content div.product {
-		div.images,
-		div.summary {
-			float: none;
-			width: 100%;
+		div.product,
+		#content div.product {
+			div.images,
+			div.summary {
+				float: none;
+				width: 100%;
+			}
 		}
-	}
 
-	/**
+		/**
 	 * Cart
 	 */
-	table.cart,
-	#content table.cart {
-		.product-thumbnail {
-			display: none;
+		table.cart,
+		#content table.cart {
+			.product-thumbnail {
+				display: none;
+			}
+
+			td.actions {
+				text-align: left;
+
+				.coupon {
+					float: none;
+					@include clearfix();
+					padding-bottom: 0.5em;
+					width: 100%;
+				}
+				> .button {
+					width: 100%;
+				}
+			}
 		}
 
-		td.actions {
-			text-align: left;
-
-			.coupon {
+		.cart-collaterals {
+			.cart_totals,
+			.shipping_calculator,
+			.cross-sells {
+				width: 100%;
 				float: none;
-				@include clearfix();
-				padding-bottom: 0.5em;
-				width: 100%;
-			}
-			> .button {
-				width: 100%;
+				text-align: left;
 			}
 		}
-	}
 
-	.cart-collaterals {
-		.cart_totals,
-		.shipping_calculator,
-		.cross-sells {
-			width: 100%;
-			float: none;
-			text-align: left;
-		}
-	}
-
-	/**
+		/**
 	 * Checkout
 	 */
-	&.woocommerce-checkout {
-		form.login {
-			.form-row {
+		&.woocommerce-checkout {
+			form.login {
+				.form-row {
+					width: 100%;
+					float: none;
+				}
+			}
+		}
+
+		#payment {
+			.terms {
+				text-align: left;
+				padding: 0;
+			}
+
+			#place_order {
+				float: none;
+				width: 100%;
+				box-sizing: border-box;
+				margin-bottom: 1em;
+			}
+		}
+
+		/**
+	 * Account
+	 */
+		.lost_reset_password {
+			.form-row-first,
+			.form-row-last {
 				width: 100%;
 				float: none;
+				margin-right: 0;
 			}
 		}
 	}
 
-	#payment {
-		.terms {
-			text-align: left;
-			padding: 0;
-		}
-
-		#place_order {
+	.woocommerce-account {
+		.woocommerce-MyAccount-navigation,
+		.woocommerce-MyAccount-content {
 			float: none;
 			width: 100%;
-			box-sizing: border-box;
-			margin-bottom: 1em;
 		}
 	}
 
 	/**
-	 * Account
-	 */
-	.lost_reset_password {
-		.form-row-first,
-		.form-row-last {
-			width: 100%;
-			float: none;
-			margin-right: 0;
-		}
-	}
-}
-
-.woocommerce-account {
-	.woocommerce-MyAccount-navigation,
-	.woocommerce-MyAccount-content {
-		float: none;
-		width: 100%;
-	}
-}
-
-/**
  * Twenty Thirteen specific styles
  */
-.single-product {
-	.twentythirteen {
-		.panel {
-			padding-left: 20px !important;
-			padding-right: 20px !important;
+	.single-product {
+		.twentythirteen {
+			.panel {
+				padding-left: 20px !important;
+				padding-right: 20px !important;
+			}
 		}
 	}
 }

--- a/src/frontend/scss/compatibility/woocommerce.scss
+++ b/src/frontend/scss/compatibility/woocommerce.scss
@@ -61,6 +61,16 @@
     }
 }
 
+// Ported from WC compat filter `customify/styling/link-color`. Wins over the
+// `.is-active a { color: $color_link_hover }` rule above via source order —
+// matches the legacy behavior where the inline filter rule was always emitted
+// after the bundled stylesheet. Also covers `a:hover` which the SCSS block
+// above does not set explicitly.
+.woocommerce-account .woocommerce-MyAccount-navigation ul li.is-active a,
+.woocommerce-account .woocommerce-MyAccount-navigation ul li a:hover {
+    color: $color_link;
+}
+
 .footer_payment_methods {
     display: inline-block;
     margin: 0px;

--- a/src/frontend/scss/footer/_footer-common.scss
+++ b/src/frontend/scss/footer/_footer-common.scss
@@ -226,32 +226,10 @@
 	}
 }
 
-// Responsive fallbacks — used when the PHP col_layout CSS is absent (e.g. old saved data).
-// PHP-generated CSS (id+class specificity) overrides these when col_layout is configured.
-@media (max-width: 1024px) {
-	#cb-row--footer-main,
-	#cb-row--footer-bottom {
-		.row-v2 {
-			grid-template-columns: repeat(2, 1fr);
-		}
-	}
-
-	// Class-based tablet fallback: 2 equal columns.
-	.footer--row .row-v2[class*="no-col"] {
-		grid-template-columns: repeat(2, 1fr);
-	}
-}
-
-@media (max-width: 767px) {
-	#cb-row--footer-main,
-	#cb-row--footer-bottom {
-		.row-v2 {
-			grid-template-columns: 1fr;
-		}
-	}
-
-	// Class-based mobile fallback: single column.
-	.footer--row .row-v2[class*="no-col"] {
-		grid-template-columns: 1fr;
-	}
-}
+// Tablet/mobile responsive fallbacks intentionally removed: PHP
+// customify_footer_row_layout_css() always emits grid-template-columns
+// for every footer row now (config-default.php seeds a per-row default
+// when nothing is saved), so a SCSS fallback only competed with the
+// PHP rule and risked confusion on extension-added rows. If a 3rd-party
+// row needs a different mobile/tablet collapse, it should register a
+// matching default via the `customify/customize/settings-default` filter.

--- a/src/frontend/scss/header/_header_builder_common.scss
+++ b/src/frontend/scss/header/_header_builder_common.scss
@@ -112,6 +112,11 @@
 // Breadcrumbs
 .page-breadcrumb {
 	padding: 9px 0px 9px;
+	// Ported from colors.php $border_css. `border-top-color` only takes
+	// visible effect when a border-top width/style is defined elsewhere
+	// (e.g. inline customizer styling); preserved here so any such border
+	// inherits the same Border token.
+	border-top-color: $color_border;
 	border-bottom: 1px solid $color_border;
 	color: $color_meta;
 	line-height: 1.6;

--- a/src/frontend/scss/header/_header_top.scss
+++ b/src/frontend/scss/header/_header_top.scss
@@ -14,4 +14,11 @@
     .dark-mode {
         background: $color_primary;
     }
+    // Ported from pre-4b5acc73 colors.php $primary_css. Inner row picks up
+    // the Primary token regardless of light/dark mode of the row chrome.
+    // (Commit 4b5acc73 dropped this when collapsing primary CSS to :root —
+    // recorded as a known follow-up in that commit message.)
+    .header--row-inner {
+        background-color: $color_primary;
+    }
 }

--- a/src/frontend/scss/header/builder_items/_navigation.scss
+++ b/src/frontend/scss/header/builder_items/_navigation.scss
@@ -213,6 +213,18 @@
                  }
              }
         }
+        // Ported from pre-4b5acc73 colors.php $primary_css. `.primary-menu-ul`
+        // is the canonical class for the desktop primary menu (see
+        // inc/customizer/configs/header/menus.php). The generic `.nav-menu`
+        // rules above use `$color_link`; this primary-scoped rule uses
+        // `$color_primary` so the actual brand menu honors the Primary token
+        // even when the Link token is overridden separately.
+        .primary-menu-ul {
+            > li:is(.current-menu-item, .current-menu-ancestor) > a,
+            > li > a:hover {
+                background-color: $color_primary;
+            }
+        }
     } // End style full height
 
     // Menu style border bottom

--- a/src/frontend/scss/header/builder_items/_search.scss
+++ b/src/frontend/scss/header/builder_items/_search.scss
@@ -73,6 +73,7 @@
 // Apply for all search form at header
 .header-search-form {
 	display: flex;
+	align-items: center;
 	margin-bottom: 0px;
 	width: 100%;
 	max-width: 100%;
@@ -85,6 +86,7 @@
 		border-color: rgba(127, 127, 127, 0.2);
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12) inset;
 		border-radius: 2px;
+		height: 100%;
 	}
 	.search-field {
 		display: block;
@@ -107,7 +109,7 @@
 		background: transparent;
 		color: $color_meta;
 		line-height: 0px;
-		padding: 0px 0.7em;
+		padding: 0.6em 0.7em;
 		min-height: auto;
 		&:hover {
 			box-shadow: none;
@@ -181,6 +183,7 @@
 			overflow: hidden;
 			.search-form-fields {
 				background-color: transparent;
+				height: 100%;
 				min-height: auto;
 				-ms-flex-preferred-size: 100%;
 				flex-basis: 100%;

--- a/src/frontend/scss/header/builder_items/_search.scss
+++ b/src/frontend/scss/header/builder_items/_search.scss
@@ -96,7 +96,7 @@
 			background-color: transparent;
 		}
 	}
-	button.search-submit {
+	.search-submit {
 		overflow: hidden;
 		box-shadow: none;
 		margin-left: -40px;

--- a/src/frontend/scss/header/builder_items/_search.scss
+++ b/src/frontend/scss/header/builder_items/_search.scss
@@ -91,6 +91,10 @@
 		width: 100%;
 		border-radius: 2px;
 		height: 2.4em;
+		// Ported from colors.php $border_css. `border-color` here applies
+		// when the input has a default UA border or when other rules add
+		// border width/style — preserves the Border token wiring.
+		border-color: $color_border;
 
 		&:focus {
 			background-color: transparent;

--- a/src/frontend/scss/layouts/_blogs.scss
+++ b/src/frontend/scss/layouts/_blogs.scss
@@ -45,6 +45,11 @@ $blog_gutter: $gl-gutter;
         align-items: stretch;
         width: 100%;
         border-bottom: 1px solid $color_border;
+        // Ported from colors.php $border_css. All-sides `border-color` only
+        // takes effect when other rules (theme.json, customizer styling)
+        // add border width/style on the remaining sides; preserves the
+        // Border token wiring for those cases.
+        border-color: $color_border;
         padding-bottom: 2em;
         @include for_device( mobile ){
             display: block;
@@ -441,6 +446,19 @@ $blog_gutter: $gl-gutter;
     .author-bio-desc p:last-child {
         margin-bottom: 0.72em;
     }
+}
+
+// Ported from colors.php $border_css. These selectors set color-only
+// (`border-color`) on elements whose border width/style is supplied by
+// other stylesheets (UA defaults, theme.json, customizer styling). The
+// Border token (`$color_border`) keeps them on the same palette as the
+// rest of the blog chrome. `.cat-links` retained verbatim from the
+// legacy template for parity — markup uses `.cats-links` (with s), so
+// this selector is currently dead but kept to mirror the inline source.
+.entry-footer .tags-links a,
+.entry-footer .cat-links a,
+.search .content-area article {
+    border-color: $color_border;
 }
 
 .post-navigation .nav-links {

--- a/src/frontend/scss/layouts/_layouts.scss
+++ b/src/frontend/scss/layouts/_layouts.scss
@@ -63,6 +63,22 @@
     margin: 0 auto;
 }
 
+// Site content full-width mode — mirrors the header `.layout-fullwidth`
+// pattern (`_header_builder_common.scss:34-38`). Customizer field
+// `site_content_layout` writes class `site-content-fullwidth` onto
+// `.site-content`; this rule lets the inner container escape the
+// default 1248px max-width and span the viewport.
+//
+// The companion class `site-content-boxed` deliberately has no rule —
+// boxed = default behavior of `.customify-container` above. Setting
+// default is `site-content-boxed`, so 30K legacy sites that never
+// touched the radio keep rendering the same boxed layout.
+.site-content-fullwidth {
+    .customify-container {
+        max-width: initial;
+    }
+}
+
 .site-content {
     // Hard-coded `#fff` overrode the body bg and broke dark-Palette sites:
     // setting Base=#000 made the body dark but `.site-content` still painted

--- a/src/frontend/scss/utils/_vars.scss
+++ b/src/frontend/scss/utils/_vars.scss
@@ -29,10 +29,11 @@ $color_text:        var(--customify-body-text, #686868);
 $color_heading:     var(--customify-heading, #2b2b2b);
 $color_primary:     var(--customify-primary, #235787);
 $color_secondary:   var(--customify-secondary, #c3512f);
-$color_link:        var(--customify-link, #1e4b75);
+$color_link:        var(--customify-link, #235787);
 $color_link_hover:  var(--customify-link-hover, #111111);
-$color_border:      var(--customify-border, color-mix(in srgb, currentcolor 14%, transparent));
+$color_border:      var(--customify-border, color-mix(in srgb, currentcolor 9%, transparent));
 $color_meta:        var(--customify-text-muted, #6d6d6d);
+$color_widget_title: var(--customify-widget-title, #2b2b2b);
 
 // Surface tints — adaptive `currentcolor` fallback so block elements
 // (table rows, code blocks, calendar headers, form inputs) stay readable

--- a/src/frontend/scss/widgets/_widgets.scss
+++ b/src/frontend/scss/widgets/_widgets.scss
@@ -7,6 +7,14 @@
 	margin-bottom: 20px;
 }
 
+// Ported from colors.php $w_title_css. Scope `.site-content` preserved
+// from inline rule so footer/header dark-theme widget-titles keep
+// inheriting their context color (currentColor on bare `.widget-title`).
+// Token bound via --customify-widget-title at :root by colors-palette.php.
+.site-content .widget-title {
+	color: $color_widget_title;
+}
+
 .widget_block {
 
 	h1,

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://pressmaximum.com/customify
 Author: WPCustomify
 Author URI: https://pressmaximum.com
 Description: Customify is fast, lightweight, responsive and super flexible multipurpose theme built with SEO, speed, and usability in mind. Unleash the power of your imagination with a true WYSIWYG Header & Footer builder (inside the WordPress Customizer) built exclusively for this theme. The theme works great with any of your favorite page builder likes Elementor, Beaver Builder, SiteOrigin, Thrive Architect, Divi, Visual Composer, etc. Combined with the Header & Footer builder, you can build any type of websites like shop, business agencies, corporate, portfolio, education, university portal, consulting, church, restaurant, medical and so on. Customify is compatible with all well-coded plugins, including major ones like WooCommerce, OrbitFox, Yoast, BuddyPress, bbPress, etc. Learn more about the theme and ready to import demo sites at https://pressmaximum.com/customify
-Version: 0.4.15
+Version: 0.4.16
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: customify

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://pressmaximum.com/customify
 Author: WPCustomify
 Author URI: https://pressmaximum.com
 Description: Customify is fast, lightweight, responsive and super flexible multipurpose theme built with SEO, speed, and usability in mind. Unleash the power of your imagination with a true WYSIWYG Header & Footer builder (inside the WordPress Customizer) built exclusively for this theme. The theme works great with any of your favorite page builder likes Elementor, Beaver Builder, SiteOrigin, Thrive Architect, Divi, Visual Composer, etc. Combined with the Header & Footer builder, you can build any type of websites like shop, business agencies, corporate, portfolio, education, university portal, consulting, church, restaurant, medical and so on. Customify is compatible with all well-coded plugins, including major ones like WooCommerce, OrbitFox, Yoast, BuddyPress, bbPress, etc. Learn more about the theme and ready to import demo sites at https://pressmaximum.com/customify
-Version: 0.4.16
+Version: 0.4.18
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: customify


### PR DESCRIPTION
## Summary

Two-version release cycle on `DEV`. 37 commits, 51 files, +2786/−1084.

### 0.4.18
- Footer builder rows fully generic — Pro's `top` row + extension-added rows now route through the same pipeline as built-in main/bottom.
- Dropped unnecessary `!important` on `.alignfull` margins so child themes and user CSS can override full-bleed behavior through normal cascade.

### 0.4.17
**New**
- Two extra Footer Builder row-layout presets for 4-column mode (40/20/20/20 and 2×2 grid).

**Fixed**
- Header Search Icon controls (Icon Size / Padding / Styling) now apply to the rendered icon.
- Header Search submit button vertical alignment with the input field.
- Container width default 1248 + dynamic content-size / wide-size for Narrow layout.
- WooCommerce mobile-only styles leaking onto desktop — now scoped to `@media (max-width: 560px)`.
- Pro Bridge settings screen 404 on metabox JS/CSS (legacy `/assets/` → `/build/`).
- Nested lists inside core blocks (Quote, Pullquote, Cover, etc.) inheriting extra `.entry-content` margin; list-block styling unified under `.wp-block-list`.

**Improved**
- Color palette Customizer settings — derived contrast tokens (text on brand backgrounds, container fills, WCAG on-color picks) now update live as you drag the picker, no save+reload needed. Backed by a single `selective_refresh` partial on the `<style id='customify-palette-tokens-inline-css'>` block.
- 13 color controls migrated from PHP inline CSS templates to bundled SCSS; 5 WooCommerce `customify/styling/*` filter handlers retired in favor of equivalent SCSS rules under `src/frontend/scss/compatibility/`.
- WooCommerce cart — narrower "remove" column + square quantity picker.
- Removed orphaned "Shop Buttons" color control (unreachable since unified Colors section in 0.4.15).

## Test plan

- [ ] Visual smoke: fresh install renders identically to 0.4.16 baseline (color palette defaults, button styles, header/footer layouts).
- [ ] Visual smoke: fixture site with saved `global_styling_color_*` overrides renders identically (border colors, link colors, widget titles, meta text, pagination).
- [ ] Customizer live preview: drag each of the 13 color pickers (6 slots + 7 overrides) — color updates instantly on base tokens, derived contrast tokens (on-primary text, container fills) catch up within ~300ms with no full-page reload.
- [ ] Header Search box: input + submit button (magnifying glass) align vertically; Icon Size/Padding/Styling controls visibly change the rendered icon.
- [ ] Header Search submit button: hover transitions through muted → text color without the dark inset overlay.
- [ ] Footer builder: 4-col presets (40/20/20/20, 2×2 grid) selectable and render correctly.
- [ ] Footer builder: Pro `top` row (if Pro active) renders via the same pipeline as main/bottom — no missing item slots.
- [ ] WooCommerce: cart `remove` column narrow, quantity picker square; mobile-only styles stay below 560px breakpoint.
- [ ] Pro Bridge: open Customify Pro settings screen — metabox JS/CSS loads (no 404 in network panel).
- [ ] Block editor: nested list inside a Quote / Pullquote / Cover block has no extra `.entry-content` left margin; matches frontend.
- [ ] Theme version: `style.css` header and `package.json` both read `0.4.18`.