### PR TITLE
fix(header): Header Top light skin ignored (Primary override)

### DIFF
--- a/src/frontend/scss/header/_header_top.scss
+++ b/src/frontend/scss/header/_header_top.scss
@@ -14,11 +14,16 @@
     .dark-mode {
         background: $color_primary;
     }
-    // Ported from pre-4b5acc73 colors.php $primary_css. Inner row picks up
-    // the Primary token regardless of light/dark mode of the row chrome.
-    // (Commit 4b5acc73 dropped this when collapsing primary CSS to :root —
-    // recorded as a known follow-up in that commit message.)
-    .header--row-inner {
+    // The header-top inner row uses the Primary brand colour by default
+    // (dark skin + the no-skin fallback). It must NOT override the light
+    // skin, so it is scoped with `:not(.light-mode)`, which also raises it
+    // to specificity (0,3,0) for the dark/fallback case while leaving
+    // light-mode rows to the `.light-mode { background: #f0f0f0 }` rule
+    // above. Previously this rule was unconditional and sat last in source
+    // order, silently overriding the light skin background (the row stayed
+    // Primary even when the user selected the light skin). Ported from
+    // pre-4b5acc73 colors.php $primary_css.
+    .header--row-inner:not(.light-mode) {
         background-color: $color_primary;
     }
 }


### PR DESCRIPTION
## Summary

Fixes the **Header Top "light" skin being ignored**: choosing **Light** for the Header Top row's Skin Mode had no visible effect — the row stayed Primary-coloured, producing dark text on a primary background.

## Root cause

`src/frontend/scss/header/_header_top.scss` had an unconditional rule:

```scss
.header--row-inner { background-color: $color_primary; }
```

The skin class (`dark-mode` / `light-mode`) is rendered on the **same** `.header--row-inner` element (the row's `text_mode` is pushed onto `$inner_class` in `class-layout-builder-frontend.php`). At equal specificity `(0,2,0)`, this rule — being last in source order — overrode `.header-top .light-mode { background:#f0f0f0 }`, so the light skin's background never applied.

## Fix

Scope the default with `:not(.light-mode)` → specificity `(0,3,0)`:

```scss
.header--row-inner:not(.light-mode) { background-color: $color_primary; }
```

Dark skin + the no-skin fallback still resolve to Primary; the light skin's background now wins. Specificity-based, so it does not depend on source order.

## Impact / 30k-site safety

- **CSS-only** — no `theme_mod`, storage shape, default value, or selector change.
- **Dark-mode (the default) renders identically** → zero change for any site that never switched the Header Top to the light skin.
- Only sites that explicitly selected the **light** skin for the Header Top are affected — and for them the feature was already broken (Primary background + dark text). Now it works as intended.

## Verification

Live Studio site, default header:

| Skin | Header-top background | Result |
|---|---|---|
| Light | `#f0f0f0` | ✅ fixed (was Primary) |
| Dark | Primary | ✅ unchanged |

Confirmed via the served CSS (`:not(.light-mode)` present) and the rendered HTML class on `.header--row-inner`.

> Note: `build/` is gitignored, so this PR is source-only. The compiled CSS is regenerated by the build/release pipeline (`npm run build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
