### PR TITLE
Page Settings metabox: exclude no-front-end CPTs from the gate

### DIFF
--- a/inc/admin/page-settings.php
+++ b/inc/admin/page-settings.php
@@ -53,7 +53,9 @@ class Customify_Page_Settings {
 	 * Register every meta key with show_in_rest so the block editor can read/write them.
 	 */
 	public function register_meta() {
-		$post_types = get_post_types( array( 'public' => true ), 'names' );
+		$post_types = function_exists( 'customify_get_meta_support_post_types' )
+			? customify_get_meta_support_post_types()
+			: get_post_types( array( 'public' => true ), 'names' );
 
 		foreach ( $post_types as $post_type ) {
 			foreach ( $this->get_meta_keys() as $key ) {
@@ -98,6 +100,15 @@ class Customify_Page_Settings {
 		if ( function_exists( 'get_current_screen' ) ) {
 			$screen = get_current_screen();
 			if ( $screen && 'post' !== $screen->base ) {
+				return;
+			}
+			// No-front-end utility CPTs (e.g. the Pro Hooks store) don't get the
+			// Customify per-post settings panel — match the metabox gate.
+			if (
+				$screen && $screen->post_type
+				&& function_exists( 'customify_get_meta_support_post_types' )
+				&& ! in_array( $screen->post_type, customify_get_meta_support_post_types(), true )
+			) {
 				return;
 			}
 		}

--- a/inc/class-metabox.php
+++ b/inc/class-metabox.php
@@ -194,15 +194,14 @@ class Customify_MetaBox {
 	}
 
 	public function get_support_post_types() {
-		$args = array(
-			'public' => true,
-		);
+		// Delegate to the shared gate so the classic metabox and the block-editor
+		// panel (inc/admin/page-settings.php) support exactly the same post types,
+		// and both exclude no-front-end utility CPTs (e.g. the Pro Hooks store).
+		if ( function_exists( 'customify_get_meta_support_post_types' ) ) {
+			return customify_get_meta_support_post_types();
+		}
 
-		$output     = 'names'; // Names or objects, note names is the default.
-		$operator   = 'and'; // Can use 'and' or 'or'.
-		$post_types = get_post_types( $args, $output, $operator );
-
-		return array_values( $post_types );
+		return array_values( get_post_types( array( 'public' => true ), 'names', 'and' ) );
 	}
 
 	/**

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -383,6 +383,47 @@ if ( ! function_exists( 'customify_get_content_post_types' ) ) {
 	}
 }
 
+if ( ! function_exists( 'customify_get_meta_support_post_types' ) ) {
+	/**
+	 * Post types that get the Customify per-post settings (the "Customify Page
+	 * Settings" metabox / block-editor panel: Content Layout, Page Title Layout,
+	 * Sidebar, Disable Elements).
+	 *
+	 * Broader than customify_get_content_post_types() — these settings affect a
+	 * singular front-end view, so the list keeps built-in `page` / `post` and any
+	 * public CPT with a viewable single. It only drops no-front-end utility CPTs:
+	 * `customify_hook` (the Pro Hooks store) is public + publicly_queryable but
+	 * has no browsable page, and the theme can't rely on how a given Pro version
+	 * flags it, so it is deny-listed; types flagged `exclude_from_search` (the
+	 * registering plugin's "not browsable content" signal) are dropped too.
+	 *
+	 * Render-safe: a post type omitted here only loses the editor UI; any saved
+	 * `_customify_*` meta is still read at render via get_post_meta.
+	 *
+	 * @return string[] Indexed array of post type slugs.
+	 */
+	function customify_get_meta_support_post_types() {
+		$post_types = get_post_types( array( 'public' => true ), 'names', 'and' );
+
+		$excluded = array( 'customify_hook' );
+		foreach ( $post_types as $pt ) {
+			$obj = get_post_type_object( $pt );
+			if ( ! $obj || in_array( $pt, $excluded, true ) || $obj->exclude_from_search ) {
+				unset( $post_types[ $pt ] );
+			}
+		}
+
+		/**
+		 * Filter the post types that receive the Customify per-post settings
+		 * metabox / block-editor panel. Add a CPT the heuristics dropped, or
+		 * remove one they kept.
+		 *
+		 * @param string[] $post_types Indexed array of post type slugs.
+		 */
+		return apply_filters( 'customify/meta_support_post_types', array_values( $post_types ) );
+	}
+}
+
 if ( ! function_exists( 'customify_get_layout' ) ) {
 	/**
 	 * Get the layout for the current page from Customizer setting or individual page/post.


### PR DESCRIPTION
## Summary

Follow-up to #413 (which merged before this commit landed). Fixes the per-post **Customify Page Settings** metabox / block-editor panel leaking onto no-front-end utility CPTs — the Pro **Hooks** store (`customify_hook`) was showing the panel.

Both registration paths were gated on `get_post_types( array( 'public' => true ) )` (which includes `customify_hook`, registered `public=true`), and the block-editor `enqueue_assets()` only checked the screen *base*, not the post type.

## Changes
- **New shared gate** `customify_get_meta_support_post_types()` — public post types minus no-front-end utility CPTs: deny-list `customify_hook` (version-proof; the theme can't depend on Pro's flags) and drop `exclude_from_search` types. Behind a `customify/meta_support_post_types` filter.
- `Customify_Metabox::get_support_post_types()` delegates to it (classic metabox).
- `admin/page-settings.php`: `register_meta()` uses it, and `enqueue_assets()` now also skips post types not in the list (previously gated only on screen base).

## Safety
Render-safe: omitting a post type only hides the editor UI — saved `_customify_*` meta still reads via `get_post_meta`. No new theme_mod / meta key, no migration.

## Verification
- `php -l` clean (3 files).
- Gate returns `post, page, attachment, portfolio, tours, product` — `customify_hook` excluded; the classic-metabox gate matches the shared helper; the deny-list holds even when `customify_hook` is simulated with `exclude_from_search=false`.
- Frontend smoke `/` `/tours/` = 200 (helper runs on `init` via `register_meta`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)