### PR TITLE
Customizer IA: Colors/Typography sections, Content/Plugins/Core groups, is_tax + CPT-gate fixes

### DIFF
--- a/docs/SPEC-customizer-colors.md
+++ b/docs/SPEC-customizer-colors.md
@@ -585,10 +585,10 @@ inc/
         │                                       dividers + 6 slot pickers +
         │                                       relocated link/background/
         │                                       override fields
-        ├── styling.php                   MODIFIED — stripped to just the
-        │                                            styling_panel
-        │                                            registration (Typography/
-        │                                            Layouts still use it)
+        ├── styling.php                   MODIFIED — styling_panel registration
+        │                                            removed (panel is empty after
+        │                                            the colors move); callback
+        │                                            kept as a no-op stub
         └── background.php                MODIFIED — class stub with no-op
                                                      config() (3 composites
                                                      moved to colors.php;

--- a/docs/SPEC-customizer.md
+++ b/docs/SPEC-customizer.md
@@ -118,7 +118,7 @@ add_filter( 'customify/customizer/config', function ( $items ) {
     $items[] = array(
         'name'     => 'my_feature_section',
         'type'     => 'section',
-        'panel'    => 'styling_panel',
+        'panel'    => 'typography_panel',
         'title'    => __( 'My Feature', 'customify' ),
         'priority' => 50,
     );
@@ -158,11 +158,11 @@ No code in `functions.php`, no manual `add_setting()` calls, no separate CSS fil
 
 ```php
 array(
-    'name'        => 'styling_panel',
+    'name'        => 'example_panel',
     'type'        => 'panel',
-    'title'       => __( 'Styling', 'customify' ),
+    'title'       => __( 'Example', 'customify' ),
     'priority'    => 22,
-    'description' => __( 'Colors, typography, layouts', 'customify' ),  // optional
+    'description' => __( 'My custom panel', 'customify' ),  // optional
 )
 ```
 
@@ -172,7 +172,7 @@ array(
 array(
     'name'     => 'global_styling',
     'type'     => 'section',
-    'panel'    => 'styling_panel',         // required to nest inside a panel
+    'panel'    => 'example_panel',         // required to nest inside a panel
     'title'    => __( 'Global Colors', 'customify' ),
     'priority' => 10,
 )

--- a/inc/admin/dashboard-v2.php
+++ b/inc/admin/dashboard-v2.php
@@ -303,7 +303,7 @@ function customify_dashboard_v2_boot_data(): array {
 				$customize
 			),
 			'typography'     => add_query_arg(
-				array( 'autofocus' => array( 'panel' => 'typography_panel' ) ),
+				array( 'autofocus' => array( 'section' => 'typography_panel' ) ),
 				$customize
 			),
 			'sidebar'        => add_query_arg(

--- a/inc/admin/dashboard-v2.php
+++ b/inc/admin/dashboard-v2.php
@@ -296,8 +296,10 @@ function customify_dashboard_v2_boot_data(): array {
 				array( 'autofocus' => array( 'panel' => 'footer_settings' ) ),
 				$customize
 			),
+			// Styling panel retired; deep-link to the top-level "Colors" section
+			// (inc/customizer/configs/colors.php) which now owns styling/colors.
 			'styling'        => add_query_arg(
-				array( 'autofocus' => array( 'panel' => 'styling_panel' ) ),
+				array( 'autofocus' => array( 'section' => 'customify_colors' ) ),
 				$customize
 			),
 			'typography'     => add_query_arg(

--- a/inc/admin/dashboard.php
+++ b/inc/admin/dashboard.php
@@ -336,7 +336,8 @@ class Customify_Dashboard
 			),
 			array(
 				'label' => __('Typography', 'customify'),
-				'url'   => add_query_arg(array('autofocus' => array('panel' => 'typography_panel')), $url),
+				// Typography is now a top-level section (was a panel); deep-link to it.
+				'url'   => add_query_arg(array('autofocus' => array('section' => 'typography_panel')), $url),
 			),
 			array(
 				'label' => __('Sidebar Settings', 'customify'),

--- a/inc/admin/dashboard.php
+++ b/inc/admin/dashboard.php
@@ -330,7 +330,9 @@ class Customify_Dashboard
 			),
 			array(
 				'label' => __('Styling', 'customify'),
-				'url'   => add_query_arg(array('autofocus' => array('panel' => 'styling_panel')), $url),
+				// Styling panel retired; colors/styling now live in the top-level
+				// "Colors" section (inc/customizer/configs/colors.php).
+				'url'   => add_query_arg(array('autofocus' => array('section' => 'customify_colors')), $url),
 			),
 			array(
 				'label' => __('Typography', 'customify'),

--- a/inc/customizer/class-customizer.php
+++ b/inc/customizer/class-customizer.php
@@ -1347,8 +1347,11 @@ class  Customify_Customizer {
 					'footer_settings',
 				),
 			),
+			// Group KEY stays `post_types` — it's a documented
+			// `customify/customizer/panel_groups` extension point (companion plugins
+			// append panels to it), so only the display title changed to "Content".
 			'post_types'      => array(
-				'title'    => __( 'Post Types', 'customify' ),
+				'title'    => __( 'Content', 'customify' ),
 				'priority' => 350,
 				'panels'   => array(
 					'blog_panel',
@@ -1357,21 +1360,29 @@ class  Customify_Customizer {
 					'portfolio_panel',
 				),
 			),
-			'core_plugins'    => array(
-				'title'    => __( 'Core & Plugins', 'customify' ),
-				'priority' => 1000,
+			// Theme + plugin integration settings, sitting above the WP-core group.
+			'plugins'         => array(
+				'title'    => __( 'Plugins', 'customify' ),
+				'priority' => 600,
 				'panels'   => array(
-					// Compatibility is a theme panel but conceptually belongs with the
-					// plugin-integration settings, so it heads the Core & Plugins group.
-					'compatibility_panel',
 					// WooCommerce registers its own panel (id `woocommerce`) OUTSIDE
-					// Customify's config, so register_panel_groups() would otherwise
-					// bump it +2000 to the bottom of the foreign zone. Listing it here
-					// pins it directly under Compatibility; the same method now exempts
-					// grouped panels from that bump. Harmless when WC is inactive (the
-					// panel simply doesn't exist).
+					// Customify's config; register_panel_groups() exempts grouped panels
+					// from the +2000 foreign bump, so it sits here cleanly. Absent (no-op)
+					// when WooCommerce is inactive — Compatibility still anchors the group.
 					'woocommerce',
+					// Compatibility is the theme's plugin-SUPPORT panel, so it belongs with
+					// the plugin integrations — not with the WP-core group.
+					'compatibility_panel',
 				),
+			),
+			// Key stays `core_plugins` (kept for any external panel_groups filter);
+			// title is now just "Core" — the WP-core items (Menus, Widgets, Homepage
+			// Settings, Additional CSS) get bumped into this zone. Compatibility +
+			// WooCommerce now live in the "Plugins" group above.
+			'core_plugins'    => array(
+				'title'    => __( 'Core', 'customify' ),
+				'priority' => 1000,
+				'panels'   => array(),
 			),
 		);
 

--- a/inc/customizer/class-customizer.php
+++ b/inc/customizer/class-customizer.php
@@ -1330,7 +1330,11 @@ class  Customify_Customizer {
 				'title'    => __( 'General Options', 'customify' ),
 				'priority' => 50,
 				'panels'   => array(
-					'styling_panel',
+					// Colors is a top-level SECTION (not a panel) — the
+					// get_section() fallback in register_panel_groups() positions
+					// it deterministically (priority 60) as the first entry here.
+					// Replaces the now-removed empty `styling_panel`.
+					'customify_colors',
 					'typography_panel',
 				),
 			),
@@ -1360,6 +1364,13 @@ class  Customify_Customizer {
 					// Compatibility is a theme panel but conceptually belongs with the
 					// plugin-integration settings, so it heads the Core & Plugins group.
 					'compatibility_panel',
+					// WooCommerce registers its own panel (id `woocommerce`) OUTSIDE
+					// Customify's config, so register_panel_groups() would otherwise
+					// bump it +2000 to the bottom of the foreign zone. Listing it here
+					// pins it directly under Compatibility; the same method now exempts
+					// grouped panels from that bump. Harmless when WC is inactive (the
+					// panel simply doesn't exist).
+					'woocommerce',
 				),
 			),
 		);
@@ -1406,9 +1417,10 @@ class  Customify_Customizer {
 			foreach ( $group['panels'] as $name ) {
 				$obj = $wp_customize->get_panel( $name );
 				if ( ! $obj ) {
-					// Fall back to a top-level section with the same name (the upsell
-					// strip in upsell.php uses this shape — kept here for symmetry even
-					// though no current group references a top-level section).
+					// Fall back to a top-level section with the same name. The
+					// "General Options" group relies on this to position the Colors
+					// section (`customify_colors`); the upsell strip in upsell.php
+					// uses the same shape.
 					$section = $wp_customize->get_section( $name );
 					if ( $section && empty( $section->panel ) ) {
 						$obj = $section;
@@ -1425,8 +1437,18 @@ class  Customify_Customizer {
 		$managed       = self::get_config();
 		$divider_token = 'customify_divider_';
 
+		// Panels explicitly placed into a group in step 1 keep that position — do
+		// NOT bump them even when foreign (e.g. the WooCommerce panel, pinned under
+		// Compatibility). Without this, step 1's positioning would be undone here.
+		$grouped_panels = array();
+		foreach ( $groups as $group ) {
+			foreach ( $group['panels'] as $name ) {
+				$grouped_panels[ $name ] = true;
+			}
+		}
+
 		foreach ( $wp_customize->panels() as $panel_id => $panel ) {
-			if ( isset( $managed[ 'panel|' . $panel_id ] ) ) {
+			if ( isset( $managed[ 'panel|' . $panel_id ] ) || isset( $grouped_panels[ $panel_id ] ) ) {
 				continue;
 			}
 			$panel->priority = (int) $panel->priority + 2000;

--- a/inc/customizer/configs/colors.php
+++ b/inc/customizer/configs/colors.php
@@ -77,10 +77,13 @@ if ( ! function_exists( 'customify_customizer_colors_config' ) ) {
 			// ──────────────────────────────────────────────────────────
 			// Top-level Section "Colors" (root, not in any panel).
 			// ──────────────────────────────────────────────────────────
-			// Position: between Styling (60) and Typography (70) in the
-			// General Options group (divider at 50). Priority 65 keeps
-			// Colors directly above Typography — sidebar order reads
-			// General Options → Styling → Colors → Typography → Layouts ….
+			// Position: anchored as the FIRST entry of the "General Options"
+			// panel group (divider at 50) by get_panel_groups() in
+			// inc/customizer/class-customizer.php, which assigns it priority 60
+			// at customize_register:99999 — sidebar order reads
+			// General Options → Colors → Typography → Layouts ….
+			// The 65 below is only a fallback for the unlikely case the group
+			// registration is filtered out; the group mechanism overrides it.
 			array(
 				'name'        => $section,
 				'type'        => 'section',

--- a/inc/customizer/configs/layouts.php
+++ b/inc/customizer/configs/layouts.php
@@ -252,7 +252,7 @@ if ( ! function_exists( 'customify_customizer_layouts_config' ) ) {
 			),
 		);
 
-		$post_types = Customify()->get_post_types( false );
+		$post_types = customify_get_content_post_types();
 
 		if ( count( $post_types ) ) {
 			$config[] = array(

--- a/inc/customizer/configs/page-header.php
+++ b/inc/customizer/configs/page-header.php
@@ -149,7 +149,7 @@ class Customify_Page_Header {
 			),
 		);
 
-		$post_types = Customify()->get_post_types( false );
+		$post_types = customify_get_content_post_types();
 		if ( count( $post_types ) > 0 ) {
 			foreach ( $post_types as $pt => $label ) {
 				$display_fields[] = array(

--- a/inc/customizer/configs/page-header.php
+++ b/inc/customizer/configs/page-header.php
@@ -806,14 +806,20 @@ class Customify_Page_Header {
 
 		if ( is_tax() ) {
 			$queried_object = get_queried_object();
-			if ( isset( $display[ $queried_object->taxonomy ] ) ) {
-				$args['display'] = $display['product_tag'];
+			$tax            = $queried_object->taxonomy;
+			// Use the queried taxonomy's OWN slice. Previously this assigned
+			// $display['product_tag'] for any taxonomy, and assigned a title
+			// string to ['display'] — a bug that stopped custom-taxonomy page
+			// headers from working. Guarded on non-empty so an unset slice falls
+			// through to the is_archive() defaults resolved above.
+			if ( ! empty( $display[ $tax ] ) ) {
+				$args['display'] = $display[ $tax ];
 			}
-			if ( isset( $titles[ $queried_object->taxonomy ] ) ) {
-				$args['display'] = $titles[ $queried_object->taxonomy ];
+			if ( isset( $titles[ $tax ] ) && '' !== $titles[ $tax ] ) {
+				$args['title'] = $titles[ $tax ];
 			}
-			if ( isset( $taglines[ $queried_object->taxonomy ] ) ) {
-				$args['tagline'] = $taglines[ $queried_object->taxonomy ];
+			if ( isset( $taglines[ $tax ] ) && '' !== $taglines[ $tax ] ) {
+				$args['tagline'] = $taglines[ $tax ];
 			}
 			$args['_page'] = 'tax_' . $queried_object->taxonomy;
 		}

--- a/inc/customizer/configs/styling.php
+++ b/inc/customizer/configs/styling.php
@@ -1,33 +1,30 @@
 <?php
 /**
- * Customizer config: Styling panel registration.
+ * Customizer config: Styling panel (retired).
  *
- * Note: Site-wide color fields previously registered here (Global Colors section)
- * have been moved to inc/customizer/configs/colors.php — a new top-level
- * "Colors" section that consolidates palette + links + backgrounds + overrides.
+ * The Styling panel and every site-wide color field that used to live under it
+ * were consolidated into the new top-level "Colors" section
+ * (inc/customizer/configs/colors.php). Nothing registers under `styling_panel`
+ * anymore, so the empty panel registration has been removed — an empty panel is
+ * dead registration (WordPress hides panels with no sections) and it needlessly
+ * reserved a slot in the "General Options" panel group.
  *
- * The styling_panel registration is kept here because typography.php and
- * layouts.php still register sections under it.
+ * The `customify_customizer_styling_config()` callback is kept as a no-op: it is
+ * a public `customify/customizer/config` filter callback (AGENTS.md §4.2 — never
+ * delete public functions), so external code that references it keeps working.
+ * No theme_mod keys are touched; saved values on existing sites are unaffected.
+ *
+ * Colors is anchored into the General Options group via get_panel_groups() in
+ * inc/customizer/class-customizer.php — not via a raw priority here.
  *
  * @package Customify
  */
 
 if ( ! function_exists( 'customify_customizer_styling_config' ) ) {
 	function customify_customizer_styling_config( $configs ) {
-
-		$config = array(
-
-			// Styling panel — kept; Typography + Layouts sections register under it.
-			array(
-				'name'     => 'styling_panel',
-				'type'     => 'panel',
-				'priority' => 22,
-				'title'    => __( 'Styling', 'customify' ),
-			),
-
-		);
-
-		return array_merge( $configs, $config );
+		// Styling panel retired — the Colors section now owns these settings.
+		// See inc/customizer/configs/colors.php.
+		return $configs;
 	}
 }
 

--- a/inc/customizer/configs/typography.php
+++ b/inc/customizer/configs/typography.php
@@ -6,6 +6,16 @@ if ( ! function_exists( 'customify_customizer_typography_config' ) ) {
 	 * @since 0.0.1
 	 * @since 0.2.6
 	 *
+	 * `typography_panel` is a top-level SECTION (formerly a panel) — like the
+	 * Colors section, clicking "Typography" drops straight into the controls
+	 * instead of an intermediate list. The former Base / Site Title & Tagline /
+	 * Content sub-sections are now `heading` separators inside this one section.
+	 *
+	 * The id stays `typography_panel` (the General Options panel group positions it
+	 * via the get_section() fallback, and the Dashboard deep-links target it).
+	 * Control names (= theme_mod keys) are unchanged, so saved values on existing
+	 * sites are unaffected.
+	 *
 	 * @param array $configs
 	 * @return array
 	 */
@@ -16,23 +26,23 @@ if ( ! function_exists( 'customify_customizer_typography_config' ) ) {
 		$config = array(
 			array(
 				'name'     => 'typography_panel',
-				'type'     => 'panel',
+				'type'     => 'section',
 				'priority' => 22,
 				'title'    => __( 'Typography', 'customify' ),
 			),
 
-			// Base.
+			// ───────── Base ─────────
 			array(
-				'name'  => "{$section}_base",
-				'type'  => 'section',
-				'panel' => 'typography_panel',
-				'title' => __( 'Base', 'customify' ),
+				'name'    => "{$section}_h_base",
+				'type'    => 'heading',
+				'section' => 'typography_panel',
+				'title'   => __( 'Base', 'customify' ),
 			),
 
 			array(
 				'name'        => "{$section}_base_p",
 				'type'        => 'typography',
-				'section'     => "{$section}_base",
+				'section'     => 'typography_panel',
 				'title'       => __( 'Body & Paragraph', 'customify' ),
 				'description' => __( 'Apply to body and paragraph text.', 'customify' ),
 				'css_format'  => 'typography',
@@ -42,7 +52,7 @@ if ( ! function_exists( 'customify_customizer_typography_config' ) ) {
 			array(
 				'name'        => "{$section}_base_heading",
 				'type'        => 'typography',
-				'section'     => "{$section}_base",
+				'section'     => 'typography_panel',
 				'title'       => __( 'Heading', 'customify' ),
 				'description' => __( 'Apply to all heading elements.', 'customify' ),
 				'css_format'  => 'typography',
@@ -56,25 +66,25 @@ if ( ! function_exists( 'customify_customizer_typography_config' ) ) {
 			array(
 				'name'        => "{$section}_base_widget_title",
 				'type'        => 'typography',
-				'section'     => "{$section}_base",
+				'section'     => 'typography_panel',
 				'title'       => __( 'Widget Title', 'customify' ),
 				'description' => __( 'Apply to all widget title in site content.', 'customify' ),
 				'css_format'  => 'typography',
 				'selector'    => '.site-content .widget-title',
 			),
 
-			// Site Title and Tagline.
+			// ───────── Site Title & Tagline ─────────
 			array(
-				'name'  => "{$section}_site_tt",
-				'type'  => 'section',
-				'panel' => 'typography_panel',
-				'title' => __( 'Site Title & Tagline', 'customify' ),
+				'name'    => "{$section}_h_site_tt",
+				'type'    => 'heading',
+				'section' => 'typography_panel',
+				'title'   => __( 'Site Title & Tagline', 'customify' ),
 			),
 
 			array(
 				'name'       => "{$section}_site_tt_title",
 				'type'       => 'typography',
-				'section'    => "{$section}_site_tt",
+				'section'    => 'typography_panel',
 				'title'      => __( 'Site Title', 'customify' ),
 				'css_format' => 'typography',
 				'selector'   => '.site-branding .site-title, .site-branding .site-title a',
@@ -83,24 +93,24 @@ if ( ! function_exists( 'customify_customizer_typography_config' ) ) {
 			array(
 				'name'       => "{$section}_site_tt_desc",
 				'type'       => 'typography',
-				'section'    => "{$section}_site_tt",
+				'section'    => 'typography_panel',
 				'title'      => __( 'Tagline', 'customify' ),
 				'css_format' => 'typography',
 				'selector'   => '.site-branding .site-description',
 			),
 
-			// Content.
+			// ───────── Content ─────────
 			array(
-				'name'  => "{$section}_content",
-				'type'  => 'section',
-				'panel' => 'typography_panel',
-				'title' => __( 'Content', 'customify' ),
+				'name'    => "{$section}_h_content",
+				'type'    => 'heading',
+				'section' => 'typography_panel',
+				'title'   => __( 'Content', 'customify' ),
 			),
 
 			array(
 				'name'       => "{$section}_heading_h1",
 				'type'       => 'typography',
-				'section'    => "{$section}_content",
+				'section'    => 'typography_panel',
 				'title'      => __( 'Heading H1', 'customify' ),
 				'css_format' => 'typography',
 				'selector'   => '.entry-content h1, .wp-block h1, .entry-single .entry-title',
@@ -109,7 +119,7 @@ if ( ! function_exists( 'customify_customizer_typography_config' ) ) {
 			array(
 				'name'       => "{$section}_heading_h2",
 				'type'       => 'typography',
-				'section'    => "{$section}_content",
+				'section'    => 'typography_panel',
 				'title'      => __( 'Heading H2', 'customify' ),
 				'css_format' => 'typography',
 				'selector'   => '.entry-content h2, .wp-block h2',
@@ -118,7 +128,7 @@ if ( ! function_exists( 'customify_customizer_typography_config' ) ) {
 			array(
 				'name'       => "{$section}_heading_h3",
 				'type'       => 'typography',
-				'section'    => "{$section}_content",
+				'section'    => 'typography_panel',
 				'title'      => __( 'Heading H3', 'customify' ),
 				'css_format' => 'typography',
 				'selector'   => '.entry-content h3, .wp-block h3',
@@ -127,7 +137,7 @@ if ( ! function_exists( 'customify_customizer_typography_config' ) ) {
 			array(
 				'name'       => "{$section}_heading_h4",
 				'type'       => 'typography',
-				'section'    => "{$section}_content",
+				'section'    => 'typography_panel',
 				'title'      => __( 'Heading H4', 'customify' ),
 				'css_format' => 'typography',
 				'selector'   => '.entry-content h4, .wp-block h4',
@@ -136,7 +146,7 @@ if ( ! function_exists( 'customify_customizer_typography_config' ) ) {
 			array(
 				'name'       => "{$section}_heading_h5",
 				'type'       => 'typography',
-				'section'    => "{$section}_content",
+				'section'    => 'typography_panel',
 				'title'      => __( 'Heading H5', 'customify' ),
 				'css_format' => 'typography',
 				'selector'   => '.entry-content h5, .wp-block h5',
@@ -145,7 +155,7 @@ if ( ! function_exists( 'customify_customizer_typography_config' ) ) {
 			array(
 				'name'       => "{$section}_heading_h6",
 				'type'       => 'typography',
-				'section'    => "{$section}_content",
+				'section'    => 'typography_panel',
 				'title'      => __( 'Heading H6', 'customify' ),
 				'css_format' => 'typography',
 				'selector'   => '.entry-content h6, .wp-block h6',

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -327,6 +327,34 @@ if ( ! function_exists( 'customify_get_all_image_sizes' ) ) {
 	}
 }
 
+if ( ! function_exists( 'customify_get_content_post_types' ) ) {
+	/**
+	 * Custom post types that warrant per-type Customizer settings (sidebar layout,
+	 * Page Header display/title/tagline).
+	 *
+	 * Tightens Customify()->get_post_types( false ) — which only filters
+	 * publicly_queryable + non-builtin, too loose — to types with a real front-end
+	 * presence: a public archive ( has_archive ) OR shown in nav menus
+	 * ( show_in_nav_menus ). Drops utility CPTs that are merely publicly_queryable
+	 * with no archive and hidden from menus (e.g. the Pro Hooks store
+	 * `customify_hook`) — they have no browsable page, so a per-type control like
+	 * "Single Customify Hook" sidebar would only be noise.
+	 *
+	 * @return array<string, array{name:string, singular_name:string}>
+	 */
+	function customify_get_content_post_types() {
+		$post_types = Customify()->get_post_types( false );
+		foreach ( $post_types as $pt => $label ) {
+			$obj = get_post_type_object( $pt );
+			if ( ! $obj || ! ( $obj->has_archive || $obj->show_in_nav_menus ) ) {
+				unset( $post_types[ $pt ] );
+			}
+		}
+
+		return $post_types;
+	}
+}
+
 if ( ! function_exists( 'customify_get_layout' ) ) {
 	/**
 	 * Get the layout for the current page from Customizer setting or individual page/post.

--- a/src/frontend/scss/header/_header_builder_common.scss
+++ b/src/frontend/scss/header/_header_builder_common.scss
@@ -206,7 +206,11 @@
 		flex-direction: column;
 		justify-content: center;
 		z-index: 5;
-		margin-top: var(--transparent-header-height, 50px);
+		// Fallback 0 (not 50px): the var is only set by theme.js when the header
+		// is transparent (gated on body.is-header-transparent). On normal opaque
+		// headers the var is unset, so a non-zero fallback would push the cover
+		// content down and break vertical centering.
+		margin-top: var(--transparent-header-height, 0px);
 		padding: 1em 30px;
 		@include for_device(desktop) {
 			min-height: 300px;


### PR DESCRIPTION
## Summary

Customizer information-architecture cleanup plus a few contained fixes. All changes are config/UI-level — **no `theme_mod` keys, defaults, or value shapes change**, so existing sites render as before (verified on a fixture site with WooCommerce + Customify Pro active; config loads with no fatal).

## Panel-group structure
New top-level order: **General Options · Layouts · Content · Plugins · Core**.

- **Colors** is a top-level section (retired the now-empty `styling_panel`), anchored first under General Options. Dashboard deep-links + docs updated.
- **Typography** converted from a panel to a top-level **section** (like Colors) — clicking it opens the controls directly; the former *Base / Site Title & Tagline / Content* sub-sections are now `heading` separators. Control names unchanged. Dashboard deep-link `autofocus[panel]` → `autofocus[section]`.
- **"Post Types" group → "Content"** (Blog, Portfolio).
- Split **"Core & Plugins" → "Plugins"** (WooCommerce + Compatibility — Compatibility is theme plugin-support) and **"Core"** (WP-core: Menus, Widgets, Homepage, Additional CSS). `register_panel_groups()` now exempts grouped panels from the +2000 foreign bump so the WooCommerce panel can live in a group instead of the bottom zone.

## Per-CPT gate
New `customify_get_content_post_types()` — keep only types with a public archive **or** shown in nav menus — used by the per-CPT sidebar loop (`layouts.php`) and the Page Header Display modal (`page-header.php`). Drops utility CPTs that are merely `publicly_queryable` with no real front-end page (e.g. the Pro Hooks store `customify_hook`), which were adding noise like a "Single Customify Hook" sidebar control.

## Fixes
- **`is_tax()` page header**: a custom taxonomy now reads its **own** `display/title/tagline` slice instead of a hardcoded `product_tag` slice (and the title was being mis-assigned into the display field) — custom-taxonomy page headers finally render. Guarded on non-empty, so unset slices behave as before.
- **WooCommerce panel** no longer buried at the bottom — grouped under Plugins.
- **Cover vertical-align**: `.page-cover-inner` margin-top fallback `50px → 0` so opaque headers don't push cover content off-center (`src/` SCSS; `build/` regen is a separate step).

## Notes
The earlier exploratory per-CPT Page Header/sidebar "reorg" (settingless proxy controls + auto-generated per-CPT sections) was **dropped** — it added more machinery and plugin/Pro panel conflicts than the central-modal clutter it set out to remove. This PR keeps only the clean, independently-useful pieces above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
