### PR TITLE
fix: update outdated WooCommerce templates + worktree build resolution

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,10 +32,22 @@ const CopyPlugin           = require( 'copy-webpack-plugin' );
  * Git installs omit `build/` (created by dashboard-kit prepublish/build).
  * Alias to `src/` and stub `style.css` so webpack matches package exports rules.
  */
-const dashboardKitRoot         = path.resolve(
-	__dirname,
-	'node_modules/@pressmaximum/dashboard-kit'
-);
+const dashboardKitRoot = ( () => {
+	// A git worktree's own node_modules is gitignored (never copied on creation),
+	// so a path hardcoded to __dirname won't exist there. Resolve wherever Node
+	// can actually find the package: a worktree nested under the main checkout
+	// walks up to the parent's node_modules. Fall back to the local path.
+	try {
+		return path.dirname(
+			require.resolve( '@pressmaximum/dashboard-kit/package.json' )
+		);
+	} catch ( _err ) {
+		return path.resolve(
+			__dirname,
+			'node_modules/@pressmaximum/dashboard-kit'
+		);
+	}
+} )();
 const dashboardKitBuildEntry   = path.join( dashboardKitRoot, 'build', 'index.mjs' );
 const dashboardKitSrcDir     = path.join( dashboardKitRoot, 'src' );
 const dashboardKitGitStyleNoopPath = path.resolve(

--- a/woocommerce/cart/cart.php
+++ b/woocommerce/cart/cart.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.1.11
+ * @version 10.8.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -27,10 +27,10 @@ do_action( 'woocommerce_before_cart' ); ?>
 			<tr>
 				<th class="product-remove"><span class="screen-reader-text"><?php esc_html_e( 'Remove item', 'customify' ); ?></span></th>
 				<th class="product-thumbnail"><span class="screen-reader-text"><?php esc_html_e( 'Thumbnail image', 'customify' ); ?></span></th>
-				<th class="product-name"><?php esc_html_e( 'Product', 'customify' ); ?></th>
-				<th class="product-price"><?php esc_html_e( 'Price', 'customify' ); ?></th>
-				<th class="product-quantity"><?php esc_html_e( 'Quantity', 'customify' ); ?></th>
-				<th class="product-subtotal"><?php esc_html_e( 'Subtotal', 'customify' ); ?></th>
+				<th scope="col" class="product-name"><?php esc_html_e( 'Product', 'customify' ); ?></th>
+				<th scope="col" class="product-price"><?php esc_html_e( 'Price', 'customify' ); ?></th>
+				<th scope="col" class="product-quantity"><?php esc_html_e( 'Quantity', 'customify' ); ?></th>
+				<th scope="col" class="product-subtotal"><?php esc_html_e( 'Subtotal', 'customify' ); ?></th>
 			</tr>
 		</thead>
 		<tbody>
@@ -41,7 +41,26 @@ do_action( 'woocommerce_before_cart' ); ?>
 				$_product   = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
 				$product_id = apply_filters( 'woocommerce_cart_item_product_id', $cart_item['product_id'], $cart_item, $cart_item_key );
 
-				if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
+				/**
+				 * Filter whether this cart item is visible in the cart.
+				 *
+				 * @since 2.1.0
+				 * @param bool   $visible     Whether the cart item is visible. Default true.
+				 * @param array  $cart_item     The cart item data.
+				 * @param string $cart_item_key The cart item key.
+				 */
+				$visible = apply_filters( 'woocommerce_cart_item_visible', true, $cart_item, $cart_item_key );
+
+				if ( $_product instanceof WC_Product && $_product->exists() && $cart_item['quantity'] > 0 && $visible ) {
+					/**
+					 * Filter the product name.
+					 *
+					 * @since 2.1.0
+					 * @param string $product_name Name of the product in the cart.
+					 * @param array $cart_item The product in the cart.
+					 * @param string $cart_item_key Key for the product in the cart.
+					 */
+					$product_name      = apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key );
 					$product_permalink = apply_filters( 'woocommerce_cart_item_permalink', $_product->is_visible() ? $_product->get_permalink( $cart_item ) : '', $cart_item, $cart_item_key );
 					?>
 					<tr class="woocommerce-cart-form__cart-item <?php echo esc_attr( apply_filters( 'woocommerce_cart_item_class', 'cart_item', $cart_item, $cart_item_key ) ); ?>">
@@ -51,7 +70,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 								echo apply_filters( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 									'woocommerce_cart_item_remove_link',
 									sprintf(
-										'<a href="%s" class="remove" aria-label="%s" data-product_id="%s" data-product_sku="%s">&times;</a>',
+										'<a role="button" href="%s" class="remove" aria-label="%s" data-product_id="%s" data-product_sku="%s">&times;</a>',
 										esc_url( wc_get_cart_remove_url( $cart_item_key ) ),
 										esc_html__( 'Remove this item', 'customify' ),
 										esc_attr( $product_id ),
@@ -64,6 +83,19 @@ do_action( 'woocommerce_before_cart' ); ?>
 
 						<td class="product-thumbnail">
 						<?php
+						/**
+						 * Filter the product thumbnail displayed in the WooCommerce cart.
+						 *
+						 * This filter allows developers to customize the HTML output of the product
+						 * thumbnail. It passes the product image along with cart item data
+						 * for potential modifications before being displayed in the cart.
+						 *
+						 * @param string $thumbnail     The HTML for the product image.
+						 * @param array  $cart_item     The cart item data.
+						 * @param string $cart_item_key Unique key for the cart item.
+						 *
+						 * @since 2.1.0
+						 */
 						$thumbnail = apply_filters( 'woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key );
 
 						if ( ! $product_permalink ) {
@@ -74,11 +106,16 @@ do_action( 'woocommerce_before_cart' ); ?>
 						?>
 						</td>
 
-						<td class="product-name" data-title="<?php esc_attr_e( 'Product', 'customify' ); ?>">
+						<td scope="row" role="rowheader" class="product-name" data-title="<?php esc_attr_e( 'Product', 'customify' ); ?>">
 						<?php
 						if ( ! $product_permalink ) {
-							echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key ) . '&nbsp;' );
+							echo wp_kses_post( $product_name . '&nbsp;' );
 						} else {
+							/**
+							 * This filter is documented above.
+							 *
+							 * @since 2.1.0
+							 */
 							echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', sprintf( '<a href="%s">%s</a>', esc_url( $product_permalink ), $_product->get_name() ), $cart_item, $cart_item_key ) );
 						}
 
@@ -103,20 +140,24 @@ do_action( 'woocommerce_before_cart' ); ?>
 						<td class="product-quantity" data-title="<?php esc_attr_e( 'Quantity', 'customify' ); ?>">
 						<?php
 						if ( $_product->is_sold_individually() ) {
-							$product_quantity = sprintf( '1 <input type="hidden" name="cart[%s][qty]" value="1" />', $cart_item_key );
+							$min_quantity = 1;
+							$max_quantity = 1;
 						} else {
-							$product_quantity = woocommerce_quantity_input(
-								array(
-									'input_name'   => "cart[{$cart_item_key}][qty]",
-									'input_value'  => $cart_item['quantity'],
-									'max_value'    => $_product->get_max_purchase_quantity(),
-									'min_value'    => '0',
-									'product_name' => $_product->get_name(),
-								),
-								$_product,
-								false
-							);
+							$min_quantity = 0;
+							$max_quantity = $_product->get_max_purchase_quantity();
 						}
+
+						$product_quantity = woocommerce_quantity_input(
+							array(
+								'input_name'   => "cart[{$cart_item_key}][qty]",
+								'input_value'  => $cart_item['quantity'],
+								'max_value'    => $max_quantity,
+								'min_value'    => $min_quantity,
+								'product_name' => $product_name,
+							),
+							$_product,
+							false
+						);
 
 						echo apply_filters( 'woocommerce_cart_item_quantity', $product_quantity, $cart_item_key, $cart_item ); // PHPCS: XSS ok.
 						?>

--- a/woocommerce/loop/result-count.php
+++ b/woocommerce/loop/result-count.php
@@ -15,27 +15,29 @@
  * @see         https://docs.woocommerce.com/document/template-structure/
  * @author      WooThemes
  * @package     WooCommerce/Templates
- * @version     9.9.0
+ * @version     10.8.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
-<p class="woocommerce-result-count text-uppercase text-xsmall">
+<p class="woocommerce-result-count text-uppercase text-xsmall" role="status" aria-relevant="all" <?php echo ( empty( $orderedby ) || 1 === intval( $total ) ) ? '' : 'data-is-sorted-by="true"'; ?>>
 	<?php
-
-	if ( 1 === $total ) {
+	// phpcs:disable WordPress.Security
+	if ( 1 === intval( $total ) ) {
 		_e( 'Showing the single result', 'customify' );
 	} elseif ( $total <= $per_page || -1 === $per_page ) {
-		/* translators: %d: total results */
-		printf( _n( 'Showing all %d result', 'Showing all %d results', $total, 'customify' ), $total );
+		$orderedby_placeholder = empty( $orderedby ) ? '%2$s' : '<span class="screen-reader-text">%2$s</span>';
+		/* translators: 1: total results 2: sorted by */
+		printf( _n( 'Showing all %1$d result', 'Showing all %1$d results', $total, 'customify' ) . $orderedby_placeholder, $total, esc_html( $orderedby ) );
 	} else {
-		$first = ( $per_page * $current ) - $per_page + 1;
-		$last  = min( $total, $per_page * $current );
-		/* translators: 1: first result 2: last result 3: total results */
-		printf( _nx( 'Showing %1$d&ndash;%2$d of %3$d result', 'Showing %1$d&ndash;%2$d of %3$d results', $total, 'with first and last result', 'customify' ), $first, $last, $total );
+		$first                 = ( $per_page * $current ) - $per_page + 1;
+		$last                  = min( $total, $per_page * $current );
+		$orderedby_placeholder = empty( $orderedby ) ? '%4$s' : '<span class="screen-reader-text">%4$s</span>';
+		/* translators: 1: first result 2: last result 3: total results 4: sorted by */
+		printf( _nx( 'Showing %1$d&ndash;%2$d of %3$d result', 'Showing %1$d&ndash;%2$d of %3$d results', $total, 'with first and last result', 'customify' ) . $orderedby_placeholder, $first, $last, $total, esc_html( $orderedby ) );
 	}
-
+	// phpcs:enable WordPress.Security
 	?>
 </p>


### PR DESCRIPTION
## Summary
Two maintenance fixes from this session.

### 1. WooCommerce — outdated templates
- Re-forked `woocommerce/cart/cart.php` and `woocommerce/loop/result-count.php` from WC core **10.8.0**.
- Re-applied Customify's deliberate customizations: `customify` textdomain, visible "Coupon:" label, "Remove this item" aria-label, `text-uppercase text-xsmall` on the result count.
- Adopted core's accessibility / markup fixes (e.g. `scope`/`role` attrs, `role="status"`, `intval($total)`); bumped `@version` to 10.8.0.
- Verified on a live WooCommerce 10.8.1 install via `WC_REST_System_Status_V2_Controller::get_theme_info()`: `has_outdated_templates: false`, **0/22** overrides flagged. Cart + Shop render correctly.

### 2. Build — worktree resolution for dashboard-kit
- `webpack.config.js` no longer hardcodes `dashboardKitRoot` to the current checkout's `node_modules`. It resolves the package via `require.resolve('@pressmaximum/dashboard-kit/package.json')` (walks up to the parent checkout) with the old hardcoded path as fallback.
- Fixes `npm run build` failing with `Can't resolve '@pressmaximum/dashboard-kit'` in nested git worktrees (whose `node_modules` is gitignored and never populated for the private `git+ssh` dep).
- **Backward-compatible**: the main checkout resolves to the same path as before.

## Test plan
- `npm run build` → compiles with 0 errors in both the main checkout and a nested worktree.
- WooCommerce → Status → Templates shows no outdated templates.

## Notes
- The two commits are independent and can be split into separate PRs if preferred.
- A few overrides (`mini-cart.php`, `single-product/title.php`, `loop/pagination.php`, `add-to-cart/*`) carry intentionally-inflated `@version` and are not content-synced with core — out of scope here (WC does not flag them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
