### PR TITLE
Sync button hover + Blocksify button text to theme color tokens

### DIFF
--- a/docs/SPEC-customizer-colors.md
+++ b/docs/SPEC-customizer-colors.md
@@ -1294,6 +1294,74 @@ SCSS auto-wire (Phase 2.13):
 | accent-container chroma | 0.040 (capped from 0.103) | — (Customify extension) |
 | on-accent-container | #8B5F00 | ~#8B5F00 (dark gold) ✓ |
 
+### 8.14 Phase 2.14 — Blocksify button text auto-contrast + button hover state layer (PR #407)
+
+Two frontend-only additions. Both consume EXISTING palette tokens — no new
+`theme_mod` keys, no storage change, no selector renames.
+
+**A. Blocksify Fill button label auto-contrast** (`src/frontend/scss/base/_blocks.scss`).
+
+Blocksify's Fill button is tagged `bsy-button-{uid}` + `bsy-bg-{slug}` and reads
+its label color from the custom property `--blocksify--button--text-color`
+(falling back to white when unset). Three rules point that property at the
+matching auto-contrast token so a brand-background button gets a WCAG-readable
+label that tracks Customizer slot edits:
+
+```scss
+[class*="bsy-button-"].bsy-bg-primary   { --blocksify--button--text-color: var(--customify-on-primary); }
+[class*="bsy-button-"].bsy-bg-secondary { --blocksify--button--text-color: var(--customify-on-secondary); }
+[class*="bsy-button-"].bsy-bg-accent    { --blocksify--button--text-color: var(--customify-on-accent); }
+```
+
+- Scoped to `[class*="bsy-button-"]` so the var lands only on the button element
+  (it must not inherit to children). A designer's explicit label-color pick still
+  wins (Blocksify sets the property inline at higher specificity).
+- **Solid brand slugs only.** `on-{primary,secondary,accent}` are emitted to
+  `:root` unconditionally (§3.2 note). The `*-container` slugs are deliberately
+  NOT mapped — their `on-*-container` tokens are gated on Palette opt-in, so a
+  theme default could not be guaranteed; container buttons rely on the designer's
+  text pick, which already tracks the palette via `var(--wp--preset--color--X)`.
+- NOT WP's `.has-{slug}-background-color` — that ships `background-color
+  !important` (locks the fill, blocks hover); Blocksify uses its own
+  `bsy-bg-{slug}` precisely to avoid it.
+- Additive + inert when Blocksify is absent (nothing carries these classes).
+- Verified end-to-end on Blocksify dev (PR #211 — per-page CSS + the consumer
+  var): on a custom palette, secondary→dark label 4.89:1, accent→dark 5.28:1,
+  primary→white 5.17:1 (all ≥ AA). Note: Blocksify keys its per-instance CSS by
+  the block `uid`, which must be a valid 8-hex string — hand-authored markup with
+  a malformed uid makes Blocksify fall the fill back to primary.
+
+**B. Native + header-builder button hover → adaptive "state layer"**
+(`base/_base.scss`, `header/builder_items/_button.scss`).
+
+Replaces the legacy darken overlay (`box-shadow: inset 0 0 0 120px
+rgba(0,0,0,.18)`) with a translucent 13%-of-text layer painted on top of the
+LIVE background (matches Blocksify's current button hover):
+
+```scss
+&:hover {
+    background-image: linear-gradient(
+        color-mix(in srgb, currentColor 13%, transparent),
+        color-mix(in srgb, currentColor 13%, transparent)
+    );
+}
+```
+
+- **Background-agnostic by design.** The overlay sits over whatever the actual
+  background is, so it adapts: a dark fill with light text lifts, a light fill
+  with dark text deepens — correct for the primary native fill, the secondary
+  builder/WooCommerce fill, AND any custom background. A named `color-mix()` on
+  `background-color` was rejected: it can't read the live background, so it
+  wrong-colours non-primary / custom-background buttons on hover.
+- Trade-off: `background-image` is not animatable → the overlay appears instantly
+  (no fade). Accepted for a subtle 13% layer.
+- `13%` matches Blocksify — keep in sync if the plugin changes it.
+- Needs `color-mix()` (Chrome 111+ / FF 113+ / Safari 16.2+, Baseline 2023);
+  older browsers show no hover shift (graceful).
+- 30K-safety: no storage/selector change. Only the transient hover *appearance*
+  changes site-wide (darken → adaptive lift/deepen); resting + saved colors render
+  identically.
+
 ### 8.12 Phase 2 — remaining (good follow-ups)
 
 #### Investigate "shadow slug" approach for legacy back-compat

--- a/src/frontend/scss/base/_base.scss
+++ b/src/frontend/scss/base/_base.scss
@@ -441,7 +441,14 @@ input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-bu
     justify-content: center;
     gap: 0.5em;
     &:not(.menu-mobile-toggle, .search-submit):hover {
-        box-shadow: inset 0 0 0 120px rgba(0, 0, 0, 0.18);
+        // State-layer hover (matches Blocksify): mix the button fill 13% toward
+        // its own text color (currentColor). Adaptive — a dark fill with light
+        // text lifts, a light fill with dark text deepens. The fill must be named
+        // explicitly because color-mix() can't read the live background; native
+        // buttons default to the primary fill, hence var(--customify-primary).
+        // Keep 13% in sync with Blocksify. Needs color-mix() (Chrome 111+ /
+        // FF 113+ / Safari 16.2+); older browsers just show no hover shift.
+        background-color: color-mix(in srgb, var(--customify-primary), currentColor 13%);
     }
     &:hover {
         color: var(--customify-on-primary, #ffffff);

--- a/src/frontend/scss/base/_base.scss
+++ b/src/frontend/scss/base/_base.scss
@@ -441,14 +441,18 @@ input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-bu
     justify-content: center;
     gap: 0.5em;
     &:not(.menu-mobile-toggle, .search-submit):hover {
-        // State-layer hover (matches Blocksify): mix the button fill 13% toward
-        // its own text color (currentColor). Adaptive — a dark fill with light
-        // text lifts, a light fill with dark text deepens. The fill must be named
-        // explicitly because color-mix() can't read the live background; native
-        // buttons default to the primary fill, hence var(--customify-primary).
-        // Keep 13% in sync with Blocksify. Needs color-mix() (Chrome 111+ /
-        // FF 113+ / Safari 16.2+); older browsers just show no hover shift.
-        background-color: color-mix(in srgb, var(--customify-primary), currentColor 13%);
+        // State-layer hover (matches Blocksify): overlay 13% of the button's own
+        // text color on top of the LIVE background via a translucent
+        // background-image. Background-agnostic — it adapts to the primary native
+        // fill, the secondary WooCommerce / header-builder fill, and any custom
+        // background. A named color-mix() on background-color can't read the live
+        // background and would wrong-colour those non-primary buttons on hover.
+        // Needs color-mix() (Chrome 111+ / FF 113+ / Safari 16.2+); older
+        // browsers just show no hover shift.
+        background-image: linear-gradient(
+            color-mix(in srgb, currentColor 13%, transparent),
+            color-mix(in srgb, currentColor 13%, transparent)
+        );
     }
     &:hover {
         color: var(--customify-on-primary, #ffffff);

--- a/src/frontend/scss/base/_blocks.scss
+++ b/src/frontend/scss/base/_blocks.scss
@@ -207,6 +207,30 @@
 	color: var(--customify-on-accent, inherit);
 }
 
+// Blocksify Fill button — auto-contrast label color.
+//
+// Blocksify tags a slug-bg button with `bsy-bg-{slug}` (NOT WP's
+// `.has-{slug}-background-color`, which ships `background-color !important`
+// that would lock the fill and block the hover state). Its label reads the
+// custom property `--blocksify--button--text-color` (unset → Blocksify's own
+// white fallback). We point that property at the matching
+// `--customify-on-{slug}` token so the label auto-flips for WCAG contrast and
+// tracks live Customizer slot edits.
+//
+// Scoped to `[class*="bsy-button-"]` so the var only lands on the button
+// element itself — it must not inherit down to children. A designer's
+// explicit label-color pick still wins (Blocksify sets the property inline).
+//
+// Solid brand slugs only: `--customify-on-{primary,secondary,accent}` are
+// emitted to :root unconditionally. The `*-container` on-tokens are gated on
+// Palette opt-in (usually unset on default installs), so they are
+// deliberately omitted here rather than risk an unreadable white-on-tint
+// fallback. Additive + inert when Blocksify is absent (nothing carries these
+// classes).
+[class*="bsy-button-"].bsy-bg-primary   { --blocksify--button--text-color: var(--customify-on-primary); }
+[class*="bsy-button-"].bsy-bg-secondary { --blocksify--button--text-color: var(--customify-on-secondary); }
+[class*="bsy-button-"].bsy-bg-accent    { --blocksify--button--text-color: var(--customify-on-accent); }
+
 .wp-block-video video {
 	max-width: 100%;
 }

--- a/src/frontend/scss/header/builder_items/_button.scss
+++ b/src/frontend/scss/header/builder_items/_button.scss
@@ -11,8 +11,13 @@
     text-transform: uppercase;
     letter-spacing: 0.5px;
     font-weight: 600;
+    transition: background-color 0.2s;
     &:hover {
-        box-shadow: inset 0 0 0 120px rgba(0,0,0,0.18);
+        // State-layer hover (matches Blocksify): mix the fill 13% toward the text
+        // color. This builder button defaults to the secondary fill, so the base
+        // is var(--customify-secondary) (color-mix can't read the live bg). Keep
+        // 13% in sync with Blocksify.
+        background-color: color-mix(in srgb, var(--customify-secondary), currentColor 13%);
         color: var(--customify-on-secondary, #ffffff);
     }
 

--- a/src/frontend/scss/header/builder_items/_button.scss
+++ b/src/frontend/scss/header/builder_items/_button.scss
@@ -11,13 +11,15 @@
     text-transform: uppercase;
     letter-spacing: 0.5px;
     font-weight: 600;
-    transition: background-color 0.2s;
     &:hover {
-        // State-layer hover (matches Blocksify): mix the fill 13% toward the text
-        // color. This builder button defaults to the secondary fill, so the base
-        // is var(--customify-secondary) (color-mix can't read the live bg). Keep
-        // 13% in sync with Blocksify.
-        background-color: color-mix(in srgb, var(--customify-secondary), currentColor 13%);
+        // State-layer hover (matches Blocksify): translucent 13%-of-text overlay
+        // on the live background — background-agnostic, adapts to the secondary
+        // default or any custom builder background. Same mechanism as the native
+        // button. Keep 13% in sync with Blocksify.
+        background-image: linear-gradient(
+            color-mix(in srgb, currentColor 13%, transparent),
+            color-mix(in srgb, currentColor 13%, transparent)
+        );
         color: var(--customify-on-secondary, #ffffff);
     }
 


### PR DESCRIPTION
## What

Aligns Customify's native button hover and the Blocksify Fill button label color with Blocksify's current behavior, driven by the theme's color tokens. **Frontend-only** — no `theme_mod`/option/meta changes, no selector renames.

## Changes

- **Blocksify Fill button label auto-contrast** (`base/_blocks.scss`) — map `[class*="bsy-button-"].bsy-bg-{primary,secondary,accent}` to set `--blocksify--button--text-color` = the matching `--customify-on-*` token. Brand-background Blocksify buttons that don't set an explicit label color get a WCAG-readable label that tracks Customizer slot edits. Solid brand slugs only; `*-container` slugs are intentionally left to the designer's text pick (which already follows the palette via `var(--wp--preset--color--X)`). Additive + inert without Blocksify.
- **Native + header-builder button hover → adaptive "state layer"** (`base/_base.scss`, `header/builder_items/_button.scss`) — replace the legacy darken overlay (`box-shadow: inset 0 0 0 120px rgba(0,0,0,.18)`) with a translucent 13%-of-text layer painted over the live background: `background-image: linear-gradient(color-mix(in srgb, currentColor 13%, transparent), …)`. **Background-agnostic** — adapts to the primary native fill, the secondary builder/WooCommerce fill, and any custom background. A named `color-mix()` on `background-color` was rejected because it can't read the live background and would wrong-colour non-primary buttons on hover. `13%` matches Blocksify.
- **Docs** — both documented in `docs/SPEC-customizer-colors.md` §8.14.

## Notes

- Needs `color-mix()` (Chrome 111+ / FF 113+ / Safari 16.2+, Baseline 2023); older browsers degrade to no hover shift.
- Trade-off: `background-image` is not animatable → the hover overlay appears instantly (no fade), accepted for a subtle 13% layer.
- **30K-safety:** no storage/selector change. Only the transient hover *appearance* changes site-wide (darken → adaptive lift/deepen); resting + saved colors render identically.

## Verification

Live on a throwaway site (Customify + WooCommerce + Blocksify dev #211), custom palette (blue primary / orange secondary / green accent):
- Blocksify brand-bg buttons with no explicit label → label resolves to `--customify-on-*` and auto-contrasts: secondary→dark **4.89:1**, accent→dark **5.28:1**, primary→white **5.17:1** (all ≥ AA).
- Native + header button hover: overlay adapts to each button's own background.

> Correction: an earlier draft of this description claimed a broad WooCommerce regression. Live testing **disproved** it — WC add-to-cart renders the **primary** fill on this theme (the native `.button` rule wins over the WC-compat secondary rule by stylesheet source order), so the primary-token hover matches. No WC regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
