### PR TITLE
feat(colors): palette switcher in Customizer Colors section

### DIFF
--- a/docs/SPEC-customizer-colors.md
+++ b/docs/SPEC-customizer-colors.md
@@ -1405,20 +1405,106 @@ trade-off preference.
 | Background composite ↔ slot two-way sync | When user edits `bg_color` subfield of `background` composite, also update `customify_palette_base` (or vice versa). Right now editing one doesn't propagate. |
 | `content_background` slot | If used in practice, add a 7th slot or a deeper-content surface. Currently has no slot equivalent. |
 
-### 8.13 Phase 3 — Custom palettes / Style Packs (future)
+### 8.13 Phase 3 — Palette switcher (done)
 
-Once Phase 2 stabilizes the slot ↔ everything-else cascade, Phase 3 can
-build the higher-level palette UX on top:
+A card-based palette switcher at the top of the Colors section. The user
+applies a named palette (preset or custom) in one click; the cards drive the
+6 existing slot pickers — no new render path, no new rendered token.
 
-- Multiple palette presets (e.g. Light + Dark) the user can switch
-  between with one click; each preset stores its own 6 slot values.
-- User-saved custom palettes (CRUD + name + thumbnail).
-- Per-site dark-mode token set wired to `prefers-color-scheme` or a
-  user toggle.
-- Style Pack concept — bundle palette + typography + spacing under a
-  single named preset that can be applied / shared / imported.
+**New file:** `inc/color-palette-switcher.php` (registered in
+`inc/class-customify.php` `includes()` right after `colors-palette.php`).
 
-Design when Phase 3 starts; not blocked by anything in Phase 1/2 today.
+**A. Storage — two NEW `theme_mod` keys (the only storage added).**
+
+| Key | Type | Default | Purpose |
+|---|---|---|---|
+| `customify_active_palette` | string | `''` | id of the palette the slots currently match (e.g. `sunrise`). Bookkeeping only — nothing renders from it. |
+| `customify_color_palettes` | JSON string | `'[]'` | user-saved custom palettes: `[{id,name,slots:{…}}]`. |
+
+The 6 slots keep their EXISTING keys — the switcher writes THROUGH to them,
+it does not introduce a parallel store:
+
+```
+primary   → global_styling_color_primary    (legacy)
+secondary → global_styling_color_secondary  (legacy)
+accent    → customify_palette_accent
+text      → customify_palette_text
+surface   → customify_palette_surface
+base      → customify_palette_base
+```
+
+**B. Presets — Sunrise (light) + Midnight (dark).**
+
+```
+Sunrise   base #ffffff  surface #ECECEC  text #2b2b2b  primary #235787  secondary #c3512f  accent #ffd042
+Midnight  base #0f1217  surface #1a1e25  text #e8eaed  primary #5a8fc2  secondary #db6a44  accent #ffd042
+```
+
+Sunrise's slot values equal the theme's per-field picker defaults
+(`surface #ECECEC`, `primary #235787`, …), so a fresh install reads as
+"Sunrise linked" without writing anything — the active state is INFERRED
+from slot equality, never auto-persisted on a clean open (see D).
+
+**C. Apply mechanism — drive the existing pickers, no new path.**
+
+Applying a palette calls `$panel.wpColorPicker('color', hex)` on each of the
+6 existing pickers (the canonical, already-proven write path). That fires the
+normal picker `change` → Customizer setting → live-preview cascade. The
+switcher adds ZERO new rendering: the frontend output is byte-identical to a
+user manually setting those 6 pickers to the same values.
+
+**D. Active-determination / reconciliation (the 30K-safety core).**
+
+`render()` infers which card is "active" from the live slot values, in three
+cases:
+
+1. **stored id matches current slots** → that palette is active + linked.
+2. **no stored id, but a preset/custom matches current slots** → adopt it as
+   active + linked; persist the id ONLY if the customizer is already dirty
+   (`wp.customize.state('saved').get() === false`). On a clean open this never
+   writes — a legacy site is never silently dirtied.
+3. **nothing matches** → no card active, no "modified" strip, no write. This
+   is the legacy saved-custom-colors case: the site shows its colors with no
+   palette chrome.
+
+This three-case model replaced an earlier `DEFAULT_ACTIVE` fallback that
+wrongly showed a legacy saved-custom site as "Sunrise active + Modified +
+reset-to-Sunrise". `syncSlotDefaults()` re-anchors each picker's reset
+baseline (`wpColorPicker('option','defaultColor', …)` + `data-default`) to the
+active palette's value — but ONLY when a palette is active; with no active
+palette (case 3) it is skipped, so legacy reset behavior is untouched.
+
+**E. Custom palettes.** Create-from-current, rename, delete, import/export
+(JSON). `customify_color_sanitize_palettes()` hardens imported JSON:
+`sanitize_text_field` on name, `customify_color_normalize_hex` on every slot,
+array capped at 100. The inline JS escapes every user value through an `esc()`
+helper before `innerHTML`. A custom palette auto-absorbs later slot edits
+while active (`maybeSyncCustom`), so editing a slot doesn't desync the card.
+
+**F. Default shift — link-hover now follows link.** As part of this phase the
+`global_styling_color_link_hover` field default changed from `#406F99` (a
+lighter mix) to "same as link" (`#235787`), and the cascade resolves
+link-hover → link → primary. 30K-impact: a site that saved a link color but
+never saved a link-hover now renders link-hover = its link color on hover
+(previously a lighter shade). Intentional, documented default shift
+(project-owner requested) — saved link-hover values are untouched.
+
+**G. WP-native styling.** All "selected/active" accents use
+`var(--wp-admin-theme-color, #3858e9)` (the admin's own accent); buttons and
+borders use WP admin tokens. The 6 existing wp-color-pickers are left as-is.
+
+**30K-safety summary.** Additive only — 2 new bookkeeping keys, 6 slots reuse
+existing keys, apply path is the existing picker write. No saved hex changes,
+no key renamed/removed. The only render delta for any existing site is the
+link-hover default shift (F), affecting only sites that never saved a
+link-hover. Verified on a saved-custom site: front-end render unchanged;
+customizer shows no active card / no modified strip / no dirty-on-open.
+
+**Still deferred (Phase 4+).** Per-site dark-mode token set wired to
+`prefers-color-scheme` / a user toggle; the Style Pack concept (bundle palette
++ typography + spacing). Applying a dark palette deliberately does NOT touch
+header Skin Mode (project-owner decision — a palette shouldn't mutate
+unrelated skin settings).
 
 ---
 

--- a/docs/SPEC-customizer-colors.md
+++ b/docs/SPEC-customizer-colors.md
@@ -227,7 +227,7 @@ computed default is used.
 | `--customify-border` | `global_styling_color_border` | `mix(text 14%, base)` (Phase 2.10 bumped 12→14% per spec §2) | Decorative borders / separators (~1.35:1, WCAG-exempt) |
 | `--customify-border-strong` | (no legacy key) | Iterate P 6%→100% until `contrast(mix(text P%, base), base) ≥ 3.0` | Form input borders, functional outlines (WCAG 1.4.11 ≥3:1) |
 | `--customify-link` | `global_styling_color_link` | `= primary` | `a { color }` |
-| `--customify-link-hover` | `global_styling_color_link_hover` | `mix(primary 85%, white)` (Phase 2.4 — surfaces, not depresses) | `a:hover/focus` |
+| `--customify-link-hover` | `global_styling_color_link_hover` | `= link` (Phase 3 — follows Link → Primary; was `mix(primary 85%, white)`) | `a:hover/focus` |
 | `--customify-primary-hover` | (no legacy key) | `mix(primary, black 10%)` | `button:hover` (NEW, didn't exist before) |
 | `--customify-heading` | `global_styling_color_heading` | `= text` | `h1-h6` |
 | `--customify-widget-title` | `global_styling_color_w_title` | `= text` | `.site-content .widget-title` |

--- a/docs/temp/palette-switcher-qa-handoff.md
+++ b/docs/temp/palette-switcher-qa-handoff.md
@@ -1,0 +1,426 @@
+# Palette Switcher — QA / Verification Handoff
+
+**Audience:** a fresh agent session with NO memory of the implementation work.
+**Goal:** independently **review the code** AND **run the full test-case suite**
+to confirm the new "color palette switcher" is correct and — above all —
+**safe for the 30,000 live sites** running this theme.
+
+> This is a verification handoff, not an implementation task. Do **not** rewrite
+> the feature. Review it, test it, and report findings. Only make code changes if
+> a test fails and the fix is small + obviously correct (and re-test after).
+
+---
+
+## 0. How to use this document
+
+1. Do the **Required reading** (§1) first — especially the 30K-safety doctrine.
+2. Skim **Key facts** (§3) — it is the cheat-sheet for every test below.
+3. Do **Part A — Code review** (§5) — read the files, tick the invariants.
+4. Do **Part B — Functional tests** (§6) — TC1…TC13, in order, on a real browser.
+5. Fill in the **Results table** (§8) and report. Restore the site (§4.4) when done.
+
+Work on branch **`claude/romantic-lamarr-d4f2fe`** (already checked out in this
+worktree). The feature is committed at **`ee685a0a`**
+(`feat(colors): palette switcher in Customizer Colors section`).
+
+---
+
+## 1. Required reading (do not skip)
+
+| Read | Why |
+|---|---|
+| [`AGENTS.md`](../../AGENTS.md) | Hard rules: **30k-site safety**, never-rename keys, English-only, AJAX, CSS handle. |
+| [`CLAUDE.md`](../../CLAUDE.md) | Claude-specific workflow + "when about to change storage shape, STOP". |
+| [`docs/SPEC-customizer-colors.md`](../SPEC-customizer-colors.md) **§2.4** (30K doctrine), **§3.1–3.2** (slots + derived tokens), **§8.13** (this feature) | The contract this feature must honor. §8.13 is the authoritative description of what was built. |
+| [`docs/migration-guide.md`](../migration-guide.md) §2 | Storage-change decision tree (this feature is additive — confirm it really is). |
+
+**30K-safety doctrine, distilled (memorize this — it is the pass/fail spine):**
+
+- **Additive only.** New behavior may add new `theme_mod` keys; it must **never
+  rename, delete, or change the meaning** of an existing key.
+- **Never change what a SAVED site renders.** A site that already saved colors
+  must render byte-identical hex after this change. Only *fresh-install
+  defaults* may shift, and only if documented.
+- **Never silently dirty a clean Customizer.** Opening the Customizer on a saved
+  site must not create "unsaved changes" or write any setting on its own.
+
+---
+
+## 2. What was built (one-paragraph orientation)
+
+A card-based **palette switcher** at the top of the Customizer **Colors**
+section (`customify_colors`). The user clicks a palette card (preset **Sunrise**
+/ **Midnight**, or a saved custom one) and it drives the **6 existing** slot
+color-pickers in one shot. Apply = `wpColorPicker('color', hex)` on each picker
+— the same path the existing quick-pick already used, so there is **no new
+render path and no new rendered CSS token**. Two new bookkeeping `theme_mod`
+keys were added; the 6 slots keep their existing keys.
+
+**Files in the change (commit `ee685a0a`):**
+
+| File | Role |
+|---|---|
+| `inc/color-palette-switcher.php` | **NEW** — the whole feature (presets, sanitizer, settings, inline JS, inline CSS). ~860 lines. |
+| `inc/class-customify.php` | One-line `includes()` entry for the new file. |
+| `inc/colors-palette.php` | link-hover cascade change + `CASCADE_MAP`/`resolveCascadeValue` + preview recompute debounce. |
+| `inc/customizer/configs/colors.php` | link-hover field default `#406F99` → `#235787`. |
+| `docs/SPEC-customizer-colors.md` | §8.13 documentation. |
+
+---
+
+## 3. Key facts & invariants (cheat-sheet for all tests)
+
+**New theme_mod keys (the ONLY storage added):**
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `customify_active_palette` | string | `''` | id of palette the slots match. **Bookkeeping only — nothing renders from it.** |
+| `customify_color_palettes` | JSON string | `'[]'` | custom palettes: `[{id,name,slots:{6}}]`. |
+
+**The 6 slot keys (existing — reused, NOT new):**
+
+```
+primary   → global_styling_color_primary     (legacy key)
+secondary → global_styling_color_secondary    (legacy key)
+accent    → customify_palette_accent
+text      → customify_palette_text
+surface   → customify_palette_surface
+base      → customify_palette_base
+```
+
+**Presets (exact hex — used to assert “applied correctly”):**
+
+```
+Sunrise  (light)  base #ffffff  surface #ECECEC  text #2b2b2b  primary #235787  secondary #c3512f  accent #ffd042
+Midnight (dark)   base #0f1217  surface #1a1e25  text #e8eaed  primary #5a8fc2  secondary #db6a44  accent #ffd042
+```
+
+Sunrise’s slot values are deliberately equal to the theme’s per-field picker
+defaults → a fresh install reads as “Sunrise linked” without writing anything.
+
+**Active-determination model (render(), three cases) — the 30K core:**
+
+1. stored id matches current slots → that palette active + **linked**.
+2. no stored id, but a preset/custom matches slots → adopt it; **persist the id
+   ONLY if the customizer is already dirty** (`wp.customize.state('saved').get()===false`).
+   On a clean open this never writes.
+3. nothing matches → **no card active, no strip, no write** (legacy saved-custom case).
+
+**link-hover default change:** field default `#235787`; cascade resolves
+`link-hover → link → primary`. A saved link-hover override still wins.
+
+**Value-format gotcha (you WILL hit this in probes):**
+`wp.customize('global_styling_color_primary').get()` returns a **wrapped**
+string like `"%22#5a8fc2%22"` after a picker write (URI-encoded JSON-quoted).
+The **stored** theme_mod is **raw** hex (`#5a8fc2`). To compare, decode with
+`JSON.parse(decodeURI(v))`. Both forms mean the same color.
+
+---
+
+## 4. Environment setup
+
+### 4.1 Paths & URLs
+
+| Thing | Value |
+|---|---|
+| Worktree (committed code lives here) | `…/wp-content/themes/customify/.claude/worktrees/romantic-lamarr-d4f2fe` |
+| **Main checkout (the LIVE site loads theme from here)** | `/Users/kientrong/Studio/free-theme-customify/wp-content/themes/customify` |
+| Front-end | `http://customify-free.wp.local/` |
+| Customizer (Colors focused) | `http://customify-free.wp.local/wp-admin/customize.php?autofocus[section]=customify_colors` |
+| wp-cli site path (`nameOrPath`) | `/Users/kientrong/Studio/free-theme-customify` |
+| Colors section id | `customify_colors` |
+
+### 4.2 Deploy the code-under-test to the live site
+
+The browser tests the **main checkout**, not the worktree. Sync the one file
+that matters (the others were already deployed) and flush:
+
+```bash
+cd /Users/kientrong/Studio/free-theme-customify/wp-content/themes/customify
+cp .claude/worktrees/romantic-lamarr-d4f2fe/inc/color-palette-switcher.php inc/color-palette-switcher.php
+cp .claude/worktrees/romantic-lamarr-d4f2fe/inc/colors-palette.php          inc/colors-palette.php
+cp .claude/worktrees/romantic-lamarr-d4f2fe/inc/customizer/configs/colors.php inc/customizer/configs/colors.php
+cp .claude/worktrees/romantic-lamarr-d4f2fe/inc/class-customify.php          inc/class-customify.php
+php -l inc/color-palette-switcher.php   # expect: No syntax errors
+```
+
+> **Hygiene:** these copies are uncommitted changes on the main checkout’s
+> branch (DEV). Do **not** `git commit` them on the main checkout. The source of
+> truth is the worktree branch. When QA is done, restore the main checkout (§4.4).
+
+### 4.3 Helper: set up / inspect / tear down theme_mods (wp-cli)
+
+Use the `mcp__wordpress-studio__wp_cli` tool, `nameOrPath` =
+`/Users/kientrong/Studio/free-theme-customify`.
+
+```
+# INSPECT current state
+eval 'foreach (["global_styling_color_primary","global_styling_color_secondary","global_styling_color_link","global_styling_color_link_hover","customify_palette_text","customify_palette_surface","customify_palette_base","customify_palette_accent","customify_active_palette","customify_color_palettes"] as $k){ $v=get_theme_mod($k); echo $k."=".(is_string($v)?$v:json_encode($v))."\n"; }'
+
+# SET a legacy "saved-custom" site (saved colors, NEVER used palettes) — used by TC2/TC4/TC12
+eval 'set_theme_mod("global_styling_color_primary","#0066cc"); set_theme_mod("global_styling_color_secondary","#ff6600"); set_theme_mod("global_styling_color_link","#0066cc"); set_theme_mod("customify_palette_text","#222222"); remove_theme_mod("customify_active_palette"); remove_theme_mod("customify_color_palettes"); echo "saved-custom set\n";'
+
+# RESET to fresh-default (all keys removed) — used by TC1
+eval 'foreach (["global_styling_color_primary","global_styling_color_secondary","global_styling_color_link","global_styling_color_link_hover","customify_palette_text","customify_palette_surface","customify_palette_base","customify_palette_accent","customify_active_palette","customify_color_palettes"] as $k){ remove_theme_mod($k); } echo "reset to fresh default\n";'
+
+# CLEAR customizer changesets + cache (do this between cases that leave the customizer dirty)
+eval 'global $wpdb; $ids=$wpdb->get_col("SELECT ID FROM {$wpdb->posts} WHERE post_type=\"customize_changeset\""); foreach($ids as $id){ wp_delete_post($id,true); } echo "deleted=".count($ids)."\n"; wp_cache_flush();'
+```
+
+Always run `cache flush` (or the changeset-clear snippet) **after** changing
+theme_mods via wp-cli and **before** loading the customizer, or you’ll read
+stale state.
+
+### 4.4 Teardown when QA is finished
+
+1. Reset the site to fresh-default (the RESET snippet above) + clear changesets.
+2. Restore the main checkout to clean **only if asked** (the owner is keeping the
+   feature deployed for live review):
+   `cd …/themes/customify && git checkout -- inc/ && rm -f inc/color-palette-switcher.php`
+   (the file is untracked on DEV; the 4 edits revert via checkout).
+
+---
+
+## 5. Part A — Code review checklist
+
+Read each file and confirm the invariant. Mark ✅/❌ + note file:line for any ❌.
+
+### 5.1 `inc/color-palette-switcher.php`
+
+- [ ] **Additive storage.** Only `customify_active_palette` + `customify_color_palettes`
+      are registered (`add_setting`). No existing key is renamed or written with a
+      new meaning. The 6 slots are driven via the existing picker, not re-stored.
+- [ ] **Sanitizer `customify_color_sanitize_palettes()`** rejects malicious import:
+      `name` → `sanitize_text_field` + length cap; **every** slot hex →
+      `customify_color_normalize_hex(...,'')` and the entry is dropped if any slot
+      fails to normalize; array hard-capped (100); non-array → `'[]'`.
+- [ ] **Custom id can’t collide with a preset id** (`in_array($id,$preset_ids,true)`
+      → prefixes `user-`).
+- [ ] **XSS:** every user-controlled value rendered into `innerHTML` passes through
+      the `esc()` helper (palette names, ids, hex in inline `style`, export
+      textarea). Rename uses `input.value=` (property, not HTML) — fine.
+- [ ] **render() three-case model** (see §3) — confirm case 3 (no match) yields
+      no active card / no strip / no write, and case 2’s `setActive` is gated on
+      `wp.customize.state('saved').get()===false`.
+- [ ] **`applyPalette` releases its `applying` guard in a `finally`** (so a picker
+      throw can’t leave it stuck and disable `maybeSyncCustom` for the session).
+- [ ] **No direct persistence:** the file never calls `set_theme_mod` /
+      `remove_theme_mod` / `previewer.save()`. (grep it.)
+- [ ] **NOWDOC** inline JS uses `<<<'JS'` (single-quoted) → no PHP `$var` interpolation.
+
+### 5.2 `inc/colors-palette.php`
+
+- [ ] `$link_hover_default = $slots['primary'];` and the static `:root` emits
+      `--customify-link-hover: var(--customify-link, …)` (pure var() chain, no
+      color-mix) — emitted **only when** `! $ov_link_hover` (saved override wins).
+- [ ] `CASCADE_MAP` has `global_styling_color_link_hover → global_styling_color_link`;
+      `FIELD_DEFAULTS` has the matching `#235787`; `resolveCascadeValue()` recurses
+      and is **acyclic** (link_hover→link→primary; primary is not a key).
+- [ ] Preview `CASCADE_FALLBACK['--customify-link-hover'] === 'var(--customify-link)'`.
+- [ ] `recomputeDerivedDebounced` coalesces the six-slot switch (~24ms) and is what
+      the SOURCE_SLOTS bind to.
+
+### 5.3 `inc/customizer/configs/colors.php`
+
+- [ ] link-hover `default` and `placeholder` are `#235787`; description “same as Link color.”
+
+### 5.4 `inc/class-customify.php`
+
+- [ ] `'/inc/color-palette-switcher.php'` added to `includes()` **after**
+      `colors-palette.php` (it depends on helpers there).
+
+---
+
+## 6. Part B — Functional test cases
+
+Drive a real browser (Claude-in-Chrome). Before each case: set theme_mods (§4.3),
+clear changesets + flush, then load the customizer URL and **wait ~7s** for boot.
+Use the **state probe** (§7) to read machine-checkable state, and a screenshot to
+confirm visuals. After any case that dirties the customizer, **do not Publish** —
+clear changesets to discard.
+
+### TC1 — Fresh-default site: Sunrise linked, no dirt
+- **Pre:** RESET to fresh-default; clear changesets; flush.
+- **Steps:** open customizer Colors.
+- **Expect:** `active_setting=""`, `saved=true`. Exactly one card shows
+  active+linked = **Sunrise** (slots equal field defaults). No “modified” strip.
+- **Front-end** (`/`): `--customify-primary/link/link-hover = #235787`,
+  `text=#2b2b2b`, `base=#ffffff`.
+
+### TC2 — Legacy saved-custom site, clean open ⭐ (THE critical 30K case)
+- **Pre:** SET saved-custom (primary #0066cc, secondary #ff6600, link #0066cc,
+  text #222222; palette keys removed); clear changesets; flush.
+- **Steps:** open customizer Colors. **Touch nothing.**
+- **Expect (all must hold):** `active_setting=""`; `saved=true`;
+  `activeCardNames=[]` (**no** card active); **no** modified strip; slots read the
+  saved values (primary `#0066cc`, secondary `#ff6600`, text `#222222`).
+- **Fail = 30K regression.** If a card shows active, or `saved=false` on open, or
+  `active_setting` got written → STOP and report as a blocker.
+
+### TC3 — Apply a preset (Midnight) on the fresh site
+- **Pre:** TC1 state.
+- **Steps:** click the **Midnight** card.
+- **Expect:** the 6 slots become Midnight hex (decode the wrapped values);
+  `active_setting="midnight"`; `saved=false`; Midnight card `is-active is-linked`;
+  preview background turns dark; **zero console errors**. Header stays light
+  (Skin Mode is intentionally NOT touched).
+- **Teardown:** clear changesets (discard).
+
+### TC4 — Apply a preset ON TOP of saved-custom, then discard
+- **Pre:** TC2 saved-custom state.
+- **Steps:** click **Sunrise**, observe, then **discard** (clear changesets, do not publish).
+- **Expect:** apply works (slots → Sunrise, dirty), and after discard +
+  re-inspect via wp-cli the **live theme_mods are still the saved-custom values**
+  (nothing persisted without Publish).
+
+### TC5 — Section reset reconciliation (was a known bug)
+- **Pre:** TC3 (Midnight applied, dirty) OR any non-default state.
+- **Steps:** click the section **Reset** control (the ↺ at the top of the Colors
+  section — it is the theme’s pre-existing `customify__reset_section`; it removes
+  the section’s theme_mods and reloads).
+- **Expect:** after reload, slots = field defaults → the UI shows **Sunrise
+  active (inferred)**, **no** “Midnight + Modified” limbo, no spurious dirty.
+- **Note:** this reset is destructive by design (immediate `remove_theme_mod`,
+  confirm-gated). It is NOT part of the palette feature — just confirm the
+  feature *reconciles* cleanly to it.
+
+### TC6 — Custom palette: create / rename / delete
+- **Steps:** edit a couple of slots to a unique combo → click **＋ (add)** /
+  “create from current”. Then rename it. Then delete it.
+- **Expect:** new card appears with a `user-…` id; it’s active+linked; rename
+  persists; **Space inside the rename input does not close it**; delete removes
+  the card and does **not** recolor the slots (slots stay as last applied).
+- Verify `customify_color_palettes` in wp-cli holds the JSON while it exists.
+
+### TC7 — Import / export (round-trip + malicious input) ⭐ security
+- **Export:** open export, pick a palette / “all”, confirm valid JSON in the textarea.
+- **Round-trip:** import that JSON → palettes reappear identically.
+- **Malicious import:** paste JSON with `name:"<img src=x onerror=alert(1)>"` and a
+  slot value `"javascript:alert(1)"` / `"not-a-color"`.
+  - **Expect:** the bad-hex entry is **dropped** (slot fails `normalize_hex`); the
+    name is stored escaped/sanitized; **no script executes**; the card renders the
+    name as inert text. Confirm via DOM that the name is text, not parsed HTML.
+
+### TC8 — link-hover cascade + saved-override-wins
+- **Default path:** on TC2 saved-custom (link `#0066cc`, link-hover unsaved),
+  front-end `--customify-link-hover` resolves to `#0066cc` (= link). The picker
+  swatch for “Link hover color” shows the cascade-resolved color.
+- **Override path:** `set_theme_mod("global_styling_color_link_hover","#abcdef")`,
+  flush, reload front-end → `--customify-link-hover = #abcdef` (saved value wins,
+  cascade suppressed). Remove it afterward.
+
+### TC9 — Per-slot reset baseline follows active palette (syncSlotDefaults)
+- **Pre:** apply Midnight (TC3).
+- **Steps:** observe the six slot rows.
+- **Expect:** after applying Midnight, the per-slot reset arrows do **not** all
+  light up (baseline re-anchored to Midnight). Editing one slot then shows a reset
+  arrow that returns to the **Midnight** value, not the theme field default.
+
+### TC10 — Edge cases
+- Empty `customify_color_palettes` (`'[]'`) → only the 2 presets show, no JS error.
+- Import a custom with `id:"sunrise"` → stored id becomes `user-sunrise` (no collision).
+- Delete the **active** custom palette → active marker clears, slots unchanged, no error.
+
+### TC11 — Persistence across save + reload (case 1)
+- **Steps:** apply Midnight → **Publish** → reopen the customizer.
+- **Expect:** `customify_active_palette` saved `"midnight"`; on reopen Midnight is
+  active+linked (case 1, stored id matches slots), `saved=true`, no strip.
+- **Teardown:** RESET to fresh-default + clear changesets (don’t leave Midnight published).
+
+### TC12 — Front-end 30K render unchanged ⭐
+- **Pre:** TC2 saved-custom; clear changesets; flush.
+- **Steps:** load `/` (front-end, not customizer).
+- **Expect:** `--customify-primary = #0066cc`, `--customify-link = #0066cc`,
+  `--customify-link-hover = #0066cc`, `--customify-text = #222222`. Content links
+  render the saved blue; the header BUTTON renders the saved secondary `#ff6600`.
+  **No visual difference vs. before the feature** except link-hover now following
+  link (documented default shift).
+
+### TC13 — No fatal / no front-end overhead
+- `php -l` all 5 files (expect clean).
+- Load `/` and confirm the switcher adds **nothing** to the front-end (its
+  customize_* hooks only fire in the customizer; front-end is just function defs).
+- Console on both front-end and customizer: **zero** errors mentioning
+  `cps|palette|customify`.
+
+---
+
+## 7. Reusable browser state-probe
+
+Run via the Chrome `javascript_tool` in the **customizer** tab (after ~7s boot).
+Returns machine-checkable JSON for the assertions above:
+
+```js
+(function(){
+  var out={}, get=function(id){try{var s=wp.customize(id);return s?s.get():'__no__';}catch(e){return '__err__';}};
+  var dec=function(v){try{return JSON.parse(decodeURI(v));}catch(e){return v;}};
+  out.slots={primary:dec(get('global_styling_color_primary')),secondary:dec(get('global_styling_color_secondary')),
+    text:dec(get('customify_palette_text')),surface:dec(get('customify_palette_surface')),
+    base:dec(get('customify_palette_base')),accent:dec(get('customify_palette_accent')),
+    link:dec(get('global_styling_color_link')),link_hover:dec(get('global_styling_color_link_hover'))};
+  out.active_setting=get('customify_active_palette');
+  out.palettes_setting=get('customify_color_palettes');
+  out.saved=(function(){try{return wp.customize.state('saved').get();}catch(e){return '__err__';}})();
+  var cards=document.querySelectorAll('.cps-card');
+  out.cardNames=[].map.call(cards,function(c){var n=c.querySelector('.cps-name');return n?n.textContent.trim():'?';});
+  out.activeCardNames=[].filter.call(cards,function(c){return /is-active/.test(c.className);})
+    .map(function(c){var n=c.querySelector('.cps-name');return n?n.textContent.trim():c.className;});
+  out.cardClasses=[].map.call(cards,function(c){return c.className;});
+  var strip=document.querySelector('[class*="cps-modified"],[class*="cps-dirty"],[class*="cps-strip"]');
+  out.modifiedStrip=strip?(strip.offsetParent!==null):'none-in-dom';
+  return JSON.stringify(out);
+})()
+```
+
+**Front-end root-var probe** (run on `/`):
+
+```js
+(function(){var cs=getComputedStyle(document.documentElement);
+  return JSON.stringify({primary:cs.getPropertyValue('--customify-primary').trim(),
+    link:cs.getPropertyValue('--customify-link').trim(),
+    linkHover:cs.getPropertyValue('--customify-link-hover').trim(),
+    text:cs.getPropertyValue('--customify-text').trim(),
+    base:cs.getPropertyValue('--customify-base').trim()});})()
+```
+
+### Expected baselines actually observed during implementation (compare against these)
+
+- **TC2 clean open (saved-custom):**
+  `{"active_setting":"","saved":true,"activeCardNames":[],"modifiedStrip":"none-in-dom"}`
+  with slots primary `#0066cc`, secondary `#ff6600`, text `#222222`.
+- **TC3 after Midnight:** slots decode to Midnight hex;
+  `{"active_setting":"midnight","saved":false,"activeCardNames":["Midnight"]}`,
+  Midnight class `cps-card is-active is-linked`.
+- **TC12 front-end (saved-custom):**
+  `{"primary":"#0066cc","link":"#0066cc","linkHover":"#0066cc","text":"#222222"}`.
+- **TC1 front-end (fresh default):**
+  `{"primary":"#235787","link":"#235787","linkHover":"#235787","text":"#2b2b2b","base":"#ffffff"}`.
+
+---
+
+## 8. Results & reporting
+
+Fill this in and report. Any ❌ on TC2 / TC4 / TC12 (the saved-site cases) or a
+storage/XSS finding in Part A is a **blocker**.
+
+| ID | Case | Pass? | Notes |
+|----|------|-------|-------|
+| A | Code review (§5, all boxes) | | |
+| TC1 | Fresh default = Sunrise linked | | |
+| TC2 | ⭐ Saved-custom clean open | | |
+| TC3 | Apply Midnight | | |
+| TC4 | Apply over saved-custom + discard | | |
+| TC5 | Section-reset reconciliation | | |
+| TC6 | Custom palette CRUD | | |
+| TC7 | ⭐ Import/export + malicious | | |
+| TC8 | link-hover cascade + override | | |
+| TC9 | Per-slot reset baseline | | |
+| TC10 | Edge cases | | |
+| TC11 | Persist across save+reload | | |
+| TC12 | ⭐ Front-end 30K render | | |
+| TC13 | No fatal / no FE overhead | | |
+
+**Report should state:** overall verdict (SHIP / FIX-FIRST / BLOCK), every ❌ with
+file:line or repro steps, and confirmation that the site + main checkout were
+restored (§4.4). Prior implementation review verdict was **SHIP**; treat this as
+an independent second pass — try to *break* it, don’t just confirm.

--- a/inc/class-customify.php
+++ b/inc/class-customify.php
@@ -470,6 +470,8 @@ class Customify
 			// Template element classes.
 			'/inc/colors-palette.php',
 			// Colors palette CSS var emitter for the new top-level Colors section.
+			'/inc/color-palette-switcher.php',
+			// Palettes UI (presets + custom palettes) at the top of the Colors section.
 			'/inc/extras.php',
 			// Custom functions that act independently of the theme templates.
 			'/inc/element-classes.php',

--- a/inc/color-palette-switcher.php
+++ b/inc/color-palette-switcher.php
@@ -1,0 +1,867 @@
+<?php
+/**
+ * Customify — Color Palette switcher (Customizer › Colors).
+ *
+ * Adds a "Palettes" card list at the top of the Colors section: built-in
+ * presets + user-created custom palettes, with apply / new / rename / delete /
+ * import / export. Applying a palette drives the EXISTING six slot color
+ * pickers (same `wpColorPicker('color', hex)` path the "From palette"
+ * quick-pick already uses), so nothing here re-implements color storage or
+ * the derivation engine — it only orchestrates the six slot settings that
+ * inc/colors-palette.php already consumes.
+ *
+ * 30K-site safety:
+ *   - Purely ADDITIVE. Two NEW theme_mod keys (customify_active_palette,
+ *     customify_color_palettes); no existing key is read differently, renamed,
+ *     or removed.
+ *   - Nothing renders or changes on the frontend until the user explicitly
+ *     clicks a palette card (which just sets the six existing slot pickers,
+ *     exactly as if they had typed the hexes by hand).
+ *   - Deleting a custom palette never recolors the site — it only clears the
+ *     stored list / active marker; the user's current slot values stay put.
+ *
+ * @package Customify
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+// ──────────────────────────────────────────────────────────────────
+// Built-in preset palettes (filterable). Sunrise == the theme's current
+// slot defaults; Midnight (dark) + Signature (alt light) are starting
+// points — final brand hexes to be tuned by the owner.
+// ──────────────────────────────────────────────────────────────────
+
+if ( ! function_exists( 'customify_color_preset_palettes' ) ) {
+	function customify_color_preset_palettes() {
+		$presets = array(
+			array(
+				'id'    => 'sunrise',
+				'name'  => __( 'Sunrise', 'customify' ),
+				'slots' => array(
+					'base'      => '#ffffff',
+					// #ECECEC matches the Surface picker's field default, so a fresh
+					// site (all slots at their defaults) reads as "linked to Sunrise"
+					// — no spurious "Modified" strip on first open.
+					'surface'   => '#ECECEC',
+					'text'      => '#2b2b2b',
+					'primary'   => '#235787',
+					'secondary' => '#c3512f',
+					'accent'    => '#ffd042',
+				),
+			),
+			array(
+				'id'    => 'midnight',
+				'name'  => __( 'Midnight', 'customify' ),
+				'slots' => array(
+					'base'      => '#0f1217',
+					'surface'   => '#1a1e25',
+					'text'      => '#e8eaed',
+					'primary'   => '#5a8fc2',
+					'secondary' => '#db6a44',
+					'accent'    => '#ffd042',
+				),
+			),
+		);
+		return apply_filters( 'customify/color/preset_palettes', $presets );
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Slot key → existing setting id. Single source of truth shared by PHP
+// (localized to JS) and any future server-side consumer.
+// ──────────────────────────────────────────────────────────────────
+
+if ( ! function_exists( 'customify_color_palette_slot_map' ) ) {
+	function customify_color_palette_slot_map() {
+		return array(
+			'primary'   => 'global_styling_color_primary',
+			'secondary' => 'global_styling_color_secondary',
+			'accent'    => 'customify_palette_accent',
+			'text'      => 'customify_palette_text',
+			'surface'   => 'customify_palette_surface',
+			'base'      => 'customify_palette_base',
+		);
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Sanitizer for the custom-palettes store. Hardened: every hex is run
+// through customify_color_normalize_hex(), every name through
+// sanitize_text_field(), the list is capped, malformed entries dropped.
+// Stored as a JSON string in a single theme_mod.
+// ──────────────────────────────────────────────────────────────────
+
+if ( ! function_exists( 'customify_color_sanitize_palettes' ) ) {
+	function customify_color_sanitize_palettes( $value ) {
+		$arr = is_string( $value ) ? json_decode( wp_unslash( $value ), true ) : $value;
+		if ( ! is_array( $arr ) ) {
+			return '[]';
+		}
+		$keys  = array( 'base', 'surface', 'text', 'primary', 'secondary', 'accent' );
+		$out   = array();
+		$count = 0;
+		// Built-in preset ids — a custom must never reuse one (it would be shadowed
+		// by the preset in findPalette() and mis-render the active card).
+		$preset_ids = array();
+		if ( function_exists( 'customify_color_preset_palettes' ) ) {
+			foreach ( customify_color_preset_palettes() as $pp ) {
+				if ( isset( $pp['id'] ) ) {
+					$preset_ids[] = $pp['id'];
+				}
+			}
+		}
+		foreach ( $arr as $p ) {
+			if ( $count >= 100 ) {
+				break; // hard cap — avoid unbounded theme_mod growth.
+			}
+			if ( ! is_array( $p ) || empty( $p['name'] ) || empty( $p['slots'] ) || ! is_array( $p['slots'] ) ) {
+				continue;
+			}
+			$slots = array();
+			$valid = true;
+			foreach ( $keys as $k ) {
+				if ( empty( $p['slots'][ $k ] ) || ! is_string( $p['slots'][ $k ] ) ) {
+					$valid = false;
+					break;
+				}
+				// normalize_hex returns the fallback for garbage — reject those
+				// so an import can't smuggle a non-color value into the store.
+				$norm = customify_color_normalize_hex( $p['slots'][ $k ], '' );
+				if ( '' === $norm ) {
+					$valid = false;
+					break;
+				}
+				$slots[ $k ] = $norm;
+			}
+			if ( ! $valid ) {
+				continue;
+			}
+			$id = ( isset( $p['id'] ) && is_string( $p['id'] ) && '' !== $p['id'] )
+				? preg_replace( '/[^a-z0-9\-]/', '', strtolower( $p['id'] ) )
+				: 'user-' . substr( md5( wp_json_encode( $slots ) . $count ), 0, 10 );
+			if ( '' === $id ) {
+				$id = 'user-' . substr( md5( wp_json_encode( $slots ) . $count ), 0, 10 );
+			}
+			if ( in_array( $id, $preset_ids, true ) ) {
+				$id = 'user-' . $id; // never collide with a built-in preset id.
+			}
+			$name = sanitize_text_field( $p['name'] );
+			$name = function_exists( 'mb_substr' ) ? mb_substr( $name, 0, 60 ) : substr( $name, 0, 60 );
+			$out[] = array(
+				'id'    => $id,
+				'name'  => $name,
+				'slots' => $slots,
+			);
+			$count++;
+		}
+		return wp_json_encode( $out );
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Register the two additive data settings. No controls — the inline JS
+// reads/writes them through wp.customize. Priority 1200 runs after the
+// colors config (and force-postmessage at 1000 / preview-refresh at 1100).
+// ──────────────────────────────────────────────────────────────────
+
+if ( ! function_exists( 'customify_color_palette_register_settings' ) ) {
+	function customify_color_palette_register_settings( $wp_customize ) {
+		$wp_customize->add_setting( 'customify_active_palette', array(
+			'type'              => 'theme_mod',
+			'default'           => '',
+			'transport'         => 'postMessage',
+			'sanitize_callback' => 'sanitize_text_field',
+		) );
+		$wp_customize->add_setting( 'customify_color_palettes', array(
+			'type'              => 'theme_mod',
+			'default'           => '[]',
+			'transport'         => 'postMessage',
+			'sanitize_callback' => 'customify_color_sanitize_palettes',
+		) );
+	}
+	add_action( 'customize_register', 'customify_color_palette_register_settings', 1200 );
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Controls-side assets: localized data + the switcher inline script.
+// NOWDOC (no PHP interpolation) keeps the jQuery `$` literal so there is
+// no `\$`-escaping to get wrong.
+// ──────────────────────────────────────────────────────────────────
+
+if ( ! function_exists( 'customify_color_palette_switcher_assets' ) ) {
+	function customify_color_palette_switcher_assets() {
+		$data = array(
+			'presets'         => array_values( customify_color_preset_palettes() ),
+			'slots'           => customify_color_palette_slot_map(),
+			// Swatch-bar segment order — matches the Palette slot order shown in
+			// the Customizer (brand-first: Primary → Secondary → Accent → Text
+			// → Surface → Base) so the bar reads consistently with the pickers.
+			'barOrder'        => array( 'primary', 'secondary', 'accent', 'text', 'surface', 'base' ),
+			'activeSetting'   => 'customify_active_palette',
+			'palettesSetting' => 'customify_color_palettes',
+			'sectionId'       => 'sub-accordion-section-customify_colors',
+			'anchorId'        => 'customize-control-customify_colors_h_palette',
+			'i18n'            => array(
+				'palettes'   => __( 'Palettes', 'customify' ),
+				'theme'      => __( 'Theme', 'customify' ),
+				'custom'     => __( 'Custom', 'customify' ),
+				'newPalette' => __( 'New palette', 'customify' ),
+				'name'       => __( 'Palette name', 'customify' ),
+				'startFrom'  => __( 'Start from', 'customify' ),
+				'current'    => __( 'Current', 'customify' ),
+				'create'     => __( 'Create palette', 'customify' ),
+				'cancel'     => __( 'Cancel', 'customify' ),
+				'save'       => __( 'Save as new', 'customify' ),
+				'saveName'   => __( 'Save', 'customify' ),
+				'modified'   => __( 'Modified — diverges from', 'customify' ),
+				'import'     => __( 'Import palette(s) from JSON', 'customify' ),
+				'importBtn'  => __( 'Import', 'customify' ),
+				'exportLbl'  => __( 'Export', 'customify' ),
+				'all'        => __( 'All custom palettes', 'customify' ),
+				'copy'       => __( 'Copy', 'customify' ),
+				'download'   => __( 'Download', 'customify' ),
+				'close'      => __( 'Close', 'customify' ),
+				'rename'     => __( 'Rename', 'customify' ),
+				'delete'     => __( 'Delete', 'customify' ),
+				'nameReq'    => __( 'Please enter a palette name.', 'customify' ),
+				'badJson'    => __( 'Invalid JSON.', 'customify' ),
+				'badSlots'   => __( 'Each palette needs a name and 6 slots (base, surface, text, primary, secondary, accent).', 'customify' ),
+				'applied'    => __( 'Palette applied', 'customify' ),
+				'noCustom'   => __( 'No custom palettes yet — create one first.', 'customify' ),
+				'linkedTip'  => __( 'Linked to palette', 'customify' ),
+			),
+		);
+
+		$boot   = 'window._customifyPalettes = ' . wp_json_encode( $data ) . ";\n";
+		$script = <<<'JS'
+( function( $ ) {
+	'use strict';
+	var D = window._customifyPalettes || {};
+	var PRESETS = D.presets || [];
+	var SLOTMAP = D.slots || {};
+	var SLOT_KEYS = [ 'base', 'surface', 'text', 'primary', 'secondary', 'accent' ];
+	var BAR = D.barOrder || SLOT_KEYS;
+	var ACTIVE = D.activeSetting;
+	var STORE = D.palettesSetting;
+	var SECTION_ID = D.sectionId;
+	var ANCHOR_ID = D.anchorId;
+	var T = D.i18n || {};
+	// True while applyPalette() is driving the pickers, so the resulting slot
+	// changes aren't mistaken for a manual edit (which would sync into a custom).
+	var applying = false;
+
+	var SVG = {
+		check:  '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8.5l3.5 3.5L13 4.5"/></svg>',
+		pen:    '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M11 2.5l2.5 2.5L6 12.5 3 13l.5-3z"/></svg>',
+		trash:  '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4h10M6.5 4V2.5h3V4M4.5 4l.5 9h6l.5-9"/></svg>',
+		plus:   '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"><path d="M8 3v10M3 8h10"/></svg>',
+		imp:    '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2v8M5 7l3 3 3-3M3 13h10"/></svg>',
+		exp:    '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 11V3M5 6l3-3 3 3M3 13h10"/></svg>',
+		link:   '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6.5 9.5a2.6 2.6 0 0 0 3.7 0l2-2a2.6 2.6 0 1 0-3.7-3.7l-1 1"/><path d="M9.5 6.5a2.6 2.6 0 0 0-3.7 0l-2 2a2.6 2.6 0 1 0 3.7 3.7l1-1"/></svg>'
+	};
+
+	function esc( s ) {
+		return String( s == null ? '' : s ).replace( /[&<>"']/g, function( c ) {
+			return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ c ];
+		} );
+	}
+	function decodeVal( v ) {
+		if ( typeof v !== 'string' ) { return v; }
+		try { return JSON.parse( decodeURI( v ) ); } catch ( e ) { return v; }
+	}
+	function readSetting( id ) {
+		try { return wp.customize( id ).get(); } catch ( e ) { return undefined; }
+	}
+	function readSlotHex( key ) {
+		var v = decodeVal( readSetting( SLOTMAP[ key ] ) );
+		return ( typeof v === 'string' && v ) ? v.toLowerCase() : '';
+	}
+	function currentSlots() {
+		var s = {};
+		SLOT_KEYS.forEach( function( k ) { s[ k ] = readSlotHex( k ); } );
+		return s;
+	}
+	function getCustoms() {
+		try { var a = JSON.parse( readSetting( STORE ) || '[]' ); return Array.isArray( a ) ? a : []; }
+		catch ( e ) { return []; }
+	}
+	function setCustoms( arr ) { try { wp.customize( STORE ).set( JSON.stringify( arr ) ); } catch ( e ) {} }
+	function getActive() { return readSetting( ACTIVE ) || ''; }
+	function setActive( id ) { try { wp.customize( ACTIVE ).set( id || '' ); } catch ( e ) {} }
+
+	function allPalettes() {
+		var theme = PRESETS.map( function( p ) { return { id: p.id, name: p.name, kind: 'theme', slots: p.slots }; } );
+		var user = getCustoms().map( function( p ) { return { id: p.id, name: p.name, kind: 'user', slots: p.slots }; } );
+		return theme.concat( user );
+	}
+	function findPalette( id ) {
+		var all = allPalettes(), i;
+		for ( i = 0; i < all.length; i++ ) { if ( all[ i ].id === id ) { return all[ i ]; } }
+		return null;
+	}
+	function slotsMatch( a, b ) {
+		return SLOT_KEYS.every( function( k ) { return ( a[ k ] || '' ).toLowerCase() === ( b[ k ] || '' ).toLowerCase(); } );
+	}
+
+	// Apply a palette by driving the existing slot color pickers — the exact
+	// path the "From palette" quick-pick already uses, so the value is stored
+	// in the canonical format and live preview + save behave identically.
+	function applyPalette( slots ) {
+		applying = true;
+		try {
+			// Re-anchor each picker's reset/dirty baseline to the NEW palette BEFORE
+			// driving it, so the pickers' own dirty-check doesn't flash all six reset
+			// arrows during the switch.
+			syncSlotDefaults( { slots: slots }, true );
+			SLOT_KEYS.forEach( function( k ) {
+				var setting = SLOTMAP[ k ], hex = slots[ k ];
+				if ( ! setting || ! hex ) { return; }
+				var $panel = $( '#customize-control-' + setting + ' .customify--color-panel' );
+				if ( $panel.length && $.fn.wpColorPicker ) {
+					$panel.wpColorPicker( 'color', hex );
+				} else {
+					try { wp.customize( setting ).set( hex ); } catch ( e ) {}
+				}
+			} );
+		} finally {
+			// Always release — even if a picker throws mid-loop — so a stuck
+			// `applying` flag can't silently disable the custom auto-sync for the
+			// rest of the session. Release after the picker-driven changes settle
+			// so a real edit afterward is treated as manual.
+			setTimeout( function() { applying = false; }, 250 );
+		}
+	}
+
+	function barSegs( slots ) {
+		return BAR.map( function( k ) {
+			return '<span class="cps-seg" style="background:' + esc( slots[ k ] || '#000000' ) + '"></span>';
+		} ).join( '' );
+	}
+
+	// ---- panels (add / import / export) ----
+	var panel = null;       // 'add' | 'import' | 'export' | null
+	var fromSel = 'current';
+	var exportSel = 'all';
+
+	function chips() {
+		var opts = [ { id: 'current', name: T.current, slots: currentSlots() } ].concat( allPalettes() );
+		return opts.map( function( o ) {
+			var mini = BAR.map( function( k ) { return '<span style="background:' + esc( o.slots[ k ] || '#000000' ) + '"></span>'; } ).join( '' );
+			return '<span class="cps-chip' + ( o.id === fromSel ? ' is-sel' : '' ) + '" data-from="' + esc( o.id ) + '">'
+				+ '<span class="cps-mini">' + mini + '</span>' + esc( o.name ) + '</span>';
+		} ).join( '' );
+	}
+	function panelHtml() {
+		if ( panel === 'add' ) {
+			return '<div class="cps-form">'
+				+ '<label>' + esc( T.name ) + '</label>'
+				+ '<input type="text" class="cps-name-in" autocomplete="off" placeholder="My Brand">'
+				+ '<div class="cps-err" data-err></div>'
+				+ '<label>' + esc( T.startFrom ) + '</label>'
+				+ '<div class="cps-from">' + chips() + '</div>'
+				+ '<div class="cps-row"><button type="button" class="button-link" data-act="cancel">' + esc( T.cancel ) + '</button>'
+				+ '<button type="button" class="button button-primary" data-act="create">' + esc( T.create ) + '</button></div>'
+				+ '</div>';
+		}
+		if ( panel === 'import' ) {
+			return '<div class="cps-form">'
+				+ '<label>' + esc( T.import ) + '</label>'
+				+ '<textarea class="cps-json" rows="5" spellcheck="false" placeholder=\'{"name":"My Brand","slots":{"base":"#fff", ...}}\'></textarea>'
+				+ '<div class="cps-err" data-err></div>'
+				+ '<div class="cps-row"><button type="button" class="button-link" data-act="cancel">' + esc( T.cancel ) + '</button>'
+				+ '<button type="button" class="button button-primary" data-act="doimport">' + esc( T.importBtn ) + '</button></div>'
+				+ '</div>';
+		}
+		if ( panel === 'export' ) {
+			var customs = getCustoms();
+			if ( exportSel !== 'all' && ! customs.some( function( p ) { return p.id === exportSel; } ) ) { exportSel = 'all'; }
+			var options = [ '<option value="all">' + esc( T.all ) + ' (' + customs.length + ')</option>' ]
+				.concat( customs.map( function( p ) { return '<option value="' + esc( p.id ) + '"' + ( p.id === exportSel ? ' selected' : '' ) + '>' + esc( p.name ) + '</option>'; } ) ).join( '' );
+			return '<div class="cps-form">'
+				+ '<label>' + esc( T.exportLbl ) + '</label>'
+				+ '<select class="cps-exp-sel"' + ( customs.length ? '' : ' disabled' ) + '>' + options + '</select>'
+				+ '<textarea class="cps-exp-json" rows="5" readonly spellcheck="false">' + esc( exportJsonStr() ) + '</textarea>'
+				+ '<div class="cps-row"><button type="button" class="button-link" data-act="cancel">' + esc( T.close ) + '</button>'
+				+ '<button type="button" class="button" data-act="copy"' + ( customs.length ? '' : ' disabled' ) + '>' + esc( T.copy ) + '</button>'
+				+ '<button type="button" class="button button-primary" data-act="download"' + ( customs.length ? '' : ' disabled' ) + '>' + esc( T.download ) + '</button></div>'
+				+ '</div>';
+		}
+		return '';
+	}
+	function exportSubset() {
+		var customs = getCustoms();
+		if ( exportSel !== 'all' ) {
+			var one = customs.filter( function( p ) { return p.id === exportSel; } );
+			if ( one.length ) { return one; }
+		}
+		return customs;
+	}
+	function exportJsonStr() {
+		var sub = exportSubset();
+		return sub.length
+			? JSON.stringify( sub.map( function( p ) { return { name: p.name, slots: p.slots }; } ), null, 2 )
+			: '// ' + T.noCustom;
+	}
+
+	// Re-anchor each slot picker's "default" (the reset target + the dirty-glyph
+	// baseline) to the ACTIVE palette's value. Without this the pickers compare
+	// against the theme field-default, so every non-Sunrise palette lights up all
+	// six reset arrows and "reset" yanks a slot back to the theme baseline —
+	// breaking the chosen palette, or silently corrupting a custom one.
+	function syncSlotDefaults( activePal, skipGlyph ) {
+		if ( ! activePal || ! activePal.slots ) { return; }
+		SLOT_KEYS.forEach( function( k ) {
+			var setting = SLOTMAP[ k ];
+			var palVal = ( activePal.slots[ k ] || '' ).toLowerCase();
+			if ( ! palVal || ! setting ) { return; }
+			var li = document.getElementById( 'customize-control-' + setting );
+			if ( ! li ) { return; }
+			try { $( li ).find( '.customify--color-panel' ).wpColorPicker( 'option', 'defaultColor', palVal ); } catch ( e ) {}
+			var input = li.querySelector( 'input.wp-color-picker' );
+			if ( input ) { input.setAttribute( 'data-default-color', palVal ); }
+			var inner = li.querySelector( '.customify-input-color' );
+			if ( inner ) {
+				inner.setAttribute( 'data-default', palVal );
+				// During a palette switch (applying) the theme's own refreshDirtyState
+				// clears the glyph off the picker change events — skip our toggle so a
+				// render mid-switch can't flash a stale "dirty" state.
+				if ( ! skipGlyph && ! applying ) {
+					var cur = ( readSlotHex( k ) || '' ).toLowerCase();
+					inner.classList.toggle( 'is-dirty', !! cur && cur !== palVal );
+				}
+			}
+		} );
+	}
+
+	function render() {
+		if ( ! window.wp || ! wp.customize ) { return; }
+		var section = document.getElementById( SECTION_ID );
+		if ( ! section ) { return; }
+		var host = document.getElementById( 'customify-palette-switcher' );
+		if ( ! host ) {
+			host = document.createElement( 'li' );
+			host.id = 'customify-palette-switcher';
+			host.className = 'customize-control customify-cps';
+			var anchor = document.getElementById( ANCHOR_ID );
+			if ( anchor && anchor.parentNode ) {
+				anchor.parentNode.insertBefore( host, anchor );
+			} else {
+				var content = section.querySelector( '.customize-section-content' ) || section.querySelector( 'ul' ) || section;
+				content.insertBefore( host, content.firstChild );
+			}
+		}
+
+		var cur = currentSlots();
+		var pals = allPalettes();
+		var stored = getActive();            // the explicitly-applied palette ('' if none)
+		var storedPal = findPalette( stored );
+		var activePal = null, linked = false;
+		if ( storedPal && slotsMatch( cur, storedPal.slots ) ) {
+			activePal = storedPal; linked = true;          // on the applied palette, untouched
+		} else {
+			// Do the live slots exactly match SOME palette? (e.g. a section "reset
+			// to default" restores Sunrise's values.) Adopt it so the card + state
+			// stay honest — and so a legacy site with custom colours that never
+			// used palettes shows NOTHING active, not a bogus "Sunrise, modified"
+			// with every slot flagged dirty.
+			var matched = pals.filter( function( p ) { return slotsMatch( cur, p.slots ); } )[ 0 ];
+			if ( matched ) {
+				activePal = matched; linked = true;
+				// Persist the adopted id only when the customizer is ALREADY dirty
+				// (a user action like a reset) — never on a clean open, which would
+				// make merely viewing Colors look like an unsaved change.
+				var dirty = false;
+				try { dirty = wp.customize.state( 'saved' ).get() === false; } catch ( e ) {}
+				if ( dirty && stored !== matched.id ) { setActive( matched.id ); }
+			} else {
+				activePal = storedPal; linked = false;     // null when a legacy/custom site never applied a palette
+			}
+		}
+		var active = activePal ? activePal.id : '';
+
+		// On a custom palette the slots ARE the palette, so the per-slot "reset to
+		// theme default" glyph is meaningless — flag the section so CSS suppresses
+		// it (and its gutter). Otherwise the glyph flashes on/off while editing,
+		// because the dirty state is computed against the theme default + Iris
+		// rewrites the data-default attribute we can't reliably override in JS.
+		if ( section ) { section.classList.toggle( 'cps-active-custom', !! ( activePal && activePal.kind === 'user' ) ); }
+
+		var cards = pals.map( function( p ) {
+			var on = ( p.id === active );
+			var badge = p.kind === 'theme'
+				? '<span class="cps-badge">' + esc( T.theme ) + '</span>'
+				: '<span class="cps-badge cps-custom">' + esc( T.custom ) + '</span>';
+			var acts = p.kind === 'user'
+				? '<span class="cps-actions"><button type="button" class="cps-icon" data-act="rename" data-id="' + esc( p.id ) + '" aria-label="' + esc( T.rename ) + '" data-tip="' + esc( T.rename ) + '">' + SVG.pen + '</button>'
+				+ '<button type="button" class="cps-icon" data-act="delete" data-id="' + esc( p.id ) + '" aria-label="' + esc( T.delete ) + '" data-tip="' + esc( T.delete ) + '">' + SVG.trash + '</button></span>'
+				: '';
+			return '<div class="cps-card' + ( on ? ' is-active' : '' ) + ( on && linked ? ' is-linked' : '' ) + '" data-id="' + esc( p.id ) + '" tabindex="0" role="button">'
+				+ '<div class="cps-top"><span class="cps-name">' + esc( p.name ) + '</span>' + badge
+				+ '<span class="cps-spacer"></span>' + acts
+				+ '<span class="cps-link" title="' + esc( T.linkedTip ) + '">' + SVG.link + '</span>'
+				+ '<span class="cps-check">' + SVG.check + '</span></div>'
+				+ '<div class="cps-bar">' + barSegs( p.slots ) + '</div></div>';
+		} ).join( '' );
+
+		// "Modified — diverges from X" is only meaningful for read-only THEME
+		// presets. A custom palette absorbs edits live (maybeSyncCustom), so it
+		// never diverges from itself — no strip.
+		var modified = ( activePal && activePal.kind === 'theme' && ! linked )
+			? '<div class="cps-modified"><span>' + esc( T.modified + ' ' + activePal.name ) + '</span>'
+			+ '<button type="button" class="button button-small" data-act="saveas">' + esc( T.save ) + '</button></div>'
+			: '';
+
+		host.innerHTML =
+			'<div class="cps-head"><span class="cps-title">' + esc( T.palettes ) + '</span>'
+			+ '<span class="cps-tools">'
+			+   '<button type="button" class="cps-icon" data-act="import" aria-label="' + esc( T.importBtn ) + '" data-tip="' + esc( T.importBtn ) + '">' + SVG.imp + '</button>'
+			+   '<button type="button" class="cps-icon" data-act="export" aria-label="' + esc( T.exportLbl ) + '" data-tip="' + esc( T.exportLbl ) + '">' + SVG.exp + '</button>'
+			+   '<button type="button" class="cps-icon" data-act="add" aria-label="' + esc( T.newPalette ) + '" data-tip="' + esc( T.newPalette ) + '">' + SVG.plus + '</button>'
+			+ '</span></div>'
+			+ '<div class="cps-panel">' + panelHtml() + '</div>'
+			+ '<div class="cps-cards">' + cards + '</div>'
+			+ modified;
+
+		// Keep the 6 slot pickers' reset/dirty baseline pointed at the active
+		// palette (see syncSlotDefaults).
+		syncSlotDefaults( activePal );
+	}
+
+	// ---- event delegation ----
+	$( document ).on( 'click', '#customify-palette-switcher [data-act]', function( e ) {
+		e.preventDefault();
+		e.stopPropagation();
+		var act = this.getAttribute( 'data-act' );
+		var id = this.getAttribute( 'data-id' );
+		var host = document.getElementById( 'customify-palette-switcher' );
+
+		if ( act === 'add' ) { panel = ( panel === 'add' ? null : 'add' ); fromSel = 'current'; render(); focusFirst(); return; }
+		if ( act === 'import' ) { panel = ( panel === 'import' ? null : 'import' ); render(); focusFirst(); return; }
+		if ( act === 'export' ) { panel = ( panel === 'export' ? null : 'export' ); exportSel = 'all'; render(); return; }
+		if ( act === 'cancel' ) { panel = null; render(); return; }
+
+		if ( act === 'create' ) {
+			var name = ( host.querySelector( '.cps-name-in' ).value || '' ).trim();
+			var errEl = host.querySelector( '[data-err]' );
+			if ( ! name ) { if ( errEl ) { errEl.textContent = T.nameReq; } return; }
+			var base = ( fromSel === 'current' ) ? currentSlots() : ( findPalette( fromSel ) || {} ).slots;
+			if ( ! base ) { base = currentSlots(); }
+			var slots = {};
+			SLOT_KEYS.forEach( function( k ) { slots[ k ] = base[ k ] || '#000000'; } );
+			var pid = 'user-' + Date.now();
+			var customs = getCustoms();
+			customs.push( { id: pid, name: name, slots: slots } );
+			setCustoms( customs );
+			panel = null;
+			applyPalette( slots );
+			setActive( pid );
+			setTimeout( render, 60 );
+			return;
+		}
+
+		if ( act === 'doimport' ) {
+			var ta = host.querySelector( '.cps-json' );
+			var ierr = host.querySelector( '[data-err]' );
+			var data;
+			try { data = JSON.parse( ta.value ); } catch ( ex ) { if ( ierr ) { ierr.textContent = T.badJson; } return; }
+			var list = Array.isArray( data ) ? data : [ data ];
+			var customs2 = getCustoms();
+			var added = [];
+			for ( var i = 0; i < list.length; i++ ) {
+				var p = list[ i ];
+				if ( ! p || typeof p.name !== 'string' || ! p.name.trim() || ! p.slots ) { if ( ierr ) { ierr.textContent = T.badSlots; } return; }
+				var ok = true, sl = {};
+				for ( var j = 0; j < SLOT_KEYS.length; j++ ) {
+					var v = p.slots[ SLOT_KEYS[ j ] ];
+					if ( ! v || typeof v !== 'string' ) { ok = false; break; }
+					sl[ SLOT_KEYS[ j ] ] = v;
+				}
+				if ( ! ok ) { if ( ierr ) { ierr.textContent = T.badSlots; } return; }
+				var np = { id: 'user-' + Date.now() + '-' + i, name: p.name.trim(), slots: sl };
+				customs2.push( np ); added.push( np );
+			}
+			setCustoms( customs2 );
+			panel = null;
+			if ( added.length ) { applyPalette( added[ added.length - 1 ].slots ); setActive( added[ added.length - 1 ].id ); }
+			setTimeout( render, 60 );
+			return;
+		}
+
+		if ( act === 'copy' ) {
+			var tx = host.querySelector( '.cps-exp-json' );
+			if ( tx && navigator.clipboard ) { navigator.clipboard.writeText( tx.value ); }
+			return;
+		}
+		if ( act === 'download' ) {
+			var sub = exportSubset();
+			var fname = ( exportSel !== 'all' && sub.length === 1 )
+				? 'customify-palette-' + String( sub[ 0 ].name ).toLowerCase().replace( /[^a-z0-9]+/g, '-' ).replace( /^-|-$/g, '' ) + '.json'
+				: 'customify-palettes.json';
+			var blob = new Blob( [ exportJsonStr() ], { type: 'application/json' } );
+			var url = URL.createObjectURL( blob );
+			var a = document.createElement( 'a' ); a.href = url; a.download = fname; a.click(); URL.revokeObjectURL( url );
+			return;
+		}
+
+		if ( act === 'rename' && id ) {
+			var customs3 = getCustoms();
+			var target = customs3.filter( function( p ) { return p.id === id; } )[ 0 ];
+			if ( ! target ) { return; }
+			var card = this.closest( '.cps-card' );
+			var nameEl = card ? card.querySelector( '.cps-name' ) : null;
+			if ( ! nameEl ) { return; }
+			card.classList.add( 'is-renaming' ); // CSS hides badge / actions / check while editing
+			var inp = document.createElement( 'input' );
+			inp.type = 'text'; inp.className = 'cps-rename-in'; inp.value = target.name; inp.setAttribute( 'aria-label', T.rename );
+			nameEl.replaceWith( inp );
+			var saveBtn = document.createElement( 'button' );
+			saveBtn.type = 'button'; saveBtn.className = 'cps-icon cps-rename-save'; saveBtn.innerHTML = SVG.check;
+			saveBtn.setAttribute( 'aria-label', T.saveName ); saveBtn.setAttribute( 'data-tip', T.saveName );
+			inp.parentNode.insertBefore( saveBtn, inp.nextSibling );
+			inp.focus(); inp.select();
+			var done = false;
+			var commit = function() {
+				if ( done ) { return; }
+				done = true;
+				var nv = ( inp.value || '' ).trim();
+				if ( nv ) { target.name = nv; setCustoms( customs3 ); }
+				render();
+			};
+			var cancel = function() { if ( done ) { return; } done = true; render(); };
+			inp.addEventListener( 'click', function( ev ) { ev.stopPropagation(); } );
+			inp.addEventListener( 'mousedown', function( ev ) { ev.stopPropagation(); } );
+			inp.addEventListener( 'blur', commit );
+			inp.addEventListener( 'keydown', function( ev ) {
+				ev.stopPropagation(); // keep Space / Enter from bubbling to the card-activate handler
+				if ( ev.key === 'Enter' ) { ev.preventDefault(); commit(); }
+				else if ( ev.key === 'Escape' ) { ev.preventDefault(); cancel(); }
+			} );
+			// mousedown fires before the field's blur, so the save click commits cleanly.
+			saveBtn.addEventListener( 'mousedown', function( ev ) { ev.preventDefault(); ev.stopPropagation(); commit(); } );
+			return;
+		}
+
+		if ( act === 'delete' && id ) {
+			// 30K-safe: deleting NEVER recolors — just drop from the list and
+			// clear the active marker if it pointed here. Current slot values
+			// (what the site actually renders) are left untouched.
+			var customs4 = getCustoms().filter( function( p ) { return p.id !== id; } );
+			setCustoms( customs4 );
+			if ( getActive() === id ) { setActive( '' ); }
+			setTimeout( render, 60 );
+			return;
+		}
+
+		if ( act === 'saveas' ) {
+			var slotsNow = currentSlots();
+			var sn = {};
+			SLOT_KEYS.forEach( function( k ) { sn[ k ] = slotsNow[ k ] || '#000000'; } );
+			var base = findPalette( getActive() );
+			var nm = ( base ? base.name : T.custom ) + ' +';
+			var nid = 'user-' + Date.now();
+			var cs = getCustoms();
+			cs.push( { id: nid, name: nm, slots: sn } );
+			setCustoms( cs );
+			setActive( nid );
+			setTimeout( render, 60 );
+			return;
+		}
+	} );
+
+	// from-chip selection inside the add panel
+	$( document ).on( 'click', '#customify-palette-switcher .cps-chip', function( e ) {
+		e.preventDefault(); e.stopPropagation();
+		fromSel = this.getAttribute( 'data-from' );
+		var host = document.getElementById( 'customify-palette-switcher' );
+		$( host ).find( '.cps-chip' ).each( function() {
+			this.classList.toggle( 'is-sel', this.getAttribute( 'data-from' ) === fromSel );
+		} );
+	} );
+
+	// export selector change
+	$( document ).on( 'change', '#customify-palette-switcher .cps-exp-sel', function() {
+		exportSel = this.value;
+		var host = document.getElementById( 'customify-palette-switcher' );
+		var ta = host.querySelector( '.cps-exp-json' );
+		if ( ta ) { ta.value = exportJsonStr(); }
+	} );
+
+	// apply a palette by clicking its card (ignore clicks on inner buttons/inputs)
+	function cardActivate( card ) {
+		var pid = card.getAttribute( 'data-id' );
+		var p = findPalette( pid );
+		if ( ! p ) { return; }
+		// Colours already match this palette — nothing to apply. Skip the re-render
+		// so a click/drag on the name can select its text (and no needless
+		// "unsaved changes" from re-applying what's already shown).
+		if ( slotsMatch( currentSlots(), p.slots ) ) { return; }
+		applyPalette( p.slots );  // drive the pickers (≈7ms) — slots are now the palette
+		setActive( pid );
+		render();                 // instant active-state feedback (no 60ms wait)
+	}
+	$( document ).on( 'click', '#customify-palette-switcher .cps-card', function( e ) {
+		// Ignore the inline rename field + action buttons; clicking anywhere else
+		// (including the name) applies the palette.
+		if ( e.target.closest( '[data-act]' ) || e.target.closest( '.cps-rename-in' ) ) { return; }
+		cardActivate( this );
+	} );
+	$( document ).on( 'keydown', '#customify-palette-switcher .cps-card', function( e ) {
+		if ( e.target && e.target.tagName === 'INPUT' ) { return; } // don't hijack typing in the rename field
+		if ( e.key === 'Enter' || e.key === ' ' ) { e.preventDefault(); cardActivate( this ); }
+	} );
+
+	function focusFirst() {
+		var host = document.getElementById( 'customify-palette-switcher' );
+		if ( ! host ) { return; }
+		var el = host.querySelector( '.cps-name-in, .cps-json' );
+		if ( el ) { el.focus(); }
+	}
+
+	// ---- mount + live refresh ----
+	var rt = null;
+	function scheduleRender() {
+		clearTimeout( rt );
+		rt = setTimeout( function() {
+			// Only the debounced (setting-bind) path defers to an open form /
+			// inline rename so a slot change mid-typing can't wipe it. Direct
+			// render() calls from the action handlers always rebuild.
+			var host = document.getElementById( 'customify-palette-switcher' );
+			if ( host && host.querySelector( '.cps-form, .cps-rename-in' ) && host.contains( document.activeElement ) ) { return; }
+			render();
+		}, 90 );
+	}
+
+	// When a slot is edited manually while a CUSTOM palette is active, fold the
+	// new values into that palette so its card swatch + stored definition stay in
+	// sync (and persist on save). No-op when already in sync → no feedback loop.
+	function maybeSyncCustom() {
+		if ( applying ) { return; }
+		var act = getActive();
+		var pal = findPalette( act );
+		if ( ! pal || pal.kind !== 'user' ) { return; }
+		var cur = currentSlots();
+		if ( slotsMatch( cur, pal.slots ) ) { return; }
+		var customs = getCustoms().map( function( p ) {
+			return p.id === act ? { id: p.id, name: p.name, slots: cur } : p;
+		} );
+		setCustoms( customs );
+	}
+	var srt = null;
+	function onSlotEdit() {
+		if ( ! applying ) { clearTimeout( srt ); srt = setTimeout( maybeSyncCustom, 100 ); }
+		scheduleRender();
+	}
+	function bindSettings() {
+		[ ACTIVE, STORE ].forEach( function( id ) {
+			try { wp.customize( id, function( s ) { s.bind( scheduleRender ); } ); } catch ( e ) {}
+		} );
+		Object.keys( SLOTMAP ).forEach( function( k ) {
+			try { wp.customize( SLOTMAP[ k ], function( s ) { s.bind( onSlotEdit ); } ); } catch ( e ) {}
+		} );
+	}
+
+	function mount() {
+		if ( ! window.wp || ! wp.customize ) { return setTimeout( mount, 300 ); }
+		wp.customize.bind( 'ready', function() {
+			render();
+			bindSettings();
+			// section may render its controls lazily — re-render a couple times.
+			setTimeout( render, 400 );
+			setTimeout( render, 1200 );
+		} );
+		// also try immediately in case 'ready' already fired
+		setTimeout( function() { render(); bindSettings(); }, 600 );
+	}
+	$( mount );
+} )( jQuery );
+JS;
+
+		wp_add_inline_script( 'customize-controls', $boot . $script );
+	}
+	add_action( 'customize_controls_enqueue_scripts', 'customify_color_palette_switcher_assets' );
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Controls-side CSS — WordPress-admin look (native buttons/active blue),
+// with a hairline border around every swatch color so a white slot can't
+// melt into the card.
+// ──────────────────────────────────────────────────────────────────
+
+if ( ! function_exists( 'customify_color_palette_switcher_css' ) ) {
+	function customify_color_palette_switcher_css() {
+		?>
+<style id="customify-palette-switcher-css">
+#customify-palette-switcher.customify-cps { padding: 12px 0 14px; }
+.customify-cps .cps-head { display: flex; align-items: center; margin: 0 0 8px; }
+.customify-cps .cps-title { flex: 1; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .5px; color: #50575e; }
+.customify-cps .cps-tools { display: flex; gap: 2px; }
+.customify-cps .cps-icon { position: relative; width: 26px; height: 26px; padding: 0; display: inline-flex; align-items: center; justify-content: center; border: 0; background: transparent; color: #50575e; border-radius: 4px; cursor: pointer; }
+.customify-cps .cps-icon[data-tip]:hover::after { content: attr(data-tip); position: absolute; top: 100%; right: 0; margin-top: 4px; padding: 3px 7px; background: #1d2327; color: #fff; font-size: 11px; line-height: 1.5; white-space: nowrap; border-radius: 4px; pointer-events: none; z-index: 100; }
+.customify-cps .cps-icon:hover { background: #f0f0f1; color: #1d2327; }
+.customify-cps .cps-icon svg { width: 16px; height: 16px; }
+.customify-cps .cps-cards { display: flex; flex-direction: column; gap: 6px; }
+.customify-cps .cps-card { position: relative; background: #fff; border: 1px solid #dcdcde; border-radius: 4px; padding: 8px 10px; cursor: pointer; }
+.customify-cps .cps-card:hover { border-color: #8c8f94; }
+.customify-cps .cps-card.is-active { border-color: var(--wp-admin-theme-color, #3858e9); box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #3858e9); }
+.customify-cps .cps-top { display: flex; align-items: center; gap: 6px; min-height: 20px; }
+.customify-cps .cps-name { min-width: 0; font-size: 13px; font-weight: 600; color: #1d2327; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; user-select: text; }
+/* Only the name shrinks (truncates) — badge / check / icons keep their size so
+   the check circle can't get squished into an oval when the name is long. */
+.customify-cps .cps-badge, .customify-cps .cps-check, .customify-cps .cps-link, .customify-cps .cps-actions { flex-shrink: 0; }
+.customify-cps .cps-rename-in { flex: 1 1 auto; min-width: 0; font-size: 13px; font-weight: 600; padding: 1px 5px; border: 1px solid var(--wp-admin-theme-color, #3858e9); border-radius: 3px; }
+/* While renaming, hide everything else on the row so the field + save button own it. */
+.customify-cps .cps-card.is-renaming .cps-badge,
+.customify-cps .cps-card.is-renaming .cps-actions,
+.customify-cps .cps-card.is-renaming .cps-check,
+.customify-cps .cps-card.is-renaming .cps-link,
+.customify-cps .cps-card.is-renaming .cps-spacer { display: none !important; }
+.customify-cps .cps-rename-save { color: var(--wp-admin-theme-color, #3858e9); flex-shrink: 0; }
+.customify-cps .cps-rename-save:hover { background: color-mix(in srgb, var(--wp-admin-theme-color, #3858e9) 12%, #fff); color: var(--wp-admin-theme-color-darker-10, #2145e6); }
+.customify-cps .cps-badge { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: .4px; padding: 1px 5px; border-radius: 9px; background: #f0f0f1; color: #646970; }
+.customify-cps .cps-badge.cps-custom { background: color-mix(in srgb, var(--wp-admin-theme-color, #3858e9) 12%, #fff); color: var(--wp-admin-theme-color, #3858e9); }
+.customify-cps .cps-spacer { flex: 1; }
+.customify-cps .cps-actions { display: none; gap: 1px; }
+/* Card action icons match the row height so revealing them on hover doesn't grow the card (no jump). */
+.customify-cps .cps-actions .cps-icon { width: 20px; height: 20px; }
+.customify-cps .cps-actions .cps-icon svg { width: 14px; height: 14px; }
+.customify-cps .cps-card:hover .cps-actions { display: flex; }
+.customify-cps .cps-card.is-active .cps-actions { display: none; }
+.customify-cps .cps-card.is-active:hover .cps-actions { display: flex; }
+.customify-cps .cps-link { display: none; color: #50575e; opacity: .7; }
+.customify-cps .cps-link svg { width: 14px; height: 14px; }
+.customify-cps .cps-card.is-linked:not(:hover) .cps-link { display: inline-flex; }
+.customify-cps .cps-check { width: 18px; height: 18px; border-radius: 50%; background: var(--wp-admin-theme-color, #3858e9); color: #fff; display: none; align-items: center; justify-content: center; }
+.customify-cps .cps-check svg { width: 12px; height: 12px; }
+.customify-cps .cps-card.is-active .cps-check { display: inline-flex; }
+.customify-cps .cps-card.is-active.is-linked .cps-link { display: none; }
+/* Card preview = 6 round swatches (slot-picker style), compact + left-aligned with a fixed gap. */
+.customify-cps .cps-bar { display: flex; justify-content: flex-start; gap: 7px; align-items: center; margin-top: 9px; }
+.customify-cps .cps-seg { flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%; border: 1px solid rgba(0,0,0,0.15); box-shadow: 0 1px 2px rgba(0,0,0,0.08); box-sizing: border-box; }
+.customify-cps .cps-modified { display: flex; align-items: center; gap: 8px; margin-top: 10px; padding: 8px 10px; background: #fcf9e8; border: 1px solid #f0e2a0; border-radius: 4px; font-size: 12px; color: #7a5c00; }
+.customify-cps .cps-modified span { flex: 1; }
+.customify-cps .cps-panel:empty { display: none; }
+.customify-cps .cps-panel { margin-bottom: 8px; }
+.customify-cps .cps-form { background: #fff; border: 1px solid var(--wp-admin-theme-color, #3858e9); border-radius: 4px; padding: 10px; display: flex; flex-direction: column; gap: 8px; }
+.customify-cps .cps-form label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .4px; color: #646970; }
+.customify-cps .cps-form input[type=text], .customify-cps .cps-form textarea, .customify-cps .cps-form select { width: 100%; box-sizing: border-box; }
+.customify-cps .cps-form textarea { font-family: ui-monospace, Menlo, monospace; font-size: 11px; }
+.customify-cps .cps-row { display: flex; gap: 6px; justify-content: flex-end; align-items: center; }
+.customify-cps .cps-err { color: #d63638; font-size: 11px; min-height: 13px; }
+.customify-cps .cps-err:empty { min-height: 0; }
+.customify-cps .cps-from { display: flex; flex-wrap: wrap; gap: 5px; }
+.customify-cps .cps-chip { display: inline-flex; align-items: center; gap: 5px; padding: 3px 8px 3px 5px; border-radius: 12px; background: #f6f7f7; border: 1.5px solid transparent; cursor: pointer; font-size: 12px; color: #50575e; }
+.customify-cps .cps-chip.is-sel { border-color: var(--wp-admin-theme-color, #3858e9); background: color-mix(in srgb, var(--wp-admin-theme-color, #3858e9) 8%, #fff); color: #1d2327; }
+.customify-cps .cps-chip .cps-mini { display: flex; width: 18px; height: 14px; border-radius: 3px; overflow: hidden; box-shadow: inset 0 0 0 1px rgba(0,0,0,.18); }
+.customify-cps .cps-chip .cps-mini span { flex: 1; box-shadow: inset 0 0 0 1px rgba(0,0,0,.18); }
+/* When a CUSTOM palette is active, the slots already ARE that palette's values,
+   so suppress the per-slot reset glyph + its reserved gutter. Without this the
+   reset button flashes on then off while editing (dirty is computed vs the theme
+   default, and Iris rewrites the data-default we can't override in JS). */
+#sub-accordion-section-customify_colors.cps-active-custom .customify-input-color.is-dirty .wp-picker-input-wrap input.wp-picker-default { display: none !important; }
+#sub-accordion-section-customify_colors.cps-active-custom .customize-control-title,
+#sub-accordion-section-customify_colors.cps-active-custom .customize-control-description { padding-right: 0 !important; }
+</style>
+		<?php
+	}
+	add_action( 'customize_controls_print_styles', 'customify_color_palette_switcher_css' );
+}

--- a/inc/colors-palette.php
+++ b/inc/colors-palette.php
@@ -524,11 +524,10 @@ if ( ! function_exists( 'customify_color_palette_root_css' ) ) {
 		// boundary that's the ONLY cue identifying a functional control.
 		$border_strong_default = customify_color_solve_border_strong( $slots['text'], $slots['base'] );
 		$primary_hover_default = customify_color_mix_hex( $slots['primary'], '#000000', 0.90 ); // primary at 90%, black at 10%
-		// Link hover = primary mixed with WHITE 15% (lighter, not darker).
-		// Hover state surfaces the link by raising luminance. Note: the
-		// existing button :hover (primary_hover) goes the other direction
-		// (darker) — different UX semantic: buttons depress, links surface.
-		$link_hover_default    = customify_color_mix_hex( $slots['primary'], '#FFFFFF', 0.85 );
+		// Link hover defaults to the SAME as link (which itself defaults to the
+		// Primary slot) — hovering keeps the link colour unless the user saves a
+		// Link-hover override. Project-owner decision (was: link lighter 15%).
+		$link_hover_default    = $slots['primary'];
 		// Body text default = slot.text directly (same pattern as heading).
 		// Earlier Phase 2.3 used mix(text, base, 88%) for a softer ink,
 		// but that desaturates the user's Text slot — e.g. setting Text to
@@ -846,6 +845,12 @@ if ( ! function_exists( 'customify_color_palette_root_css' ) ) {
 		if ( ! $ov_link ) {
 			$lines[] = "--customify-link: var(--customify-primary, {$slots['primary']})";
 		}
+		// Link-hover cascade — follows Link (which follows Primary) so hovering
+		// keeps the link colour unless a Link-hover override is saved. Pure var()
+		// chain (no color-mix) now that hover == link.
+		if ( ! $ov_link_hover ) {
+			$lines[] = "--customify-link-hover: var(--customify-link, {$link_hover_default})";
+		}
 
 		$static_root = ':root{' . implode( ';', $lines ) . ';}';
 
@@ -872,13 +877,8 @@ if ( ! function_exists( 'customify_color_palette_root_css' ) ) {
 			$mix_lines[] = '--customify-border: color-mix(in oklab, var(--customify-text) 9%, var(--customify-base))';
 		}
 		$mix_lines[] = '--customify-primary-hover: color-mix(in oklab, var(--customify-primary), black 10%)';
-		// Link hover cascade — LIGHTER variant of link (which itself cascades
-		// from primary unless overridden). 15% white mixed in oklab keeps
-		// perceived hue stable while lifting luminance. Saved override
-		// suppresses the cascade so legacy explicit values still win.
-		if ( ! $ov_link_hover ) {
-			$mix_lines[] = '--customify-link-hover: color-mix(in oklab, var(--customify-link) 85%, white)';
-		}
+		// Link-hover is now a pure var() chain (= Link) emitted in the static
+		// $lines block above — no @supports color-mix line needed.
 
 		$css = $static_root;
 		if ( $mix_lines ) {
@@ -968,6 +968,7 @@ if ( ! function_exists( 'customify_color_palette_quickpick_js' ) ) {
 	// picker writes a real value and breaks out of cascade mode.
 	var CASCADE_MAP = {
 		'global_styling_color_link':         'global_styling_color_primary',
+		'global_styling_color_link_hover':   'global_styling_color_link',
 		'global_styling_color_heading':      'customify_palette_text',
 		'global_styling_color_w_title':      'customify_palette_text',
 		'global_styling_color_text':         'customify_palette_text'
@@ -977,6 +978,7 @@ if ( ! function_exists( 'customify_color_palette_quickpick_js' ) ) {
 	// Mirrors the 'default' keys in inc/customizer/configs/colors.php.
 	var FIELD_DEFAULTS = {
 		'global_styling_color_link':         '#235787',
+		'global_styling_color_link_hover':   '#235787',
 		'global_styling_color_heading':      '#2b2b2b',
 		'global_styling_color_w_title':      '#2b2b2b',
 		'global_styling_color_text':         '#2b2b2b'
@@ -986,6 +988,19 @@ if ( ! function_exists( 'customify_color_palette_quickpick_js' ) ) {
 	function decodeValue(v) {
 		if (typeof v !== 'string') return v;
 		try { return JSON.parse(decodeURI(v)); } catch (e) { return v; }
+	}
+
+	// Resolve a setting's EFFECTIVE cascade value by walking the chain when the
+	// setting is itself unset (= empty or its field default). e.g. link-hover
+	// cascades from link, which cascades from primary — so the link-hover swatch
+	// tracks Primary even though its direct source is Link.
+	function resolveCascadeValue(id) {
+		var val = decodeValue(wp.customize(id).get() || '');
+		var src = CASCADE_MAP[id];
+		if (src && (val === '' || val === FIELD_DEFAULTS[id])) {
+			return resolveCascadeValue(src);
+		}
+		return val;
 	}
 
 	// Sync the override picker's swatch to its cascade source when the
@@ -1003,7 +1018,7 @@ if ( ! function_exists( 'customify_color_palette_quickpick_js' ) ) {
 			li.style.removeProperty('--customify-cascade-display');
 			return;
 		}
-		var cascadeValue = decodeValue(wp.customize(sourceId).get() || '');
+		var cascadeValue = resolveCascadeValue(sourceId);
 		if (!cascadeValue) return;
 		li.classList.add('is-cascading');
 		li.style.setProperty('--customify-cascade-display', cascadeValue);
@@ -1461,7 +1476,7 @@ if ( ! function_exists( 'customify_color_palette_preview_js' ) ) {
 		'--customify-body-text':    'var(--customify-text)',
 		'--customify-widget-title': 'var(--customify-text)',
 		'--customify-link':         'var(--customify-primary)',
-		'--customify-link-hover':   'color-mix(in oklab, var(--customify-link) 85%, white)',
+		'--customify-link-hover':   'var(--customify-link)',
 		'--customify-text-muted':   'color-mix(in oklab, var(--customify-text) 70%, var(--customify-base))',
 		'--customify-border':       'color-mix(in oklab, var(--customify-text) 9%, var(--customify-base))'
 	};
@@ -1745,9 +1760,15 @@ if ( ! function_exists( 'customify_color_palette_preview_js' ) ) {
 		'customify_palette_surface',
 		'customify_palette_base'
 	];
+	// Debounce: a palette switch changes all six slots at once; binding the raw
+	// recomputeDerived would run the OKLab derivation six times back-to-back and
+	// block the preview paint (~100ms+). Coalesce into ONE recompute ~24ms after
+	// the last slot settles — imperceptible for a drag, snappy for a switch.
+	var _cfyRderiveT;
+	function recomputeDerivedDebounced(){ clearTimeout(_cfyRderiveT); _cfyRderiveT = setTimeout(recomputeDerived, 24); }
 	SOURCE_SLOTS.forEach(function(setting){
 		wp.customize(setting, function(value){
-			value.bind(recomputeDerived);
+			value.bind(recomputeDerivedDebounced);
 		});
 	});
 	// Prime the initial state on load so the preview iframe shows

--- a/inc/customizer/configs/colors.php
+++ b/inc/customizer/configs/colors.php
@@ -222,20 +222,20 @@ if ( ! function_exists( 'customify_customizer_colors_config' ) ) {
 				'selector'    => 'format',
 			),
 
-			// Link hover color — REUSE existing key. Default = link lighter
-			// 15% (mix with white) so the hover state surfaces the link by
-			// raising luminance. Fresh installs shift from legacy `#111111`
-			// (near-black) to `#406F99` — a much bigger jump than other
-			// overrides; explicit design call by the project owner.
+			// Link hover color — REUSE existing key. Default = same as Link color
+			// (which itself cascades from the Primary slot), so hovering keeps the
+			// link colour unless the user overrides it. Fresh installs shift from
+			// legacy `#111111` to `#235787` (Primary); saved overrides untouched.
+			// Project-owner decision (was: Link lighter 15% = `#406F99`).
 			array(
 				'name'        => 'global_styling_color_link_hover',
 				'type'        => 'color',
 				'section'     => $section,
 				'priority'    => 26,
 				'title'       => __( 'Link hover color', 'customify' ),
-				'description' => __( 'Default: derived (Link color lighter 15%).', 'customify' ),
-				'default'     => '#406F99',
-				'placeholder' => '#406F99',
+				'description' => __( 'Default: same as Link color.', 'customify' ),
+				'default'     => '#235787',
+				'placeholder' => '#235787',
 				'css_format'  => '',
 				'selector'    => 'format',
 			),


### PR DESCRIPTION
## What

A card-based **palette switcher** at the top of the Customizer **Colors** section (`customify_colors`):

- Preset palettes **Sunrise** (light) + **Midnight** (dark), plus user **custom palettes** (create-from-current / rename / delete / import / export JSON).
- Applying a palette drives the **6 existing slot color-pickers** via `wpColorPicker('color', hex)` — the same path the existing quick-pick already used. **No new render path, no new rendered CSS token.**
- **Link-hover default shift**: `global_styling_color_link_hover` now defaults to **Link → Primary** (pure `var()` cascade) instead of `mix(primary 85%, white)`. Saved link-hover overrides are untouched.

## Storage (additive — 30K-safe)

| Key | Type | Default | Role |
|---|---|---|---|
| `customify_active_palette` | string | `''` | id of the palette the slots match — **bookkeeping only, nothing renders from it** |
| `customify_color_palettes` | JSON | `'[]'` | custom palettes `[{id,name,slots}]` |

The **6 slots reuse their existing keys** (`global_styling_color_primary`/`_secondary`, `customify_palette_*`). No key renamed/removed, no saved hex changed.

## 30K-safety

- Clean open on a legacy saved-custom site → **no card active, no "modified" strip, no write, customizer not dirtied**.
- Active state is **inferred from slot equality**; the stored id is persisted only when the customizer is already dirty — never on a clean open.
- Custom-palette import is hardened server-side (`customify_color_sanitize_palettes`: normalize every slot hex, drop bad entries, sanitize names, cap at 100, no preset-id collision); inline JS escapes all user values before `innerHTML`.

## QA

Full functional suite passed (**SHIP**): fresh-default = Sunrise linked, saved-custom clean open, apply preset, section-reset reconciliation, custom CRUD, import/export + malicious XSS, link-hover cascade + override, per-slot reset baseline, persist across save+reload, front-end render unchanged. See `docs/temp/palette-switcher-qa-handoff.md` for the full test matrix.

> Note: `docs/temp/palette-switcher-qa-handoff.md` is internal QA scaffolding — safe to drop before promoting DEV → master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
