### PR TITLE
refactor(typography): 2-tier token model — foundation :root vars, leaf literal

### DIFF
--- a/docs/SPEC-customizer.md
+++ b/docs/SPEC-customizer.md
@@ -243,7 +243,7 @@ All control classes live in `inc/customizer/controls/`. The `type` field picks t
 |---|---|
 | `font` | Google Fonts dropdown |
 | `font_style` | Font-weight + variant |
-| `typography` | Composite: font + weight + size + line-height + letter-spacing. Renders as a single control with a dedicated CSS pipeline. **As of theme `0.5.0`**, fields whose setting `name` starts with `global_typography_` emit `:root { --customify-typo-*: value }` CSS variables; per-component typography (header builder items, footer copyright, blog read-more, breadcrumb, WC cart) keeps selector-scoped CSS. See [`SPEC-typography.md`](SPEC-typography.md) for var naming rules, the `customify/typography/field_uses_vars` route filter, and the SCSS consumer pattern. |
+| `typography` | Composite: font + weight + size + line-height + letter-spacing. Renders as a single control with a dedicated CSS pipeline. **As of theme `0.4.19`**, only the foundation typography settings (`global_typography_base_p`, `global_typography_base_heading`, `global_typography_heading_h1`–`h6` — see `Customify_Customizer_Auto_CSS::TYPO_VAR_MAP`) emit `:root { --customify-typo-*: value }` CSS variables; leaf-global typography (site title, tagline, widget title) and per-component typography (header builder items, footer copyright, blog read-more, breadcrumb, WC cart) keep selector-scoped literal CSS. See [`SPEC-typography.md`](SPEC-typography.md) for var naming rules, the `customify/typography/field_uses_vars` route filter, and the SCSS consumer pattern. |
 | `css_ruler` | Margin / padding quad editor (`top right bottom left`). Stored as object. |
 | `shadow` | Box-shadow builder (x / y / blur / spread / color). |
 

--- a/docs/SPEC-typography.md
+++ b/docs/SPEC-typography.md
@@ -1,8 +1,8 @@
 # SPEC — Typography (CSS Variables)
 
-Customify renders **Global Typography panel settings** (font family, size, weight, line-height, letter-spacing, text-decoration, text-transform, font-style) as **`:root { --customify-typo-*: value }` CSS custom properties**. SCSS layer consumes the vars via `var(--customify-typo-…, fallback)` at the matching selectors. **Per-component typography** (header builder items, footer copyright, blog read-more, breadcrumb, WC cart) keeps the legacy selector-scoped output because its SCSS layer doesn't carry generic consumer rules — vars mode would silently drop the user's value. Landed in theme `0.5.0`.
+Customify renders typography in **two tiers**. **Foundation roles** — Base body (`global_typography_base_p` → `body`), the shared Heading family/weight (`global_typography_base_heading` → `heading`), and the h1–h6 type scale (`global_typography_heading_h1..h6` → `h1`..`h6`) — emit **`:root { --customify-typo-*: value }` CSS custom properties** (8 settings → 18 emitted tokens). The SCSS layer consumes those tokens via `var(--customify-typo-…, fallback)` at the matching selectors. **Leaf roles** (site title, tagline, widget title) and **per-component typography** (header builder items, footer copyright, blog read-more, breadcrumb, WC cart) mint NO token of their own — they emit selector-scoped **literal** CSS at the field selector. Leaf SCSS rules still *reuse* a foundation token where it makes sense (site title and widget title default their `font-family` to `var(--customify-typo-heading-font-family, inherit)`; the tagline `.site-description` inherits the body font and carries no typography var consumer at all). Landed in theme `0.4.19`.
 
-The scope boundary is the field's setting `name`: vars emit only when `name` starts with `global_typography_` (the Base / Site Title & Tagline / Heading family — 11 settings). Everything else falls through to the legacy emit path. The gate keys off `name` rather than `section` because the Typography IA was flattened into a single `typography_panel` section, so the section id no longer encodes which group a field belongs to.
+The scope boundary is the field's setting `name`: tokens emit only for the **8 foundation names** in `Customify_Customizer_Auto_CSS::TYPO_VAR_MAP` — `typography_field_uses_vars()` returns `true` for exactly those. The 3 leaf settings that *also* start with `global_typography_` (`global_typography_site_tt_title`, `global_typography_site_tt_desc`, `global_typography_base_widget_title`) do **not** emit tokens. Everything else falls through to the selector-scoped literal emit path. The gate keys off the explicit `TYPO_VAR_MAP` rather than a `section` id or a `name` prefix because the Typography IA was flattened into a single `typography_panel` section (so the section id no longer encodes which group a field belongs to) and because not every `global_typography_` setting is a foundation role.
 
 Related references:
 - [`SPEC-customizer.md`](SPEC-customizer.md) — underlying Customizer architecture and the typography control type registration (`§5.3`).
@@ -18,15 +18,15 @@ This file is permanent. For the in-flight rollout notes used during implementati
 
 | Surface | Role |
 |---|---|
-| Customizer Typography panel + per-component typography fields | 20 registered fields (11 global panel, 9 per-component) — see [`SPEC-customizer.md §5.3`](SPEC-customizer.md) |
+| Customizer Typography panel + per-component typography fields | 20 registered fields (11 in the global panel, 9 per-component) — see [`SPEC-customizer.md §5.3`](SPEC-customizer.md) |
 | `theme_mod` storage (unchanged) | Persistent typography values per setting; per-device map for `font_size` and `line_height` |
-| `Customify_Customizer_Auto_CSS::typography()` | PHP emit — vars for global fields, selector-scoped literal CSS for per-component (route decided by `typography_field_uses_vars()`) |
+| `Customify_Customizer_Auto_CSS::typography()` | PHP emit — `:root` tokens for the 8 foundation settings, selector-scoped literal CSS for the 3 leaf-global + 9 per-component settings (route decided by `typography_field_uses_vars()` against `TYPO_VAR_MAP`) |
 | `CustomifyAutoCSS.prototype.typography` (`auto-css.js`) | JS mirror for Customizer live preview |
-| `src/frontend/scss/*` consumers | Read vars via `var(--customify-typo-…, fallback)` at the relevant selectors — only for the 11 global settings |
+| `src/frontend/scss/*` consumers | Read tokens via `var(--customify-typo-…, fallback)` at the relevant selectors — for the 8 foundation settings. Leaf selectors (site title, widget title) reuse the heading token; they own no token of their own |
 | Block editor canvas | Inherits via [`src/backend/admin/scss/editor.scss`](../src/backend/admin/scss/editor.scss) which imports the frontend `_base`/`_blocks`/`_widgets` partials |
 
-**Default mode is vars for global typography only.** One filter knob:
-- `customify/typography/field_uses_vars` (default = setting `name` starts with `global_typography_`) — per-field override. Return `false` to force a global field through legacy, or `true` to opt a per-component field into vars (requires adding an SCSS consumer at the matching selector). See §7.
+**Default mode is tokens for the 8 foundation settings only.** Everything else emits selector-scoped literal CSS. One filter knob:
+- `customify/typography/field_uses_vars` (default = setting `name` is one of the 8 foundation roles in `TYPO_VAR_MAP`) — per-field override. Return `false` to force a foundation field through literal emit, or `true` to opt a non-foundation field into tokens (requires adding an SCSS consumer at the matching selector). See §7.
 
 ---
 
@@ -35,10 +35,9 @@ This file is permanent. For the in-flight rollout notes used during implementati
 | File | Lines | Responsibility |
 |---|---|---|
 | [`inc/customizer/class-customizer-auto-css.php`](../inc/customizer/class-customizer-auto-css.php) | `typography()`, `code_to_root_vars()`, `typography_var_name()`, `typography_field_uses_vars()`, `$css_root` bucket + `render_css()` flush | PHP generator + helpers |
-| [`src/backend/customizer/js/auto-css.js`](../src/backend/customizer/js/auto-css.js) | `typography()`, `code_to_root_vars()`, `typography_var_name()`, `typography_field_uses_vars()`, `css_root` flush | JS live preview mirror |
-| [`src/frontend/scss/utils/_mixins.scss`](../src/frontend/scss/utils/_mixins.scss) | `@mixin customify-typography($name, $props, $fallbacks)` | Emits 8 var consumers in one call for selectors without existing typography literals |
-| ~10 frontend SCSS partials (see §4) | inline | Var consumers — direct `var(...)` calls or via the mixin |
-| [`inc/admin/editor.php`](../inc/admin/editor.php) | Unchanged for vars mode | Editor inline CSS via `Customify_Editor::css()` + `load_style()`; both call `Customify_Customizer_Auto_CSS::render_css()` which flushes `$css_root` automatically |
+| [`src/backend/customizer/js/auto-css.js`](../src/backend/customizer/js/auto-css.js) | `typography()`, `code_to_root_vars()`, `typography_var_name()`, `typography_field_uses_vars()`, `TYPO_VAR_MAP`, `css_root` flush | JS live preview mirror |
+| ~10 frontend SCSS partials (see §4) | inline | Token consumers — direct 2-arg `var(...)` calls at the foundation selectors |
+| [`inc/admin/editor.php`](../inc/admin/editor.php) | `Customify_Editor::css()`, `load_style()` | Editor inline CSS; both call `Customify_Customizer_Auto_CSS::render_css()` which flushes `$css_root` automatically |
 
 ---
 
@@ -68,24 +67,33 @@ See [`SPEC-customizer.md §5.3`](SPEC-customizer.md) for the full per-field conf
 
 ### 3.2 Registered typography settings (20 total)
 
-#### Vars mode — Global panel (11 settings, file: [`inc/customizer/configs/typography.php`](../inc/customizer/configs/typography.php))
+#### Foundation / tokenized (8 settings, file: [`inc/customizer/configs/typography.php`](../inc/customizer/configs/typography.php))
 
-These emit `:root { --customify-typo-…: value }` at frontend. SCSS consumers live in `_base.scss`, `_widgets.scss`, `_logo_site_identity.scss`.
+These are the ONLY settings that emit `:root { --customify-typo-…: value }` at frontend — the 8 entries in `Customify_Customizer_Auto_CSS::TYPO_VAR_MAP`. SCSS token consumers live in `_base.scss`. Per-role field gating (see §6, and the `fields` arrays in `typography.php`) restricts `base_heading` to family + weight and `heading_h1..h6` to font-size + line-height, so the 8 settings expand to **18 emitted tokens**.
 
-All 11 settings live in the flattened `typography_panel` section (the former Base / Site Title & Tagline / Content sub-sections are now `heading` separators inside it).
+The `selector` column below is the field's configured `selector` (from `typography.php`). For tokenized fields PHP **ignores** that selector — SCSS owns the consumer selector — but it stays the field's identity and drives where literal cosmetic-property CSS lands when set (see §4.3 step 6).
 
-| Setting name | Semantic name | SCSS consumer selector |
+| Setting name | Semantic name (token segment) | Field `selector` | SCSS token consumer |
+|---|---|---|---|
+| `global_typography_base_p` | `body` | `body` | `body` in `_base.scss` |
+| `global_typography_base_heading` | `heading` (family + weight only) | `h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6` | the shared heading rule in `_base.scss` |
+| `global_typography_heading_h1` … `h6` | `h1` … `h6` (font-size + line-height only) | `.entry-content {tag}, .wp-block {tag}` (h1 also adds `, .entry-single .entry-title`) | `h1, .h1` … `h6, .h6` in `_base.scss` (with `@include for_device` responsive blocks for h1/h2) |
+
+#### Leaf / literal — global panel (3 settings)
+
+These live in the `typography_panel` section and start with `global_typography_`, but they are **not** in `TYPO_VAR_MAP`, so `typography_field_uses_vars()` returns `false` for them. They mint **no token of their own** — when the user sets a value the generator emits selector-scoped **literal** CSS at the field's `selector`. Their SCSS default font-family *reuses* the foundation heading token (site title and widget title), or simply inherits the body font (tagline).
+
+| Setting name | Field `selector` | Default font-family source |
 |---|---|---|
-| `global_typography_base_p` | `base-p` | `body` |
-| `global_typography_base_heading` | `base-heading` | `h1..h6, .h1..h6` (family/weight only) |
-| `global_typography_base_widget_title` | `base-widget-title` | `.widget-title` |
-| `global_typography_site_tt_title` | `site-tt-title` | `.site-branding .site-title` |
-| `global_typography_site_tt_desc` | `site-tt-desc` | `.site-branding .site-description` |
-| `global_typography_heading_h1` … `h6` | `h1` … `h6` | `h1, .h1` … `h6, .h6` (with `@include for_device` responsive blocks for h1/h2) |
+| `global_typography_site_tt_title` | `.site-branding .site-title, .site-branding .site-title a` | reuses `var(--customify-typo-heading-font-family, inherit)` |
+| `global_typography_site_tt_desc` (tagline) | `.site-branding .site-description` | none — `.site-description` has no typography var consumer; inherits the body font |
+| `global_typography_base_widget_title` | `.site-content .widget-title` | reuses `var(--customify-typo-heading-font-family, inherit)` |
 
-#### Selector-scoped mode — Per-component (9 settings)
+All 11 panel settings (8 foundation + 3 leaf) live in the flattened `typography_panel` section (the former Base / Site Title & Tagline / Content sub-sections are now `heading` separators inside it).
 
-These emit selector-scoped literal CSS at the field's `selector` exactly as pre-`0.5.0`. No SCSS var consumers exist for these — adding one and toggling `customify/typography/field_uses_vars` for the field is the opt-in path.
+#### Selector-scoped / literal — per-component (9 settings)
+
+These emit selector-scoped literal CSS at the field's `selector`. No SCSS token consumers exist for these — adding one and toggling `customify/typography/field_uses_vars` for the field is the opt-in path.
 
 | Setting (file) | Semantic name | Selector |
 |---|---|---|
@@ -107,40 +115,43 @@ These emit selector-scoped literal CSS at the field's `selector` exactly as pre-
 
 `--customify-typo-{semantic-name}-{css-property-kebab}`
 
-**Semantic name** derives from the setting `name` via these strips (in order — PHP helper `Customify_Customizer_Auto_CSS::typography_var_name()`):
+**Semantic name** is resolved by the PHP helper `Customify_Customizer_Auto_CSS::typography_var_name()` in two stages:
 
-1. Strip prefix `global_typography_` (if present)
-2. Strip prefix `heading_` (if still present after step 1 — collapses `heading_h1` → `h1`)
-3. Strip the **first matching** suffix: `_modal_font_size`, `_typography`, `_font_size`, `_typo`
-4. Replace `_` with `-`
+1. **Primary path — explicit map.** If the setting `name` is one of the 8 foundation roles in `self::TYPO_VAR_MAP`, the semantic segment is the mapped value directly (`global_typography_base_p` → `body`, `global_typography_base_heading` → `heading`, `global_typography_heading_h1..h6` → `h1`..`h6`). This is how every token actually emitted today is named.
+2. **Fallback path — strip + kebab.** Only reached for a NON-foundation field that a site has opted into tokens via the `customify/typography/field_uses_vars` filter. The helper derives the segment from the setting `name`:
+   1. Strip prefix `global_typography_` (if present)
+   2. Strip the **first matching** suffix: `_modal_font_size`, `_typography`, `_font_size`, `_typo`
+   3. Replace `_` with `-`
 
 CSS properties (already kebab): `font-family`, `font-style`, `font-weight`, `font-size`, `line-height`, `letter-spacing`, `text-decoration`, `text-transform`.
 
-Worked examples (only Global Typography fields actually emit vars today; the strip rule covers the others so the helper output is well-defined if a site opts a per-component field in via `customify/typography/field_uses_vars`):
+Worked examples (only the 8 foundation fields emit tokens today — the first two rows; the fallback rows show what the helper would produce if a site opts a per-component field in via `customify/typography/field_uses_vars`):
 
-| Setting | Property | Resulting var |
-|---|---|---|
-| `global_typography_base_p` | font-family | `--customify-typo-base-p-font-family` |
-| `global_typography_heading_h1` | font-size | `--customify-typo-h1-font-size` |
-| `header_button_typography` (legacy by default) | font-weight | `--customify-typo-header-button-font-weight` |
-| `search_icon_modal_font_size` (legacy by default) | font-family | `--customify-typo-search-icon-font-family` |
+| Setting | Property | Path | Resulting var |
+|---|---|---|---|
+| `global_typography_base_p` | font-family | map | `--customify-typo-body-font-family` |
+| `global_typography_heading_h1` | font-size | map | `--customify-typo-h1-font-size` |
+| `header_button_typography` (literal by default) | font-weight | fallback | `--customify-typo-header-button-font-weight` |
+| `search_icon_modal_font_size` (literal by default) | font-family | fallback | `--customify-typo-search-icon-font-family` |
 
-PHP and JS helpers must stay in lockstep — the JS mirror is at `CustomifyAutoCSS.prototype.typography_var_name`.
+PHP and JS helpers must stay in lockstep — the JS mirror is `CustomifyAutoCSS.prototype.typography_var_name`, and both read the shared `TYPO_VAR_MAP` (PHP const / JS `var`).
 
-### 4.2 Output shape (vars mode — default)
+### 4.2 Output shape (tokens — default for foundation fields)
 
 Non-device properties land in the `all` bucket at `:root`:
 
 ```css
 :root {
-    --customify-typo-base-p-font-family: "Inter";
-    --customify-typo-base-p-font-weight: 400;
-    --customify-typo-h1-font-family: "Inter";
-    --customify-typo-h1-font-weight: 700;
+    --customify-typo-body-font-family: "Inter";
+    --customify-typo-body-font-weight: 400;
+    --customify-typo-heading-font-family: "Inter";
+    --customify-typo-heading-font-weight: 700;
     --customify-typo-h1-font-size: 2.5rem;
     --customify-typo-h1-line-height: 1.2;
 }
 ```
+
+Note `base_heading` emits `--customify-typo-heading-font-family` / `--customify-typo-heading-font-weight` (family + weight only — the per-role gate drops the rest), and `heading_h1..h6` emit `--customify-typo-h{n}-font-size` / `--customify-typo-h{n}-line-height` (the gate drops family/weight). That gating is why 8 settings yield 18 tokens, not the full Cartesian product.
 
 Device-scoped properties (`font_size`, `line_height`) wrap in the matching media query:
 
@@ -163,62 +174,65 @@ Device-scoped properties (`font_size`, `line_height`) wrap in the matching media
 2. `setup_font()` runs **regardless of mode** — it populates `$this->fonts`, `$this->library_fonts`, `$this->theme_fonts` for Google Fonts URL / WP Font Library / theme.json `@font-face` emission. **These side effects must always run.**
 3. Non-device props built into `$code` (literal `property: value;` lines); device props into `$devices_css[device]` (same shape).
 4. `apply_filters('customify/customizer/auto_css', $devices_css, $field, $this)` — contract unchanged.
-5. **Route decision** — if `typography_field_uses_vars($field)` returns `false` (i.e. field's setting `name` doesn't start with `global_typography_`), emit selector-scoped CSS into `$this->css[device]` (legacy path — byte-identical to pre-`0.5.0` for that field).
-6. Otherwise → `code_to_root_vars()` parses each `property: value;` line, derives the var name via `typography_var_name()`, and **appends the raw `--var: value;` lines** to `$this->css_root[device]`. Multiple fields accumulate into the same bucket.
+5. **Route decision** — if `typography_field_uses_vars($field)` returns `false` (i.e. the field's setting `name` is NOT one of the 8 foundation roles in `TYPO_VAR_MAP`), take the early-return literal path: emit selector-scoped CSS at `$field['selector']` into `$this->css[device]` / `$this->css['all']`. Leaf-global and per-component fields go here.
+6. Otherwise (foundation field) → **per-property split**. Core props (font-family, font-weight, font-size, line-height) go through `code_to_root_vars()`, which parses each `property: value;` line, derives the token name via `typography_var_name()`, and **appends the raw `--var: value;` lines** to `$this->css_root[device]`. Cosmetic props (letter-spacing, text-decoration, text-transform, font-style) are NOT tokenized — they emit as selector-scoped literal CSS at `$field['selector']` only when the user set them. Multiple fields accumulate into the same `:root` bucket.
 7. `render_css()` wraps each non-empty `$this->css_root[device]` in a **single** `:root { ... }` block and the matching media query, then flushes `$this->css[device]` afterwards.
 8. Final CSS lands inline via `wp_add_inline_style('customify-style', ...)` — handle unchanged.
 
-### 4.4 SCSS consumer placement (Global panel only)
+### 4.4 SCSS consumer placement (foundation tokens only)
 
-For the 11 Global Typography settings, **SCSS owns the selector** — vars at `:root` don't apply until something consumes them. Per-component fields stay in legacy mode and PHP still emits the selector-scoped CSS directly, so no SCSS var consumer exists for them.
+For the 8 foundation settings, **SCSS owns the selector** — tokens at `:root` don't apply until something consumes them. Leaf-global and per-component fields emit selector-scoped literal CSS directly from PHP, so they have **no SCSS token consumer** of their own.
 
-| Setting group | Primary SCSS file |
+| Foundation token | Primary SCSS file |
 |---|---|
-| `base_p`, `base_heading` (group rules h1-h6) | [`base/_base.scss`](../src/frontend/scss/base/_base.scss) lines 21-51 |
-| `base_widget_title` | [`widgets/_widgets.scss`](../src/frontend/scss/widgets/_widgets.scss) lines 1-12 |
-| `heading_h1` … `h6` (with `@include for_device` responsive for h1/h2) | [`base/_base.scss`](../src/frontend/scss/base/_base.scss) lines 53-113 |
-| `site_tt_title`, `site_tt_desc` | [`header/builder_items/_logo_site_identity.scss`](../src/frontend/scss/header/builder_items/_logo_site_identity.scss) lines 18-32 |
-| `footer_copyright_typography` | [`footer/_footer-common.scss`](../src/frontend/scss/footer/_footer-common.scss) |
-| `base_widget_title` | [`widgets/_widgets.scss`](../src/frontend/scss/widgets/_widgets.scss) |
-| `blog_post_more_typography` | [`layouts/_blogs.scss`](../src/frontend/scss/layouts/_blogs.scss) (`.readmore-button`) |
-| `wc_cart_typography` | [`compatibility/wc/_wc-cart.scss`](../src/frontend/scss/compatibility/wc/_wc-cart.scss) |
+| `body` (`base_p`) | [`base/_base.scss`](../src/frontend/scss/base/_base.scss) — the `body` rule |
+| `heading` (`base_heading`, family + weight) | [`base/_base.scss`](../src/frontend/scss/base/_base.scss) — the shared `h1..h6, .h1..h6` rule |
+| `h1` … `h6` (`heading_h1..h6`, font-size + line-height; with `@include for_device` responsive for h1/h2) | [`base/_base.scss`](../src/frontend/scss/base/_base.scss) — the per-level `h1, .h1` … `h6, .h6` rules |
 
-**Two consumer patterns:**
+**Leaf reuse note.** Leaf selectors don't mint their own tokens but two of them *reuse* the foundation heading token as their default font-family:
 
-- **Direct `var(...)` calls** — preferred for selectors that already had typography literals. Preserves breakpoint-specific fallbacks (e.g. h1 `font-size` differs per `@include for_device`):
-  ```scss
-  h1, .h1 {
-      font-size: var(--customify-typo-h1-font-size, 2.42em);
-      @include for_device(tablet) {
-          font-size: var(--customify-typo-h1-font-size, 2.1em);
-      }
-  }
-  ```
-- **`customify-typography` mixin** in [`utils/_mixins.scss`](../src/frontend/scss/utils/_mixins.scss) — used for selectors that had no typography literal to start (currently the tagline `.site-description`). Emits all 8 properties in one call with safe no-override fallbacks (`inherit` / `normal` / `none`); kept available for opt-in scenarios via `customify/typography/field_uses_vars`:
-  ```scss
-  .site-description {
-      margin: 5px 0 7px;
-      @include customify-typography('site-tt-desc');
-  }
-  ```
+- `.site-branding .site-title` (and `.widget-title` / `.site-content .widget-title`) default to `font-family: var(--customify-typo-heading-font-family, inherit)` — see [`header/builder_items/_logo_site_identity.scss`](../src/frontend/scss/header/builder_items/_logo_site_identity.scss) and [`widgets/_widgets.scss`](../src/frontend/scss/widgets/_widgets.scss). When the user sets Site Title / Widget Title typography, PHP emits selector-scoped literal CSS that overrides these defaults.
+- The tagline `.site-description` carries **no** typography var consumer (only `margin`); it inherits the body font and is overridden by the literal CSS that the Tagline field emits when set.
+
+**Consumer pattern — direct 2-arg `var(...)`.** Preferred for selectors that already had typography literals. Preserves breakpoint-specific fallbacks (e.g. h1 `font-size` differs per `@include for_device`):
+
+```scss
+h1, .h1 {
+    font-size: var(--customify-typo-h1-font-size, 2.42em);
+    @include for_device(tablet) {
+        font-size: var(--customify-typo-h1-font-size, 2.1em);
+    }
+}
+```
+
+For a fresh selector with no existing literals, hand-write one 2-arg `var()` per property with a safe no-override fallback (`inherit` / `normal` / `none`):
+
+```scss
+.my-component {
+    font-family: var(--customify-typo-my-name-font-family, inherit);
+    font-weight: var(--customify-typo-my-name-font-weight, inherit);
+    font-size:   var(--customify-typo-my-name-font-size, inherit);
+    line-height: var(--customify-typo-my-name-line-height, inherit);
+}
+```
 
 Every `var(...)` must be 2-arg (1-arg banned per [`../AGENTS.md`](../AGENTS.md)).
 
 ### 4.5 Live preview & block editor
 
-- **Customizer live preview**: `CustomifyAutoCSS.prototype.typography` mirrors PHP — builds `:root { ... }` strings into `that.css_root[device]`, flushed before `that.css[device]`. CSS injects into `<style id="customify-style-inline-css">` in the preview iframe head; Google Fonts URL into `<link id="customify-google-font-css">`. Both unchanged from pre-`0.5.0`.
-- **Block editor**: [`src/backend/admin/scss/editor.scss`](../src/backend/admin/scss/editor.scss) imports the frontend `_base.scss`, `_blocks.scss`, and `_widgets.scss` — the same consumers run inside `.editor-styles-wrapper`. `Customify_Editor::load_style()` calls `render_css($all_config_fields)` so every typography setting's `:root` vars land in the editor canvas via the editor ajax stylesheet. `Customify_Editor::css()` (lines 121-127) still rewrites typography field selectors to `.editor-styles-wrapper .wp-block-post-title` for legacy mode — dormant no-op in vars mode.
+- **Customizer live preview**: `CustomifyAutoCSS.prototype.typography` mirrors PHP — builds `:root { ... }` strings into `that.css_root[device]`, flushed before `that.css[device]`. CSS injects into `<style id="customify-style-inline-css">` in the preview iframe head; Google Fonts URL into `<link id="customify-google-font-css">`.
+- **Block editor**: [`src/backend/admin/scss/editor.scss`](../src/backend/admin/scss/editor.scss) imports the frontend `_base.scss`, `_blocks.scss`, and `_widgets.scss` — the same token consumers run inside `.editor-styles-wrapper`. `Customify_Editor::load_style()` calls `render_css($all_config_fields)` so every foundation setting's `:root` tokens land in the editor canvas via the editor ajax stylesheet. `Customify_Editor::css()` still rewrites typography field selectors to `.editor-styles-wrapper .wp-block-post-title`, but for the foundation fields (`global_typography_base_heading` / `global_typography_heading_h1`) this is a **dormant no-op**: the token path ignores `$field['selector']` (core props emit at `:root`) and no cosmetic prop survives their per-role `fields` gate. The post-title block tracks the heading family/scale because it renders as `<h1>`, which the `_base.scss` `h1` token consumer (imported by `editor.scss`) already covers.
 
 ---
 
 ## 5. Design decisions
 
-### 5.1 Decision: vars only, no parallel emission
+### 5.1 Decision: tokens only, no parallel emission
 
-- **Chose**: Always emit `:root` vars for Global Typography fields. Per-component fields stay selector-scoped (no SCSS consumers exist for them — see §5.3).
+- **Chose**: Always emit `:root` tokens for the 8 foundation fields. Leaf-global and per-component fields stay selector-scoped literal (no SCSS token consumers exist for them — see §5.3).
 - **Rejected**: A global `customify/typography/legacy_output` kill switch to revert all typography to selector-scoped output.
 - **Rejected**: Emit BOTH `:root { --var: ... }` and `{selector} { property: var(--var) }` in PHP.
-- **Reason**: Single source of truth. Child themes and JS read the same `:root` variable name regardless of which selector binds it. The kill switch was originally designed to coordinate with the Pro plugin during rollout; since the Pro plugin doesn't reference these vars at all, the escape hatch added complexity without buying anything.
+- **Reason**: Single source of truth. Child themes and JS read the same `:root` token name regardless of which selector binds it. The kill switch was originally designed to coordinate with the Pro plugin during rollout; since the Pro plugin doesn't reference these tokens at all, the escape hatch added complexity without buying anything.
 
 ### 5.2 Decision: prefix `--customify-typo-` (not `--cfy-`)
 
@@ -226,28 +240,28 @@ Every `var(...)` must be 2-arg (1-arg banned per [`../AGENTS.md`](../AGENTS.md))
 - **Rejected**: Shorter `--cfy-typo-` or `--cfy-`. Original plan in memory `typography-vars-migration` used `--cfy-`.
 - **Reason**: Consistency with the color token convention already in [`src/frontend/scss/`](../src/frontend/scss/) (e.g. `var(--customify-body-text, #686868)`). One namespace for the whole theme is easier to document and override.
 
-### 5.3 Decision: vars limited to the Global Typography panel
+### 5.3 Decision: tokens limited to the 8 foundation roles
 
-- **Chose**: Only fields whose setting `name` starts with `global_typography_` (the 11 Global settings — Base, Site Title & Tagline, Heading family) emit `:root` vars. Per-component typography (header builder items, footer copyright, blog read-more, breadcrumb, WC cart — 9 fields) stays in legacy selector-scoped output.
-- **Rejected**: Emit vars for ALL 20 fields, with SCSS consumers everywhere.
-- **Reason**: Per-component selectors are dynamic (`a.item--button`, `.builder-header-cart-item`, `#blog-posts .entry-readmore a`) and often paired with **hardcoded** field prefixes — there's no per-instance setting, so a single var would apply uniformly across every button / cart / read-more on the page. Mixing this with the Global panel's "single source of truth" promise creates confusion: users would expect their per-button typography to differ per instance, but the var-mode plumbing can't deliver that. Legacy emit keeps the existing per-component selectors authoritative without inventing instance vars.
+- **Chose**: Only the 8 foundation fields in `TYPO_VAR_MAP` (Base body, the shared Heading family/weight, the h1–h6 type scale) emit `:root` tokens. The 3 leaf-global settings (Site Title, Tagline, Widget Title) and the 9 per-component fields (header builder items, footer copyright, blog read-more, breadcrumb, WC cart) emit selector-scoped **literal** CSS. The leaf settings do **not** emit `:root` tokens — but their SCSS defaults reuse the heading token (site title, widget title) so they still track the heading family without minting a token.
+- **Rejected**: Emit tokens for ALL 20 fields, with SCSS consumers everywhere.
+- **Reason**: Foundation roles are 1-to-many (body text is inherited document-wide; the heading family/scale is shared across every heading), so a `:root` token earns its place. Leaf and per-component selectors are 1-to-1 and often dynamic (`a.item--button`, `.builder-header-cart-item`, `#blog-posts .entry-readmore a`) and paired with **hardcoded** field prefixes — there's no per-instance setting, so a single token would apply uniformly across every button / cart / read-more on the page. Literal emit keeps those selectors authoritative without inventing instance tokens.
 
-### 5.4 Decision: `:root` scope for the Global vars (no per-instance scoping)
+### 5.4 Decision: `:root` scope for the foundation tokens (no per-instance scoping)
 
-- **Chose**: Every Global Typography var lives at `:root`. Var name encodes the semantic role (`base-p`, `heading-h1`, `site-tt-title`); the SCSS consumer selector decides where it applies.
-- **Rejected**: Scoping vars to per-section selectors.
-- **Reason**: The 11 Global fields target site-wide elements (body, headings, site title) — there's no "per-instance" of `<body>` or `<h1>`. `:root` is the natural home.
+- **Chose**: Every foundation token lives at `:root`. The token name encodes the semantic role (`body`, `heading`, `h1`); the SCSS consumer selector decides where it applies.
+- **Rejected**: Scoping tokens to per-section selectors.
+- **Reason**: The foundation fields target site-wide elements (body, headings) — there's no "per-instance" of `<body>` or `<h1>`. `:root` is the natural home.
 
-### 5.5 Decision: SCSS owns selectors; PHP owns var values (for global fields)
+### 5.5 Decision: SCSS owns selectors; PHP owns token values (for foundation fields)
 
-- **Chose**: For the Global fields, `$field['selector']` is **ignored** by the vars emit path. SCSS is the only layer that decides which selectors consume which vars.
-- **Rejected**: PHP emits `{$field['selector']} { property: var(--customify-typo-…, …) }` alongside `:root` vars.
-- **Reason**: SCSS already had partial typography rules on the global selectors (body, h1-h6, widget title, site title). Having PHP also emit selector-scoped rules in vars mode would duplicate work and complicate the cascade. With SCSS as sole consumer for vars-mode fields, the SCSS layer is the canonical "where typography applies" — easier to audit, easier to override.
+- **Chose**: For the foundation fields, `$field['selector']` is **ignored** by the token emit path (cosmetic properties aside — see §4.3 step 6). SCSS is the only layer that decides which selectors consume which tokens.
+- **Rejected**: PHP emits `{$field['selector']} { property: var(--customify-typo-…, …) }` alongside `:root` tokens.
+- **Reason**: SCSS already had partial typography rules on the foundation selectors (body, h1–h6). Having PHP also emit selector-scoped rules in token mode would duplicate work and complicate the cascade. With SCSS as sole consumer for foundation fields, the SCSS layer is the canonical "where typography applies" — easier to audit, easier to override.
 
 ### 5.6 Decision: keep `setup_font()` side effects unconditional
 
-- **Chose**: `setup_font()` runs regardless of legacy-vs-vars mode. Google Fonts URL building, WP Font Library `@font-face` tracking, and theme.json font registry stay intact.
-- **Rejected**: Skip font tracking in vars mode (e.g. assume CSS vars alone are enough).
+- **Chose**: `setup_font()` runs regardless of token-vs-literal mode. Google Fonts URL building, WP Font Library `@font-face` tracking, and theme.json font registry stay intact.
+- **Rejected**: Skip font tracking in token mode (e.g. assume CSS tokens alone are enough).
 - **Reason**: CSS `font-family: var(--…, fallback)` references a family by NAME — the browser still needs the `@font-face` declaration (Library) or external stylesheet (`<link href="fonts.googleapis.com/…">`) to actually load the font. Skipping `setup_font()` would silently break Google Fonts and WP Font Library on every site that uses them.
 
 ---
@@ -272,38 +286,31 @@ For a typography Customizer field that already has an SCSS rule with literal val
 }
 ```
 
-`{semantic}` derives from the field's setting `name` per the strip rule in §4.1.
+`{semantic}` resolves from the field's setting `name` per §4.1 — the `TYPO_VAR_MAP` value for a foundation field, or the strip-rule fallback for an opted-in non-foundation field.
 
 ### 6.2 Add a typography consumer for a fresh selector
 
-For an SCSS rule with NO existing typography literals (only structural CSS) — use the mixin so all 8 properties wire up at once with safe no-override fallbacks:
+For an SCSS rule with NO existing typography literals (only structural CSS) — hand-write one 2-arg `var()` per property you want to wire, each with a safe no-override fallback (`inherit` / `normal` / `none`):
 
 ```scss
 .my-fresh-component {
-    margin-top: 1em;                       // structural
-    @include customify-typography('my-semantic-name');
+    margin-top: 1em;                                                   // structural
+    font-family: var(--customify-typo-my-semantic-name-font-family, inherit);
+    font-weight: var(--customify-typo-my-semantic-name-font-weight, inherit);
+    font-size:   var(--customify-typo-my-semantic-name-font-size, inherit);
+    line-height: var(--customify-typo-my-semantic-name-line-height, inherit);
 }
 ```
 
-To limit which properties wire (e.g. only family / size):
-
-```scss
-@include customify-typography('my-semantic-name', $props: (font-family, font-size));
-```
-
-To override the fallback for a specific property (e.g. theme-default font-weight should be 600 instead of `inherit`):
-
-```scss
-@include customify-typography('my-semantic-name', $fallbacks: (font-weight: 600));
-```
+Wire only the properties you need (e.g. just family + size) by omitting the rest. To give a property a different theme default (e.g. font-weight 600 instead of `inherit`), set that as the 2nd `var()` arg: `font-weight: var(--customify-typo-my-semantic-name-font-weight, 600);`. Every `var()` must be 2-arg (1-arg banned per [`../AGENTS.md`](../AGENTS.md)).
 
 ### 6.3 Register a new typography field
 
-See [`SPEC-customizer.md §5.3`](SPEC-customizer.md) — register a `'type' => 'typography'` field with `'css_format' => 'typography'`. The generator routes it through the same pipeline. **Emit mode is decided by the setting `name`:** if `name` starts with `global_typography_` the field emits `:root` vars (and you must add an SCSS consumer at the matching selector — see §6.2); otherwise it emits selector-scoped CSS at `$field['selector']` exactly as pre-`0.5.0`.
+See [`SPEC-customizer.md §5.3`](SPEC-customizer.md) — register a `'type' => 'typography'` field with `'css_format' => 'typography'`. The generator routes it through the same pipeline. **Emit mode is decided by the setting `name`:** if `name` is one of the 8 foundation roles in `TYPO_VAR_MAP` the field emits `:root` tokens (and you must add an SCSS consumer at the matching selector — see §6.2); otherwise it emits selector-scoped literal CSS at `$field['selector']`. To tokenize a brand-new role you must also add it to `TYPO_VAR_MAP` (PHP const + JS mirror) — the explicit map is the primary naming path.
 
-### 6.4 Opt a per-component field into vars mode
+### 6.4 Opt a non-foundation field into token mode
 
-If you want a per-component typography field (e.g. `header_button_typography`) to emit vars instead of legacy CSS:
+If you want a non-foundation typography field (e.g. `header_button_typography`) to emit tokens instead of literal CSS:
 
 1. Add the SCSS consumer at the field's selector — see §6.1 / §6.2.
 2. Filter the field through:
@@ -317,7 +324,7 @@ If you want a per-component typography field (e.g. `header_button_typography`) t
    }, 10, 2 );
    ```
 
-Without step 1 the var lands at `:root` but no selector consumes it — the user's saved value silently no-ops on the frontend.
+The token name comes from the §4.1 fallback strip rule (the field isn't in `TYPO_VAR_MAP`). Without step 1 the token lands at `:root` but no selector consumes it — the user's saved value silently no-ops on the frontend.
 
 ---
 
@@ -325,29 +332,29 @@ Without step 1 the var lands at `:root` but no selector consumes it — the user
 
 | Hook | Type | Payload | Purpose |
 |---|---|---|---|
-| `customify/typography/field_uses_vars` | filter | `(bool $uses_vars, array $field)` (default = setting `name` starts with `global_typography_`) | **Per-field route override.** Return `false` to force a Global field through selector-scoped emit, or `true` to opt a per-component field into vars mode. The vars-mode field still needs an SCSS consumer at the matching selector — see §6.4. |
-| `customify/customizer/auto_css` | filter | `(array $devices_css, $field, Customify_Customizer_Auto_CSS $instance)` | Unchanged — runs before the route decision. In vars mode, modifying a CSS line here changes the var value that gets emitted; in selector-scoped mode, it changes the CSS line. |
-| `customify/auto-css` | filter | `string $css` — final assembled CSS | Unchanged. Receives the `:root { ... }` blocks ahead of any selector-scoped CSS in vars mode. |
+| `customify/typography/field_uses_vars` | filter | `(bool $uses_vars, array $field)` (default = setting `name` is one of the 8 foundation roles in `TYPO_VAR_MAP`) | **Per-field route override.** Return `false` to force a foundation field through selector-scoped emit, or `true` to opt a non-foundation field into token mode. The token-mode field still needs an SCSS consumer at the matching selector — see §6.4. |
+| `customify/customizer/auto_css` | filter | `(array $devices_css, $field, Customify_Customizer_Auto_CSS $instance)` | Unchanged — runs before the route decision. For a foundation field, modifying a core CSS line here changes the token value that gets emitted; otherwise it changes the literal CSS line. |
+| `customify/auto-css` | filter | `string $css` — final assembled CSS | Unchanged. Receives the `:root { ... }` token blocks ahead of any selector-scoped literal CSS. |
 
 ---
 
 ## 8. Known issues / edge cases
 
-### Issue #1 — Per-component typography stays in selector-scoped mode
+### Issue #1 — Leaf and per-component typography stay in literal mode
 
-This is **intentional**. The 9 per-component fields (header menu/button/HTML/search, footer copyright, blog read-more, breadcrumb, WC cart) all emit selector-scoped CSS at their field `selector` — byte-identical to pre-`0.5.0`. Sites opting them into vars mode must add SCSS consumers and toggle `customify/typography/field_uses_vars` — see §6.4. Don't simply flip the filter without adding the consumer, or the user's saved value silently no-ops.
+This is **intentional**. The 3 leaf-global fields (site title, tagline, widget title) and the 9 per-component fields (header menu/button/HTML/search, footer copyright, blog read-more, breadcrumb, WC cart) all emit selector-scoped literal CSS at their field `selector` — they mint no token of their own. Site title and widget title still *reuse* the foundation heading token (`--customify-typo-heading-font-family`) as their SCSS default; the tagline inherits the body font. Sites opting any of these into token mode must add SCSS consumers and toggle `customify/typography/field_uses_vars` — see §6.4. Don't simply flip the filter without adding the consumer, or the user's saved value silently no-ops.
 
-### Issue #2 — Naming collision: `_font_size` strip on a setting named `*_font_size`
+### Issue #2 — Fallback naming collision: `_font_size` strip on a setting named `*_font_size`
 
-The strip rule trims `_font_size` from the suffix to handle the misleadingly-named `search_box_font_size` / `search_icon_modal_font_size` typography fields. If a future setting genuinely IS a single `font_size` field named `something_font_size`, its var would also lose the `_font_size` suffix. Today no such setting exists. If one is added, prefer a non-conflicting name (e.g. `something_size`) or update `typography_var_name()` to special-case it.
+This only affects the **fallback** naming path (§4.1 step 2) — reached for a non-foundation field opted into tokens, since the 8 foundation fields are named explicitly via `TYPO_VAR_MAP`. The fallback strip rule trims `_font_size` from the suffix to handle the misleadingly-named `search_box_font_size` / `search_icon_modal_font_size` typography fields. If a future opted-in setting genuinely IS a single `font_size` field named `something_font_size`, its token would also lose the `_font_size` suffix. Today no such setting is opted in. If one is added, prefer a non-conflicting name (e.g. `something_size`), add it to `TYPO_VAR_MAP`, or update the `typography_var_name()` fallback to special-case it.
 
 ---
 
 ## 9. Pro plugin handoff
 
-Pro typography fields all use `'css_format' => 'typography'` and route through the theme's `typography()` generator — no separate Pro emission path. They follow the same `typography_field_uses_vars()` gate: Pro fields whose setting `name` starts with `global_typography_` would emit `:root` vars; everything else falls through to selector-scoped CSS at `$field['selector']`.
+Pro typography fields all use `'css_format' => 'typography'` and route through the theme's `typography()` generator — no separate Pro emission path. They follow the same `typography_field_uses_vars()` gate: a Pro field would emit `:root` tokens only if its setting `name` is one of the foundation roles in `TYPO_VAR_MAP` (none are today) or a site opts it in via `customify/typography/field_uses_vars`; everything else falls through to selector-scoped literal CSS at `$field['selector']`.
 
-Pro's own inline-CSS callsites (header builder items, scrolltop, blog) write literal CSS at component selectors — no `--customify-typo-*` references today. The migration to read theme typography vars from Pro's SCSS is a separate task tracked in [`SPEC-pro-integration.md`](SPEC-pro-integration.md).
+Pro's own inline-CSS callsites (header builder items, scrolltop, blog) write literal CSS at component selectors — no `--customify-typo-*` references today. The migration to read theme typography tokens from Pro's SCSS is a separate task tracked in [`SPEC-pro-integration.md`](SPEC-pro-integration.md).
 
 ---
 
@@ -358,7 +365,7 @@ Pro's own inline-CSS callsites (header builder items, scrolltop, blog) write lit
 | Customizer setting saves but nothing changes on frontend | Setting's CSS field schema disables the property (e.g. `base_heading` only enables family + weight — see [`typography.php`](../inc/customizer/configs/typography.php)). Verify via the field config. |
 | Setting changes apply on frontend but not in block editor | Editor canvas selector differs from frontend. Add an editor-specific consumer rule in [`src/backend/admin/scss/editor.scss`](../src/backend/admin/scss/editor.scss) targeting `.editor-styles-wrapper {your-selector}`. |
 | Per-device font-size value ignored on smaller screen | The SCSS consumer's `@include for_device(tablet) { ... }` block sets a literal value AFTER the base rule, winning by source order. Convert the responsive block to also use `var(..., breakpoint-fallback)` — see h1/h2 in `_base.scss` for the pattern. |
-| Google Fonts URL missing | `setup_font()` skipped. The vars-mode emit path MUST still call `setup_font()` unconditionally — see §4.3 step 2. |
+| Google Fonts URL missing | `setup_font()` skipped. The token emit path MUST still call `setup_font()` unconditionally — see §4.3 step 2. |
 
 ---
 
@@ -367,9 +374,9 @@ Pro's own inline-CSS callsites (header builder items, scrolltop, blog) write lit
 | I want to… | Code |
 |---|---|
 | Override a typography value site-wide | Child theme CSS: `:root { --customify-typo-h1-font-size: 3rem; }` |
-| Override at a specific page | `body.page-id-42 { --customify-typo-base-p-font-size: 18px; }` |
-| Inspect the resolved var in the browser | DevTools → `<html>` → Computed → search `--customify-typo-` |
-| Get the var name for a setting programmatically | `Customify_Customizer_Auto_CSS::get_instance()->typography_var_name( $setting, $property );` |
+| Override at a specific page | `body.page-id-42 { --customify-typo-body-font-size: 18px; }` |
+| Inspect the resolved token in the browser | DevTools → `<html>` → Computed → search `--customify-typo-` |
+| Get the token name for a setting programmatically | `Customify_Customizer_Auto_CSS::get_instance()->typography_var_name( $setting, $property );` |
 
 ---
 
@@ -384,8 +391,8 @@ Pro's own inline-CSS callsites (header builder items, scrolltop, blog) write lit
 - [`src/backend/customizer/js/auto-css.js`](../src/backend/customizer/js/auto-css.js) — live preview mirror
 
 **SCSS**
-- [`src/frontend/scss/utils/_mixins.scss`](../src/frontend/scss/utils/_mixins.scss) — `customify-typography` mixin
-- [`src/frontend/scss/base/_base.scss`](../src/frontend/scss/base/_base.scss) — heaviest consumer
+- [`src/frontend/scss/base/_base.scss`](../src/frontend/scss/base/_base.scss) — the foundation token consumers (body + heading + h1–h6)
+- [`src/frontend/scss/header/builder_items/_logo_site_identity.scss`](../src/frontend/scss/header/builder_items/_logo_site_identity.scss), [`src/frontend/scss/widgets/_widgets.scss`](../src/frontend/scss/widgets/_widgets.scss) — leaf selectors that reuse the heading token
 
 **Related specs**
 - [`SPEC-customizer.md`](SPEC-customizer.md) §5.3 — typography control type registration

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -55,10 +55,10 @@ add_filter( 'customify_get_layout', function ( $layout ) {
 
 | Hook | Type | Payload | File |
 |---|---|---|---|
-| `customify/customizer/auto_css` | filter | `(array $css_lines, $field, Customify_Customizer_Auto_CSS $instance)` | [`inc/customizer/class-customizer-auto-css.php:790`](../inc/customizer/class-customizer-auto-css.php) |
-| `customify/auto-css` | filter | `string $css` — final assembled CSS before `wp_add_inline_style` | [`inc/customizer/class-customizer-auto-css.php:1261`](../inc/customizer/class-customizer-auto-css.php) |
+| `customify/customizer/auto_css` | filter | `(array $css_lines, $field, Customify_Customizer_Auto_CSS $instance)` | [`inc/customizer/class-customizer-auto-css.php`](../inc/customizer/class-customizer-auto-css.php) `maybe_devices_setup()` / `typography()` |
+| `customify/auto-css` | filter | `string $css` — final assembled CSS before `wp_add_inline_style` | [`inc/customizer/class-customizer-auto-css.php`](../inc/customizer/class-customizer-auto-css.php) `render_css()` |
 | `customify/styling/<field>` | filter | `string $css` — append CSS template to a specific field (e.g. `customify/styling/primary-color`) | dynamic — emitted per-field by auto-CSS |
-| `customify/typography/field_uses_vars` | filter | `(bool $uses_vars, array $field)` — **per-field route.** Default is `true` when the field's setting `name` starts with `global_typography_`. Return `false` to force a Global field through selector-scoped emit, or `true` to opt a per-component field into vars (also requires an SCSS consumer at the matching selector — see [`SPEC-typography.md §6.4`](SPEC-typography.md)). | [`inc/customizer/class-customizer-auto-css.php`](../inc/customizer/class-customizer-auto-css.php) `typography_field_uses_vars()` |
+| `customify/typography/field_uses_vars` | filter | `(bool $uses_vars, array $field)` — **per-field route.** Default is `true` only for the 8 foundation roles in `TYPO_VAR_MAP` (`global_typography_base_p`, `global_typography_base_heading`, `global_typography_heading_h1`…`h6`); leaf-global roles (site title, tagline, widget title) and per-component fields default `false`. Return `false` to force a foundation field through selector-scoped emit, or `true` to opt a non-foundation field into tokens (also requires an SCSS consumer at the matching selector — see [`SPEC-typography.md §6.4`](SPEC-typography.md)). | [`inc/customizer/class-customizer-auto-css.php`](../inc/customizer/class-customizer-auto-css.php) `typography_field_uses_vars()` |
 
 Example — extend the primary color CSS targets without forking the config file:
 

--- a/inc/customizer/class-customizer-auto-css.php
+++ b/inc/customizer/class-customizer-auto-css.php
@@ -77,6 +77,26 @@ class Customify_Customizer_Auto_CSS
 	);
 
 	/**
+	 * Foundational typography settings that emit :root tokens.
+	 * setting name => semantic var segment. Single source of truth for
+	 * both typography_field_uses_vars() (route gate) and
+	 * typography_var_name() (token name). Keep in lockstep with the JS
+	 * mirror's TYPO_VAR_MAP in src/backend/customizer/js/auto-css.js.
+	 *
+	 * @var array
+	 */
+	const TYPO_VAR_MAP = array(
+		'global_typography_base_p'       => 'body',
+		'global_typography_base_heading' => 'heading',
+		'global_typography_heading_h1'   => 'h1',
+		'global_typography_heading_h2'   => 'h2',
+		'global_typography_heading_h3'   => 'h3',
+		'global_typography_heading_h4'   => 'h4',
+		'global_typography_heading_h5'   => 'h5',
+		'global_typography_heading_h6'   => 'h6',
+	);
+
+	/**
 	 * Get intance.
 	 *
 	 * @return Customify_Customizer_Auto_CSS
@@ -1049,24 +1069,25 @@ class Customify_Customizer_Auto_CSS
 
 	/**
 	 * Whether a typography field emits :root CSS variables (vars mode)
-	 * or selector-scoped literal CSS (legacy). Vars are restricted to
-	 * fields whose setting `name` starts with `global_typography_` —
-	 * the Base / Site Title & Tagline / Heading family registered in
-	 * the Typography section. Per-component typography (header builder
-	 * items, footer copyright, blog read-more, breadcrumb, WC cart)
-	 * keeps the legacy selector-scoped output because their SCSS layer
-	 * doesn't carry generic consumer rules.
+	 * or selector-scoped literal CSS (legacy). Vars (tokens) are
+	 * restricted to the FOUNDATIONAL typography — Base body
+	 * (`global_typography_base_p`), the shared Heading family/weight
+	 * (`global_typography_base_heading`) and the h1–h6 type scale
+	 * (`global_typography_heading_h{1..6}`). These are 1-to-many
+	 * (inherited document-wide / shared across every heading) so a
+	 * :root token earns its place.
 	 *
-	 * Gate is keyed off the field `name` (not `section`) because the
-	 * Typography IA was flattened from a panel into a single section
-	 * (`typography_panel`), so the section id no longer encodes which
-	 * group a field belongs to — only the `global_typography_` name
-	 * prefix does.
+	 * Component-leaf typography — site title, tagline, widget title —
+	 * plus per-component typography (header builder items, footer
+	 * copyright, blog read-more, breadcrumb, WC cart) is 1-to-1, so it
+	 * keeps the legacy selector-scoped literal output. The leaf SCSS
+	 * rules still reuse the foundational tokens (e.g. site title reads
+	 * `--customify-typo-heading-font-family`) without minting their own.
 	 *
 	 * Sites can override the decision with the
 	 * `customify/typography/field_uses_vars` filter — return false
 	 * to force a specific field through the legacy path, or true to
-	 * opt a non-global field into vars (requires adding an SCSS
+	 * opt a non-foundational field into vars (requires adding an SCSS
 	 * consumer at the matching selector).
 	 *
 	 * @since 0.4.19
@@ -1076,22 +1097,24 @@ class Customify_Customizer_Auto_CSS
 	 */
 	public function typography_field_uses_vars($field)
 	{
-		$name      = isset($field['name']) ? (string) $field['name'] : '';
-		$is_global = ('' !== $name && 0 === strpos($name, 'global_typography_'));
-		return (bool) apply_filters('customify/typography/field_uses_vars', $is_global, $field);
+		$name = isset($field['name']) ? (string) $field['name'] : '';
+		// Foundational typography only (see self::TYPO_VAR_MAP): Base
+		// body, shared Heading family/weight, h1–h6 type scale. Leaf
+		// roles (site title, tagline, widget title) fall through to
+		// selector-scoped literal.
+		$tokenized = isset(self::TYPO_VAR_MAP[$name]);
+		return (bool) apply_filters('customify/typography/field_uses_vars', $tokenized, $field);
 	}
 
 	/**
 	 * Build the CSS custom-property name for a typography setting +
-	 * property pair. Strips well-known prefixes/suffixes so the name
-	 * stays short and predictable, then kebabs the remainder.
+	 * property pair. The foundational typography settings (Base body,
+	 * Heading, h1–h6) map to short, explicit semantic names; other
+	 * (opted-in) fields fall back to a prefix-strip + kebab.
 	 *
-	 *   global_typography_base_p, font-size
-	 *     → --customify-typo-base-p-font-size
-	 *   header_menus_typography, line-height
-	 *     → --customify-typo-header-menus-line-height
-	 *   blog_default_more_typography, font-family
-	 *     → --customify-typo-blog-default-more-font-family
+	 *   global_typography_base_p, font-size      → --customify-typo-body-font-size
+	 *   global_typography_base_heading, weight    → --customify-typo-heading-font-weight
+	 *   global_typography_heading_h1, font-size   → --customify-typo-h1-font-size
 	 *
 	 * @since 0.4.19
 	 *
@@ -1103,21 +1126,19 @@ class Customify_Customizer_Auto_CSS
 	{
 		$name = (string) $setting_name;
 
-		// Prefix strips, applied in order. 'heading_' is collapsed
-		// after 'global_typography_' so `global_typography_heading_h1`
-		// becomes `h1` (not `heading-h1`) — shorter var names for the
-		// per-level heading settings.
-		$prefix_strips = array(
-			'global_typography_',
-			'heading_',
-		);
-		foreach ($prefix_strips as $prefix) {
-			$len = strlen($prefix);
-			if (strlen($name) > $len && 0 === strpos($name, $prefix)) {
-				$name = substr($name, $len);
-			}
+		// Foundational settings map to short, explicit semantic names —
+		// single source of truth in self::TYPO_VAR_MAP (lockstep w/ JS).
+		if (isset(self::TYPO_VAR_MAP[$name])) {
+			return '--customify-typo-' . self::TYPO_VAR_MAP[$name] . '-' . $property;
 		}
 
+		// Fallback for fields opted into vars mode via
+		// customify/typography/field_uses_vars that aren't foundation
+		// settings: strip the known prefix/suffixes, then kebab.
+		$prefix = 'global_typography_';
+		if (strlen($name) > strlen($prefix) && 0 === strpos($name, $prefix)) {
+			$name = substr($name, strlen($prefix));
+		}
 		$suffix_strips = array(
 			'_modal_font_size',
 			'_typography',
@@ -1186,11 +1207,11 @@ class Customify_Customizer_Auto_CSS
 			);
 		}
 
-		if (isset($values['style']) && $values['style']) {
-
-			if ($values['style'] && 'default' !== $values['style']) {
-				$code['style'] = 'font-style: ' . $values['style'] . ';';
-			}
+		// Gate on $fields['style'] too — a role that disabled the style
+		// sub-field (e.g. base_heading) must not leak a saved font-style
+		// into the output. Mirrors how font_weight / text_* are gated.
+		if (isset($fields['style']) && isset($values['style']) && $values['style'] && 'default' !== $values['style']) {
+			$code['style'] = 'font-style: ' . $values['style'] . ';';
 		}
 
 		// Font Weight.
@@ -1279,12 +1300,12 @@ class Customify_Customizer_Auto_CSS
 
 		$devices_css = apply_filters('customify/customizer/auto_css', $devices_css, $field, $this);
 
-		// Vars mode is opt-in per field — only fields whose setting
-		// `name` starts with `global_typography_` (Base / Site Title &
-		// Tagline / Heading family) emit :root vars. Per-component
-		// typography (header builder items, footer copyright, etc.)
-		// falls through to selector-scoped output because its SCSS
-		// layer doesn't carry generic consumer rules.
+		// Only foundational typography (Base body, shared Heading,
+		// h1–h6 scale — see typography_field_uses_vars) emits :root
+		// tokens. Component-leaf global typography (site title, tagline,
+		// widget title) and per-component typography (header builder
+		// items, footer copyright, etc.) fall through to selector-scoped
+		// literal output here.
 		if (! $this->typography_field_uses_vars($field)) {
 			foreach ($devices_css as $device => $els) {
 				if (!empty($els)) {
@@ -1299,11 +1320,16 @@ class Customify_Customizer_Auto_CSS
 			return;
 		}
 
-		// Vars mode (default): accumulate the raw `--var: value;` lines
-		// into the device bucket. render_css() wraps each non-empty
-		// bucket in a single :root { ... } block so multiple typography
-		// fields collapse into one rule per device instead of one rule
-		// per field.
+		// Vars mode (default): split per-property. Core font-identity
+		// props (family / weight / size / line-height) emit :root vars —
+		// the typography token surface. Cosmetic props (letter-spacing,
+		// text-decoration, text-transform, font-style) are NOT tokenized;
+		// they emit as selector-scoped literal CSS at $field['selector']
+		// only when the user set them. The setting keeps working exactly
+		// as before without inflating the :root token namespace.
+		//
+		// Only font_size / line_height are device-scoped, and both are
+		// core, so every $devices_css entry goes straight to :root vars.
 		foreach ($devices_css as $device => $els) {
 			if (empty($els)) {
 				continue;
@@ -1318,8 +1344,19 @@ class Customify_Customizer_Auto_CSS
 		}
 
 		$code = array_filter($code);
-		if (!empty($code)) {
-			$vars = $this->code_to_root_vars($field['name'], $code);
+
+		// Cosmetic props → selector-scoped literal CSS (no token).
+		$cosmetic_keys = array('style', 'text_decoration', 'text_transform', 'letter_spacing');
+		$cosmetic_flip = array_flip($cosmetic_keys);
+		$cosmetic      = array_intersect_key($code, $cosmetic_flip);
+		if (!empty($cosmetic)) {
+			$this->css['all'] .= "{$field['selector']} {\r\n\t" . join("\r\n\t", $cosmetic) . "\r\n}";
+		}
+
+		// Core props → :root vars.
+		$core = array_diff_key($code, $cosmetic_flip);
+		if (!empty($core)) {
+			$vars = $this->code_to_root_vars($field['name'], $core);
 			if (!empty($vars)) {
 				if ('' !== $this->css_root['all']) {
 					$this->css_root['all'] .= "\r\n\t";

--- a/languages/customify.pot
+++ b/languages/customify.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Customify 0.4.19\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/customify\n"
-"POT-Creation-Date: 2026-05-31 00:37:18+00:00\n"
+"POT-Creation-Date: 2026-06-07 04:31:19+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -208,7 +208,7 @@ msgstr ""
 msgid "Copy now"
 msgstr ""
 
-#: inc/admin/dashboard.php:316 inc/customizer/class-customizer.php:1282
+#: inc/admin/dashboard.php:316 inc/customizer/class-customizer.php:1278
 msgid "Logo & Site Identity"
 msgstr ""
 
@@ -234,275 +234,274 @@ msgstr ""
 #: inc/customizer/configs/header/button.php:107
 #: inc/customizer/configs/header/panel.php:300
 #: inc/customizer/configs/header/transparent.php:69
-#: inc/customizer/configs/styling.php:25
 msgid "Styling"
 msgstr ""
 
-#: inc/admin/dashboard.php:336 inc/compatibility/breadcrumb.php:203
+#: inc/admin/dashboard.php:338 inc/compatibility/breadcrumb.php:203
 #: inc/compatibility/woocommerce/config/header/cart.php:206
 #: inc/customizer/configs/blogs.php:357
 #: inc/customizer/configs/header/button.php:96
-#: inc/customizer/configs/typography.php:21
+#: inc/customizer/configs/typography.php:31
 msgid "Typography"
 msgstr ""
 
-#: inc/admin/dashboard.php:340
+#: inc/admin/dashboard.php:343
 msgid "Sidebar Settings"
 msgstr ""
 
-#: inc/admin/dashboard.php:344 inc/customizer/configs/page-header.php:332
+#: inc/admin/dashboard.php:347 inc/customizer/configs/page-header.php:349
 msgid "Titlebar Settings"
 msgstr ""
 
-#: inc/admin/dashboard.php:349 inc/customizer/configs/blogs.php:8
+#: inc/admin/dashboard.php:352 inc/customizer/configs/blogs.php:8
 msgid "Blog Posts"
 msgstr ""
 
-#: inc/admin/dashboard.php:353
+#: inc/admin/dashboard.php:356
 msgid "Homepage Settings"
 msgstr ""
 
-#: inc/admin/dashboard.php:361
+#: inc/admin/dashboard.php:364
 msgid "Links to Customizer Settings"
 msgstr ""
 
-#: inc/admin/dashboard.php:382
+#: inc/admin/dashboard.php:385
 msgid "Font Icons Settings"
 msgstr ""
 
-#: inc/admin/dashboard.php:386
+#: inc/admin/dashboard.php:389
 msgid "Font Awesome version 4"
 msgstr ""
 
-#: inc/admin/dashboard.php:389
+#: inc/admin/dashboard.php:392
 msgid "Font Awesome version 6"
 msgstr ""
 
-#: inc/admin/dashboard.php:392
+#: inc/admin/dashboard.php:395
 msgid "Font Awesome version 6 and support version 4&5"
 msgstr ""
 
-#: inc/admin/dashboard.php:407
+#: inc/admin/dashboard.php:410
 msgid "Join the community!"
 msgstr ""
 
-#: inc/admin/dashboard.php:409
+#: inc/admin/dashboard.php:412
 msgid ""
 "Join the Facebook group for updates, discussions, chat with other Customify "
 "lovers."
 msgstr ""
 
-#: inc/admin/dashboard.php:410
+#: inc/admin/dashboard.php:413
 msgid "Join Our Facebook Group &rarr;\t"
 msgstr ""
 
-#: inc/admin/dashboard.php:424
+#: inc/admin/dashboard.php:427
 msgid "Customify ready to import sites"
 msgstr ""
 
-#: inc/admin/dashboard.php:429
+#: inc/admin/dashboard.php:432
 msgid ""
 "<strong>Customify Sites</strong> is a free add-on for the Customify theme "
 "which help you browse and import ready made websites with few clicks."
 msgstr ""
 
-#: inc/admin/dashboard.php:460
+#: inc/admin/dashboard.php:463
 msgid "View Site Library"
 msgstr ""
 
-#: inc/admin/dashboard.php:463 inc/admin/dashboard.php:631
+#: inc/admin/dashboard.php:466 inc/admin/dashboard.php:634
 msgid "Install Now"
 msgstr ""
 
-#: inc/admin/dashboard.php:476
+#: inc/admin/dashboard.php:479
 msgid "Download Plugin"
 msgstr ""
 
-#: inc/admin/dashboard.php:490
+#: inc/admin/dashboard.php:493
 msgid "Active Now"
 msgstr ""
 
-#: inc/admin/dashboard.php:509 inc/admin/dashboard.php:659
+#: inc/admin/dashboard.php:512 inc/admin/dashboard.php:662
 msgid "Details"
 msgstr ""
 
-#: inc/admin/dashboard.php:627
+#: inc/admin/dashboard.php:630
 msgid "Activate"
 msgstr ""
 
-#: inc/admin/dashboard.php:670
+#: inc/admin/dashboard.php:673
 msgid "Recommend Plugins"
 msgstr ""
 
-#: inc/admin/dashboard.php:686
+#: inc/admin/dashboard.php:689
 msgid "Header Transparent"
 msgstr ""
 
-#: inc/admin/dashboard.php:687
+#: inc/admin/dashboard.php:690
 msgid "Make your website stand out with transparent header modules."
 msgstr ""
 
-#: inc/admin/dashboard.php:691 inc/customizer/configs/upsell.php:31
+#: inc/admin/dashboard.php:694 inc/customizer/configs/upsell.php:31
 msgid "Header Sticky"
 msgstr ""
 
-#: inc/admin/dashboard.php:692
+#: inc/admin/dashboard.php:695
 msgid "Let your header accessible when users scroll up or down in unique style."
 msgstr ""
 
-#: inc/admin/dashboard.php:696
+#: inc/admin/dashboard.php:699
 msgid "Header and Footer Builder Booster"
 msgstr ""
 
-#: inc/admin/dashboard.php:697
+#: inc/admin/dashboard.php:700
 msgid "Get more header and footer builder items, plus advanced styling options."
 msgstr ""
 
-#: inc/admin/dashboard.php:701
+#: inc/admin/dashboard.php:704
 msgid "Scroll To Top"
 msgstr ""
 
-#: inc/admin/dashboard.php:702
+#: inc/admin/dashboard.php:705
 msgid ""
 "Get a better user experience with a scroll to top button with beautiful "
 "animation."
 msgstr ""
 
-#: inc/admin/dashboard.php:706
+#: inc/admin/dashboard.php:709
 msgid "Blog Pro"
 msgstr ""
 
-#: inc/admin/dashboard.php:707
+#: inc/admin/dashboard.php:710
 msgid "Take advantage of the Blog Pro module to show off your posts in any layouts."
 msgstr ""
 
-#: inc/admin/dashboard.php:711 inc/customizer/configs/header/panel.php:200
+#: inc/admin/dashboard.php:714 inc/customizer/configs/header/panel.php:200
 msgid "Advanced Styling"
 msgstr ""
 
-#: inc/admin/dashboard.php:712
+#: inc/admin/dashboard.php:715
 msgid ""
 "Control the layout and typography setting for page header title, page "
 "header cover and more."
 msgstr ""
 
-#: inc/admin/dashboard.php:716
+#: inc/admin/dashboard.php:719
 msgid "Portfolio"
 msgstr ""
 
-#: inc/admin/dashboard.php:717
+#: inc/admin/dashboard.php:720
 msgid "Show off your best project in a beautiful way."
 msgstr ""
 
-#: inc/admin/dashboard.php:721
+#: inc/admin/dashboard.php:724
 msgid "Multiple Headers"
 msgstr ""
 
-#: inc/admin/dashboard.php:722
+#: inc/admin/dashboard.php:725
 msgid "Create unique header for each page, post, archive or WooCommerce pages."
 msgstr ""
 
-#: inc/admin/dashboard.php:726
+#: inc/admin/dashboard.php:729
 msgid "Mega Menu"
 msgstr ""
 
-#: inc/admin/dashboard.php:727
+#: inc/admin/dashboard.php:730
 msgid "Create mega menu for your sites that need more space for navigation."
 msgstr ""
 
-#: inc/admin/dashboard.php:731
+#: inc/admin/dashboard.php:734
 msgid "Multilingual Integration"
 msgstr ""
 
-#: inc/admin/dashboard.php:732
+#: inc/admin/dashboard.php:735
 msgid ""
 "WPML multilingual plugin support, plus a fully customized language switcher "
 "header builder item."
 msgstr ""
 
-#: inc/admin/dashboard.php:736
+#: inc/admin/dashboard.php:739
 msgid "Custom Fonts"
 msgstr ""
 
-#: inc/admin/dashboard.php:737
+#: inc/admin/dashboard.php:740
 msgid ""
 "Custom Fonts module allows you to add your self-hosted fonts and use them "
 "on your Customify powered websites."
 msgstr ""
 
-#: inc/admin/dashboard.php:742
+#: inc/admin/dashboard.php:745
 msgid "Typekit"
 msgstr ""
 
-#: inc/admin/dashboard.php:743
+#: inc/admin/dashboard.php:746
 msgid ""
 "Typekit module allows you to add Typekit fonts and use them on your "
 "Customify powered websites."
 msgstr ""
 
-#: inc/admin/dashboard.php:747
+#: inc/admin/dashboard.php:750
 msgid "Customify Hooks"
 msgstr ""
 
-#: inc/admin/dashboard.php:748
+#: inc/admin/dashboard.php:751
 msgid "Add custom hook scripts."
 msgstr ""
 
-#: inc/admin/dashboard.php:753
+#: inc/admin/dashboard.php:756
 msgid "WooCommerce Booster"
 msgstr ""
 
-#: inc/admin/dashboard.php:754
+#: inc/admin/dashboard.php:757
 msgid "Gives you creative control of style and layout options for your shop."
 msgstr ""
 
-#: inc/admin/dashboard.php:759
+#: inc/admin/dashboard.php:762
 msgid "Single Product Layouts"
 msgstr ""
 
-#: inc/admin/dashboard.php:760
+#: inc/admin/dashboard.php:763
 msgid "More beautiful layouts for your single product."
 msgstr ""
 
-#: inc/admin/dashboard.php:765
+#: inc/admin/dashboard.php:768
 msgid "Off Canvas Filter"
 msgstr ""
 
-#: inc/admin/dashboard.php:766
+#: inc/admin/dashboard.php:769
 msgid "Add off canvas products filter for shop and product archive pages."
 msgstr ""
 
-#: inc/admin/dashboard.php:771
+#: inc/admin/dashboard.php:774
 msgid "Product Gallery Slider"
 msgstr ""
 
-#: inc/admin/dashboard.php:772
+#: inc/admin/dashboard.php:775
 msgid "Add slider for product gallery."
 msgstr ""
 
-#: inc/admin/dashboard.php:777
+#: inc/admin/dashboard.php:780
 msgid "Quick View"
 msgstr ""
 
-#: inc/admin/dashboard.php:778
+#: inc/admin/dashboard.php:781
 msgid "Add product quick view modal for product listing.."
 msgstr ""
 
-#: inc/admin/dashboard.php:784
+#: inc/admin/dashboard.php:787
 msgid "Infinity Scroll."
 msgstr ""
 
-#: inc/admin/dashboard.php:785
+#: inc/admin/dashboard.php:788
 msgid ""
 "Loads the next posts, products automatically when the reader approaches the "
 "bottom of the page."
 msgstr ""
 
-#: inc/admin/dashboard.php:793
+#: inc/admin/dashboard.php:796
 msgid "Customify Pro Modules"
 msgstr ""
 
-#: inc/admin/dashboard.php:794
+#: inc/admin/dashboard.php:797
 msgid "Upgrade Now &rarr;"
 msgstr ""
 
@@ -600,7 +599,7 @@ msgid "Pages:"
 msgstr ""
 
 #: inc/blog/functions-posts-layout.php:41
-#: inc/customizer/configs/page-header.php:793
+#: inc/customizer/configs/page-header.php:810
 #. translators: 1: Search query name
 msgid "Search Results for: %s"
 msgstr ""
@@ -610,18 +609,18 @@ msgid "Feed for all posts filed under %s"
 msgstr ""
 
 #: inc/class-customify.php:199 inc/class-customify.php:261
-#: inc/colors-palette.php:1894 inc/customizer/configs/colors.php:112
+#: inc/colors-palette.php:1894 inc/customizer/configs/colors.php:115
 msgid "Primary"
 msgstr ""
 
 #: inc/class-customify.php:266 inc/colors-palette.php:1906
-#: inc/customizer/configs/colors.php:126
+#: inc/customizer/configs/colors.php:129
 msgid "Secondary"
 msgstr ""
 
 #: inc/class-customify.php:271
 #: inc/compatibility/woocommerce/config/catalog-designer.php:393
-#: inc/customizer/configs/colors.php:154
+#: inc/customizer/configs/colors.php:157
 #: inc/customizer/configs/header/button.php:46
 msgid "Text"
 msgstr ""
@@ -660,24 +659,25 @@ msgstr ""
 
 #: inc/class-metabox-fields.php:442
 #: inc/compatibility/woocommerce/config/single-product.php:196
-#: inc/customizer/class-customizer.php:576
-#: inc/customizer/class-customizer.php:587
-#: inc/customizer/class-customizer.php:599
-#: inc/customizer/class-customizer.php:684
-#: inc/customizer/class-customizer.php:701
-#: inc/customizer/class-customizer.php:721
-#: inc/customizer/class-customizer.php:738
-#: inc/customizer/class-customizer.php:758
-#: inc/customizer/class-customizer.php:853
+#: inc/customizer/class-customizer.php:572
+#: inc/customizer/class-customizer.php:583
+#: inc/customizer/class-customizer.php:595
+#: inc/customizer/class-customizer.php:680
+#: inc/customizer/class-customizer.php:697
+#: inc/customizer/class-customizer.php:717
+#: inc/customizer/class-customizer.php:734
+#: inc/customizer/class-customizer.php:754
+#: inc/customizer/class-customizer.php:849
 #: inc/customizer/configs/header/social-icons.php:271
-#: inc/customizer/configs/layouts.php:273
-#: inc/customizer/configs/page-header.php:219
-#: inc/customizer/configs/page-header.php:260
-#: inc/customizer/configs/page-header.php:271
-#: inc/customizer/configs/page-header.php:488
-#: inc/customizer/configs/page-header.php:506
-#: inc/customizer/configs/page-header.php:527
-#: inc/customizer/configs/page-header.php:545
+#: inc/customizer/configs/layouts.php:309
+#: inc/customizer/configs/layouts.php:332
+#: inc/customizer/configs/page-header.php:236
+#: inc/customizer/configs/page-header.php:277
+#: inc/customizer/configs/page-header.php:288
+#: inc/customizer/configs/page-header.php:505
+#: inc/customizer/configs/page-header.php:523
+#: inc/customizer/configs/page-header.php:544
+#: inc/customizer/configs/page-header.php:562
 #: inc/customizer/controls/class-control-base.php:290
 #: inc/customizer/controls/class-control-base.php:314
 msgid "Default"
@@ -705,11 +705,11 @@ msgstr ""
 #: inc/customizer/configs/footer/panel.php:151
 #: inc/customizer/configs/footer/panel.php:567
 #: inc/customizer/configs/header/panel.php:122
-#: inc/customizer/configs/page-header.php:214
+#: inc/customizer/configs/page-header.php:231
 msgid "Layout"
 msgstr ""
 
-#: inc/class-metabox.php:55 inc/customizer/configs/page-header.php:207
+#: inc/class-metabox.php:55 inc/customizer/configs/page-header.php:224
 msgid "Page Header"
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr ""
 #: inc/class-metabox.php:67 inc/customizer/configs/footer/panel.php:158
 #: inc/customizer/configs/header/panel.php:129
 #: inc/customizer/configs/layouts.php:42
-#: inc/customizer/configs/page-header.php:221
+#: inc/customizer/configs/page-header.php:238
 msgid "Full Width"
 msgstr ""
 
@@ -744,9 +744,9 @@ msgstr ""
 msgid "Default - inside main content"
 msgstr ""
 
-#: inc/class-metabox.php:90 inc/customizer/class-customizer.php:686
+#: inc/class-metabox.php:90 inc/customizer/class-customizer.php:682
 #: inc/customizer/configs/page-header.php:37
-#: inc/customizer/configs/page-header.php:490
+#: inc/customizer/configs/page-header.php:507
 msgid "Cover"
 msgstr ""
 
@@ -829,7 +829,7 @@ msgstr ""
 msgid "Show"
 msgstr ""
 
-#: inc/class-metabox.php:233
+#: inc/class-metabox.php:232
 msgid "Customify Settings"
 msgstr ""
 
@@ -968,7 +968,7 @@ msgstr ""
 msgid "Secondary Container"
 msgstr ""
 
-#: inc/colors-palette.php:1916 inc/customizer/configs/colors.php:140
+#: inc/colors-palette.php:1916 inc/customizer/configs/colors.php:143
 msgid "Accent"
 msgstr ""
 
@@ -980,12 +980,12 @@ msgstr ""
 msgid "Body Text"
 msgstr ""
 
-#: inc/colors-palette.php:1945 inc/customizer/configs/colors.php:172
+#: inc/colors-palette.php:1945 inc/customizer/configs/colors.php:175
 msgid "Surface"
 msgstr ""
 
-#: inc/colors-palette.php:1950 inc/customizer/configs/colors.php:186
-#: inc/customizer/configs/typography.php:29
+#: inc/colors-palette.php:1950 inc/customizer/configs/colors.php:189
+#: inc/customizer/configs/typography.php:39
 msgid "Base"
 msgstr ""
 
@@ -1075,14 +1075,14 @@ msgstr ""
 #: inc/compatibility/breadcrumb.php:188 inc/compatibility/breadcrumb.php:193
 #: inc/customizer/configs/header/transparent.php:180
 #: inc/customizer/configs/header/transparent.php:185
-#: inc/customizer/configs/page-header.php:237
-#: inc/customizer/configs/page-header.php:248
+#: inc/customizer/configs/page-header.php:254
+#: inc/customizer/configs/page-header.php:265
 msgid "Display"
 msgstr ""
 
 #: inc/compatibility/breadcrumb.php:189
 #: inc/customizer/configs/header/transparent.php:181
-#: inc/customizer/configs/page-header.php:238
+#: inc/customizer/configs/page-header.php:255
 msgid "Settings display for special pages."
 msgstr ""
 
@@ -1111,7 +1111,7 @@ msgstr ""
 #: inc/compatibility/woocommerce/config/catalog-designer.php:278
 #: inc/customizer/configs/blogs.php:298
 #: inc/customizer/configs/header/social-icons.php:99
-#: inc/customizer/configs/page-header.php:289
+#: inc/customizer/configs/page-header.php:306
 #: inc/customizer/configs/related-posts.php:31
 #: inc/customizer/configs/related-posts.php:149
 #: inc/customizer/configs/related-posts.php:211
@@ -1575,309 +1575,309 @@ msgstr ""
 msgid "Font Awesome v6"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:531
+#: inc/customizer/class-customizer.php:527
 msgid "Font Family"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:537
+#: inc/customizer/class-customizer.php:533
 msgid "Font Weight"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:543
+#: inc/customizer/class-customizer.php:539
 msgid "Font Languages"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:548
+#: inc/customizer/class-customizer.php:544
 msgid "Font Size"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:557
+#: inc/customizer/class-customizer.php:553
 msgid "Line Height"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:566
+#: inc/customizer/class-customizer.php:562
 msgid "Letter Spacing"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:574
+#: inc/customizer/class-customizer.php:570
 msgid "Font Style"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:577
-#: inc/customizer/class-customizer.php:619
+#: inc/customizer/class-customizer.php:573
+#: inc/customizer/class-customizer.php:615
 #: inc/customizer/configs/header/menus.php:165
 #: inc/customizer/configs/header/social-icons.php:213
 msgid "Normal"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:578
+#: inc/customizer/class-customizer.php:574
 #: inc/customizer/controls/class-control-font-style.php:17
 msgid "Italic"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:579
+#: inc/customizer/class-customizer.php:575
 msgid "Oblique"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:585
+#: inc/customizer/class-customizer.php:581
 msgid "Text Decoration"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:588
+#: inc/customizer/class-customizer.php:584
 #: inc/customizer/controls/class-control-font-style.php:18
 msgid "Underline"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:589
+#: inc/customizer/class-customizer.php:585
 msgid "Overline"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:590
+#: inc/customizer/class-customizer.php:586
 msgid "Line through"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:591
-#: inc/customizer/class-customizer.php:603
-#: inc/customizer/class-customizer.php:759
-#: inc/customizer/class-customizer.php:854
+#: inc/customizer/class-customizer.php:587
+#: inc/customizer/class-customizer.php:599
+#: inc/customizer/class-customizer.php:755
+#: inc/customizer/class-customizer.php:850
 #: inc/customizer/configs/header/social-icons.php:185
 #: inc/customizer/configs/header/social-icons.php:272
 msgid "None"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:597
+#: inc/customizer/class-customizer.php:593
 msgid "Text Transform"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:600
+#: inc/customizer/class-customizer.php:596
 #: inc/customizer/controls/class-control-font-style.php:20
 msgid "Uppercase"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:601
+#: inc/customizer/class-customizer.php:597
 msgid "Lowercase"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:602
+#: inc/customizer/class-customizer.php:598
 msgid "Capitalize"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:620
+#: inc/customizer/class-customizer.php:616
 #: inc/customizer/configs/header/social-icons.php:214
 msgid "Hover"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:626
-#: inc/customizer/class-customizer.php:822
+#: inc/customizer/class-customizer.php:622
+#: inc/customizer/class-customizer.php:818
 #: inc/customizer/configs/header/nav-icon.php:79
 #: inc/customizer/configs/header/social-icons.php:196
 msgid "Color"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:632
-#: inc/customizer/class-customizer.php:828
+#: inc/customizer/class-customizer.php:628
+#: inc/customizer/class-customizer.php:824
 msgid "Link Color"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:646
+#: inc/customizer/class-customizer.php:642
 #: inc/customizer/configs/header/panel.php:432
 msgid "Margin"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:659
+#: inc/customizer/class-customizer.php:655
 #: inc/customizer/configs/header/social-icons.php:158
 msgid "Padding"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:665
-#: inc/customizer/class-customizer.php:834
+#: inc/customizer/class-customizer.php:661
+#: inc/customizer/class-customizer.php:830
 msgid "Background"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:671
-#: inc/customizer/class-customizer.php:839
+#: inc/customizer/class-customizer.php:667
+#: inc/customizer/class-customizer.php:835
 #: inc/customizer/configs/footer/panel.php:198
 #: inc/customizer/configs/header/social-icons.php:220
 #: inc/customizer/configs/header/social-icons.php:236
 msgid "Background Color"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:677
-#: inc/customizer/configs/page-header.php:480
+#: inc/customizer/class-customizer.php:673
+#: inc/customizer/configs/page-header.php:497
 msgid "Background Image"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:685
-#: inc/customizer/configs/page-header.php:489
+#: inc/customizer/class-customizer.php:681
+#: inc/customizer/configs/page-header.php:506
 #: inc/customizer/controls/class-control-css-ruler.php:21
 msgid "Auto"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:687
-#: inc/customizer/configs/page-header.php:491
+#: inc/customizer/class-customizer.php:683
+#: inc/customizer/configs/page-header.php:508
 msgid "Contain"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:690
+#: inc/customizer/class-customizer.php:686
 #: inc/customizer/configs/header/social-icons.php:144
-#: inc/customizer/configs/page-header.php:494
+#: inc/customizer/configs/page-header.php:511
 msgid "Size"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:697
-#: inc/customizer/configs/page-header.php:502
+#: inc/customizer/class-customizer.php:693
+#: inc/customizer/configs/page-header.php:519
 msgid "Position"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:702
-#: inc/customizer/configs/page-header.php:507
+#: inc/customizer/class-customizer.php:698
+#: inc/customizer/configs/page-header.php:524
 msgid "Center"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:703
-#: inc/customizer/configs/page-header.php:508
+#: inc/customizer/class-customizer.php:699
+#: inc/customizer/configs/page-header.php:525
 msgid "Top Left"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:704
-#: inc/customizer/configs/page-header.php:509
+#: inc/customizer/class-customizer.php:700
+#: inc/customizer/configs/page-header.php:526
 msgid "Top Right"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:705
-#: inc/customizer/configs/page-header.php:510
+#: inc/customizer/class-customizer.php:701
+#: inc/customizer/configs/page-header.php:527
 msgid "Top Center"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:706
-#: inc/customizer/configs/page-header.php:511
+#: inc/customizer/class-customizer.php:702
+#: inc/customizer/configs/page-header.php:528
 msgid "Bottom Left"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:707
-#: inc/customizer/configs/page-header.php:512
+#: inc/customizer/class-customizer.php:703
+#: inc/customizer/configs/page-header.php:529
 msgid "Bottom Center"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:708
-#: inc/customizer/configs/page-header.php:513
+#: inc/customizer/class-customizer.php:704
+#: inc/customizer/configs/page-header.php:530
 msgid "Bottom Right"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:715
-#: inc/customizer/configs/page-header.php:521
+#: inc/customizer/class-customizer.php:711
+#: inc/customizer/configs/page-header.php:538
 msgid "Repeat"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:722
-#: inc/customizer/configs/page-header.php:528
+#: inc/customizer/class-customizer.php:718
+#: inc/customizer/configs/page-header.php:545
 msgid "No repeat"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:723
-#: inc/customizer/configs/page-header.php:529
+#: inc/customizer/class-customizer.php:719
+#: inc/customizer/configs/page-header.php:546
 msgid "Repeat horizontal"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:724
-#: inc/customizer/configs/page-header.php:530
+#: inc/customizer/class-customizer.php:720
+#: inc/customizer/configs/page-header.php:547
 msgid "Repeat vertical"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:732
-#: inc/customizer/configs/page-header.php:539
+#: inc/customizer/class-customizer.php:728
+#: inc/customizer/configs/page-header.php:556
 msgid "Attachment"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:739
-#: inc/customizer/configs/page-header.php:546
+#: inc/customizer/class-customizer.php:735
+#: inc/customizer/configs/page-header.php:563
 msgid "Scroll"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:740
-#: inc/customizer/configs/page-header.php:547
+#: inc/customizer/class-customizer.php:736
+#: inc/customizer/configs/page-header.php:564
 msgid "Fixed"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:748
-#: inc/customizer/class-customizer.php:845
+#: inc/customizer/class-customizer.php:744
+#: inc/customizer/class-customizer.php:841
 #: inc/customizer/configs/header/social-icons.php:257
 msgid "Border"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:755
-#: inc/customizer/class-customizer.php:850
+#: inc/customizer/class-customizer.php:751
+#: inc/customizer/class-customizer.php:846
 #: inc/customizer/configs/header/social-icons.php:268
 msgid "Border Style"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:760
-#: inc/customizer/class-customizer.php:855
+#: inc/customizer/class-customizer.php:756
+#: inc/customizer/class-customizer.php:851
 #: inc/customizer/configs/header/social-icons.php:273
 msgid "Solid"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:761
-#: inc/customizer/class-customizer.php:856
+#: inc/customizer/class-customizer.php:757
+#: inc/customizer/class-customizer.php:852
 #: inc/customizer/configs/header/social-icons.php:274
 msgid "Dotted"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:762
-#: inc/customizer/class-customizer.php:857
+#: inc/customizer/class-customizer.php:758
+#: inc/customizer/class-customizer.php:853
 #: inc/customizer/configs/header/social-icons.php:275
 msgid "Dashed"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:763
-#: inc/customizer/class-customizer.php:858
+#: inc/customizer/class-customizer.php:759
+#: inc/customizer/class-customizer.php:854
 #: inc/customizer/configs/header/social-icons.php:276
 msgid "Double"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:764
-#: inc/customizer/class-customizer.php:859
+#: inc/customizer/class-customizer.php:760
+#: inc/customizer/class-customizer.php:855
 #: inc/customizer/configs/header/social-icons.php:277
 msgid "Ridge"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:765
-#: inc/customizer/class-customizer.php:860
+#: inc/customizer/class-customizer.php:761
+#: inc/customizer/class-customizer.php:856
 #: inc/customizer/configs/header/social-icons.php:278
 msgid "Inset"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:766
-#: inc/customizer/class-customizer.php:861
+#: inc/customizer/class-customizer.php:762
+#: inc/customizer/class-customizer.php:857
 #: inc/customizer/configs/header/social-icons.php:279
 msgid "Outset"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:774
-#: inc/customizer/class-customizer.php:868
+#: inc/customizer/class-customizer.php:770
+#: inc/customizer/class-customizer.php:864
 #: inc/customizer/configs/header/social-icons.php:288
 msgid "Border Width"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:789
-#: inc/customizer/class-customizer.php:880
+#: inc/customizer/class-customizer.php:785
+#: inc/customizer/class-customizer.php:876
 #: inc/customizer/configs/header/menus.php:108
 #: inc/customizer/configs/header/social-icons.php:301
 msgid "Border Color"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:800
-#: inc/customizer/class-customizer.php:887
+#: inc/customizer/class-customizer.php:796
+#: inc/customizer/class-customizer.php:883
 #: inc/customizer/configs/header/social-icons.php:310
 msgid "Border Radius"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:812
-#: inc/customizer/class-customizer.php:898
+#: inc/customizer/class-customizer.php:808
+#: inc/customizer/class-customizer.php:894
 msgid "Box Shadow"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:1334
+#: inc/customizer/class-customizer.php:1330
 msgid "General Options"
 msgstr ""
 
@@ -1886,12 +1886,18 @@ msgstr ""
 msgid "Layouts"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:1351
-msgid "Post Types"
+#: inc/customizer/class-customizer.php:1354
+#: inc/customizer/configs/single-blog-post.php:71
+#: inc/customizer/configs/typography.php:114
+msgid "Content"
 msgstr ""
 
-#: inc/customizer/class-customizer.php:1361
-msgid "Core & Plugins"
+#: inc/customizer/class-customizer.php:1365
+msgid "Plugins"
+msgstr ""
+
+#: inc/customizer/class-customizer.php:1383
+msgid "Core"
 msgstr ""
 
 #: inc/customizer/configs/blogs.php:41
@@ -2054,105 +2060,105 @@ msgstr ""
 msgid "Blog"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:88 inc/customizer/configs/colors.php:204
+#: inc/customizer/configs/colors.php:91 inc/customizer/configs/colors.php:207
 msgid "Colors"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:89
+#: inc/customizer/configs/colors.php:92
 msgid "Pick 6 brand colors. The theme derives everything else."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:97
+#: inc/customizer/configs/colors.php:100
 msgid "Palette"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:113
+#: inc/customizer/configs/colors.php:116
 msgid "Brand color, CTAs."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:127
+#: inc/customizer/configs/colors.php:130
 msgid "Secondary brand color."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:141
+#: inc/customizer/configs/colors.php:144
 msgid "Highlight / decorative pop."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:155
+#: inc/customizer/configs/colors.php:158
 msgid "Ink baseline. Headings inherit from this slot by default."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:173
+#: inc/customizer/configs/colors.php:176
 msgid "Card / elevated container background."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:187
+#: inc/customizer/configs/colors.php:190
 msgid "Page background."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:217
+#: inc/customizer/configs/colors.php:220
 msgid "Link color"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:218
+#: inc/customizer/configs/colors.php:221
 msgid "Default: derived from Primary slot."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:235
+#: inc/customizer/configs/colors.php:238
 msgid "Link hover color"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:236
+#: inc/customizer/configs/colors.php:239
 msgid "Default: same as Link color."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:253
+#: inc/customizer/configs/colors.php:256
 msgid "Heading color"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:254
+#: inc/customizer/configs/colors.php:257
 msgid "Default: derived from Text slot."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:266
+#: inc/customizer/configs/colors.php:269
 msgid "Backgrounds"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:282
+#: inc/customizer/configs/colors.php:285
 msgid "Page Background"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:302
+#: inc/customizer/configs/colors.php:305
 msgid "Content Area Background"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:321
+#: inc/customizer/configs/colors.php:324
 msgid "Site Content Background"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:341
+#: inc/customizer/configs/colors.php:344
 msgid "Legacy fine-tuning"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:342
+#: inc/customizer/configs/colors.php:345
 msgid ""
 "Per-element color overrides. Beats the Palette cascade when saved. Click to "
 "expand."
 msgstr ""
 
-#: inc/customizer/configs/colors.php:356
+#: inc/customizer/configs/colors.php:359
 msgid "Body text override"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:369
+#: inc/customizer/configs/colors.php:372
 msgid "Border override"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:389
+#: inc/customizer/configs/colors.php:392
 msgid "Meta text override"
 msgstr ""
 
-#: inc/customizer/configs/colors.php:406
+#: inc/customizer/configs/colors.php:409
 msgid "Widget title override"
 msgstr ""
 
@@ -2206,13 +2212,13 @@ msgstr ""
 
 #: inc/customizer/configs/footer/panel.php:157
 #: inc/customizer/configs/header/panel.php:128
-#: inc/customizer/configs/page-header.php:220
+#: inc/customizer/configs/page-header.php:237
 msgid "Full width - Contained"
 msgstr ""
 
 #: inc/customizer/configs/footer/panel.php:159
 #: inc/customizer/configs/header/panel.php:130
-#: inc/customizer/configs/page-header.php:222
+#: inc/customizer/configs/page-header.php:239
 msgid "Contained"
 msgstr ""
 
@@ -2343,14 +2349,14 @@ msgstr ""
 
 #: inc/customizer/configs/header/logo.php:55
 #: inc/customizer/configs/header/logo.php:69
-#: inc/customizer/configs/layouts.php:54 inc/customizer/configs/layouts.php:198
+#: inc/customizer/configs/layouts.php:54 inc/customizer/configs/layouts.php:227
 msgid "Yes"
 msgstr ""
 
 #: inc/customizer/configs/header/logo.php:56
 #: inc/customizer/configs/header/logo.php:70
 #: inc/customizer/configs/header/panel.php:469
-#: inc/customizer/configs/layouts.php:55 inc/customizer/configs/layouts.php:199
+#: inc/customizer/configs/layouts.php:55 inc/customizer/configs/layouts.php:228
 msgid "No"
 msgstr ""
 
@@ -2806,7 +2812,7 @@ msgstr ""
 msgid "Select global site layout."
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:43 inc/customizer/configs/layouts.php:145
+#: inc/customizer/configs/layouts.php:43 inc/customizer/configs/layouts.php:166
 msgid "Boxed"
 msgstr ""
 
@@ -2822,74 +2828,94 @@ msgstr ""
 msgid "Site framed margin"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:104
+#: inc/customizer/configs/layouts.php:88
+msgid "Width"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:111
 msgid "Container Width"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:105
+#: inc/customizer/configs/layouts.php:112
 msgid "Max width of the site container."
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:131
+#: inc/customizer/configs/layouts.php:145
 msgid "Narrow Content Width"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:132
+#: inc/customizer/configs/layouts.php:146
 msgid ""
 "Max width when a post uses the \"Narrow\" Content Layout option in the Page "
 "Settings panel."
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:142
+#: inc/customizer/configs/layouts.php:155
+msgid "Content Area"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:163
 msgid "Site content layout"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:144
+#: inc/customizer/configs/layouts.php:165
 msgid "Full width"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:156
+#: inc/customizer/configs/layouts.php:177
 msgid "Site content padding"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:175
+#: inc/customizer/configs/layouts.php:196
 msgid "Sidebars"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:188
+#: inc/customizer/configs/layouts.php:203
+msgid "General"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:217
 msgid "Default Sidebar Layout"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:196
+#: inc/customizer/configs/layouts.php:225
 msgid "Sidebar with vertical border"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:214
-msgid "Pages"
-msgstr ""
-
-#: inc/customizer/configs/layouts.php:223
-msgid "Blog posts"
-msgstr ""
-
-#: inc/customizer/configs/layouts.php:232
-msgid "Blog Archive Page"
-msgstr ""
-
-#: inc/customizer/configs/layouts.php:241
-msgid "Search Page"
+#: inc/customizer/configs/layouts.php:239
+msgid "Page Types"
 msgstr ""
 
 #: inc/customizer/configs/layouts.php:250
+msgid "Pages"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:259
+msgid "Blog posts"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:268
+msgid "Blog Archive Page"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:277
+msgid "Search Page"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:286
 msgid "404 Page"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:262
+#: inc/customizer/configs/layouts.php:298
 msgid "Post Type Settings"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:271
+#: inc/customizer/configs/layouts.php:307
 msgid "Single %s"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:330
+msgid "%s Archive"
 msgstr ""
 
 #: inc/customizer/configs/page-header.php:47
@@ -2985,158 +3011,166 @@ msgid "Display on %s page"
 msgstr ""
 
 #: inc/customizer/configs/page-header.php:159
-#: inc/customizer/configs/page-header.php:188
-#: inc/customizer/configs/page-header.php:196
+#: inc/customizer/configs/page-header.php:205
+#: inc/customizer/configs/page-header.php:213
 msgid "Apply when viewing single %s"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:177
+#: inc/customizer/configs/page-header.php:174
+msgid "Display on %s archive"
+msgstr ""
+
+#: inc/customizer/configs/page-header.php:175
+msgid "Apply when viewing the %s archive"
+msgstr ""
+
+#: inc/customizer/configs/page-header.php:194
 msgid "Display on %1$s %2$s"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:178
+#: inc/customizer/configs/page-header.php:195
 msgid "Apply when viewing %1$s %2$s"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:187
+#: inc/customizer/configs/page-header.php:204
 msgid "Title for %s"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:195
+#: inc/customizer/configs/page-header.php:212
 msgid "Tagline for %s"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:230
+#: inc/customizer/configs/page-header.php:247
 msgid "Display Settings"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:249
+#: inc/customizer/configs/page-header.php:266
 msgid "Advanced"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:256
+#: inc/customizer/configs/page-header.php:273
 msgid "Post Header Background Cover"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:257
+#: inc/customizer/configs/page-header.php:274
 msgid "Apply when viewing single post and page header setting displays as cover."
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:261
+#: inc/customizer/configs/page-header.php:278
 msgid "Use featured image from blog page"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:262
+#: inc/customizer/configs/page-header.php:279
 msgid "Use featured image of current post"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:268
+#: inc/customizer/configs/page-header.php:285
 msgid "Single Post Title & Tagline"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:272
+#: inc/customizer/configs/page-header.php:289
 msgid "Use title & tagline from blog page"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:273
+#: inc/customizer/configs/page-header.php:290
 msgid "Use title & tagline of current post"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:284
+#: inc/customizer/configs/page-header.php:301
 msgid "Title & Tagline"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:285
+#: inc/customizer/configs/page-header.php:302
 msgid "Title & tagline for special pages."
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:290
-#: inc/customizer/configs/typography.php:87
+#: inc/customizer/configs/page-header.php:307
+#: inc/customizer/configs/typography.php:104
 msgid "Tagline"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:303
+#: inc/customizer/configs/page-header.php:320
 msgid "Archive Prefix"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:304
+#: inc/customizer/configs/page-header.php:321
 msgid "Enable or disable archive prefix on category, date, tag page."
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:305
-#: inc/customizer/configs/page-header.php:341
-#: inc/customizer/configs/page-header.php:351
-#: inc/customizer/configs/page-header.php:427
-#: inc/customizer/configs/page-header.php:437
+#: inc/customizer/configs/page-header.php:322
+#: inc/customizer/configs/page-header.php:358
+#: inc/customizer/configs/page-header.php:368
+#: inc/customizer/configs/page-header.php:444
+#: inc/customizer/configs/page-header.php:454
 msgid "Enable"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:339
-#: inc/customizer/configs/page-header.php:425
+#: inc/customizer/configs/page-header.php:356
+#: inc/customizer/configs/page-header.php:442
 msgid "Show Title"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:340
-#: inc/customizer/configs/page-header.php:426
+#: inc/customizer/configs/page-header.php:357
+#: inc/customizer/configs/page-header.php:443
 msgid "Title is pull from post title, archive title."
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:349
-#: inc/customizer/configs/page-header.php:435
+#: inc/customizer/configs/page-header.php:366
+#: inc/customizer/configs/page-header.php:452
 msgid "Show Tagline"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:350
-#: inc/customizer/configs/page-header.php:436
+#: inc/customizer/configs/page-header.php:367
+#: inc/customizer/configs/page-header.php:453
 msgid "Tagline is pull from post excerpt, archive description."
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:358
-#: inc/customizer/configs/page-header.php:464
+#: inc/customizer/configs/page-header.php:375
+#: inc/customizer/configs/page-header.php:481
 msgid "Title Color"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:367
-#: inc/customizer/configs/page-header.php:472
+#: inc/customizer/configs/page-header.php:384
+#: inc/customizer/configs/page-header.php:489
 msgid "Tagline Color"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:383
+#: inc/customizer/configs/page-header.php:400
 msgid "Titlebar Background"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:384
+#: inc/customizer/configs/page-header.php:401
 msgid ""
 "Override the titlebar background. Leave empty to follow the Palette Surface "
 "color (or the legacy #f9f9f9 fallback when Palette is not used)."
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:396
+#: inc/customizer/configs/page-header.php:413
 msgid "Text Align"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:418
+#: inc/customizer/configs/page-header.php:435
 msgid "Cover Settings"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:445
+#: inc/customizer/configs/page-header.php:462
 msgid "Color & Background"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:560
+#: inc/customizer/configs/page-header.php:577
 msgid "Cover Overlay"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:576
-#: inc/customizer/configs/page-header.php:608
+#: inc/customizer/configs/page-header.php:593
+#: inc/customizer/configs/page-header.php:625
 msgid "Cover Text Align"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:585
+#: inc/customizer/configs/page-header.php:602
 msgid "Cover Height"
 msgstr ""
 
-#: inc/customizer/configs/page-header.php:786
+#: inc/customizer/configs/page-header.php:803
 msgid "Oops! That page can't be found."
 msgstr ""
 
@@ -3254,11 +3288,6 @@ msgstr ""
 msgid "Thumbnail"
 msgstr ""
 
-#: inc/customizer/configs/single-blog-post.php:71
-#: inc/customizer/configs/typography.php:97
-msgid "Content"
-msgstr ""
-
 #: inc/customizer/configs/single-blog-post.php:81
 msgid "Tags"
 msgstr ""
@@ -3279,60 +3308,41 @@ msgstr ""
 msgid "Meta Settings"
 msgstr ""
 
-#: inc/customizer/configs/typography.php:36
+#: inc/customizer/configs/typography.php:46
 msgid "Body & Paragraph"
 msgstr ""
 
-#: inc/customizer/configs/typography.php:37
+#: inc/customizer/configs/typography.php:47
 msgid "Apply to body and paragraph text."
 msgstr ""
 
-#: inc/customizer/configs/typography.php:46
+#: inc/customizer/configs/typography.php:56
 msgid "Heading"
 msgstr ""
 
-#: inc/customizer/configs/typography.php:47
+#: inc/customizer/configs/typography.php:57
 msgid "Apply to all heading elements."
 msgstr ""
 
-#: inc/customizer/configs/typography.php:60
+#: inc/customizer/configs/typography.php:77
 msgid "Widget Title"
 msgstr ""
 
-#: inc/customizer/configs/typography.php:61
+#: inc/customizer/configs/typography.php:78
 msgid "Apply to all widget title in site content."
 msgstr ""
 
-#: inc/customizer/configs/typography.php:71
+#: inc/customizer/configs/typography.php:88
 msgid "Site Title & Tagline"
 msgstr ""
 
-#: inc/customizer/configs/typography.php:78
+#: inc/customizer/configs/typography.php:95
 msgid "Site Title"
 msgstr ""
 
-#: inc/customizer/configs/typography.php:104
-msgid "Heading H1"
-msgstr ""
-
-#: inc/customizer/configs/typography.php:113
-msgid "Heading H2"
-msgstr ""
-
-#: inc/customizer/configs/typography.php:122
-msgid "Heading H3"
-msgstr ""
-
-#: inc/customizer/configs/typography.php:131
-msgid "Heading H4"
-msgstr ""
-
-#: inc/customizer/configs/typography.php:140
-msgid "Heading H5"
-msgstr ""
-
-#: inc/customizer/configs/typography.php:149
-msgid "Heading H6"
+#: inc/customizer/configs/typography.php:139
+#. translators: %s: heading tag name (H1, H2, etc.).
+msgid "Heading %s"
 msgstr ""
 
 #: inc/customizer/configs/upsell.php:17
@@ -3620,7 +3630,7 @@ msgstr ""
 msgid "Content / Sidebar / Sidebar"
 msgstr ""
 
-#: inc/template-functions.php:636
+#: inc/template-functions.php:761
 msgid "Search &hellip;"
 msgstr ""
 
@@ -3840,7 +3850,7 @@ msgstr ""
 #: inc/customizer/configs/header/search-box.php:287
 #: inc/customizer/configs/header/search-icon.php:347
 #: inc/customizer/configs/header/search-icon.php:348
-#: inc/template-functions.php:635 inc/template-functions.php:636
+#: inc/template-functions.php:760 inc/template-functions.php:761
 msgctxt "label"
 msgid "Search for:"
 msgstr ""
@@ -3855,17 +3865,17 @@ msgctxt "customify-font-weight"
 msgid "Bold"
 msgstr ""
 
-#: inc/template-functions.php:614
+#: inc/template-functions.php:739
 msgctxt "yearly archives date format"
 msgid "Y"
 msgstr ""
 
-#: inc/template-functions.php:616
+#: inc/template-functions.php:741
 msgctxt "monthly archives date format"
 msgid "F Y"
 msgstr ""
 
-#: inc/template-functions.php:618
+#: inc/template-functions.php:743
 msgctxt "daily archives date format"
 msgid "F j, Y"
 msgstr ""

--- a/src/backend/customizer/js/auto-css.js
+++ b/src/backend/customizer/js/auto-css.js
@@ -71,16 +71,31 @@ var CustomifyAutoCSS = window.CustomifyAutoCSS || null;
         };
     };
 
+    // Foundational typography settings that emit :root tokens — single
+    // source of truth for typography_field_uses_vars() (route gate) and
+    // typography_var_name() (token name). Keep in lockstep with PHP
+    // Customify_Customizer_Auto_CSS::TYPO_VAR_MAP.
+    var TYPO_VAR_MAP = {
+        'global_typography_base_p':       'body',
+        'global_typography_base_heading': 'heading',
+        'global_typography_heading_h1':   'h1',
+        'global_typography_heading_h2':   'h2',
+        'global_typography_heading_h3':   'h3',
+        'global_typography_heading_h4':   'h4',
+        'global_typography_heading_h5':   'h5',
+        'global_typography_heading_h6':   'h6'
+    };
+
     /**
-     * Mirror of PHP typography_field_uses_vars(). Vars are restricted
-     * to fields whose setting `name` starts with `global_typography_`
-     * (base / site_tt / heading family). Per-component typography
-     * (header builder items, footer copyright, blog read-more,
-     * breadcrumb, WC cart) stays in legacy mode.
+     * Mirror of PHP typography_field_uses_vars(). Tokens are restricted
+     * to the foundational typography (TYPO_VAR_MAP) — Base body, shared
+     * Heading family/weight, h1–h6 type scale. Component-leaf roles
+     * (site title, tagline, widget title) and per-component typography
+     * stay in legacy selector-scoped (literal) mode.
      */
     CustomifyAutoCSS.prototype.typography_field_uses_vars = function( field ){
         var name = ( field && field.name ) ? String( field.name ) : '';
-        return name.indexOf( 'global_typography_' ) === 0;
+        return !! TYPO_VAR_MAP[ name ];
     };
 
     /**
@@ -89,14 +104,15 @@ var CustomifyAutoCSS = window.CustomifyAutoCSS || null;
      */
     CustomifyAutoCSS.prototype.typography_var_name = function( setting_name, property ){
         var name = String( setting_name || '' );
-        // Prefix strips, in order — `heading_` collapses
-        // `global_typography_heading_h1` → `h1`.
-        var prefixes = [ 'global_typography_', 'heading_' ];
-        for ( var p = 0; p < prefixes.length; p++ ) {
-            var pr = prefixes[ p ];
-            if ( name.length > pr.length && name.indexOf( pr ) === 0 ) {
-                name = name.substr( pr.length );
-            }
+        // Foundational settings map to explicit semantic names via the
+        // shared TYPO_VAR_MAP (lockstep with PHP).
+        if ( TYPO_VAR_MAP[ name ] ) {
+            return '--customify-typo-' + TYPO_VAR_MAP[ name ] + '-' + property;
+        }
+        // Fallback for opted-in non-foundational fields.
+        var gp = 'global_typography_';
+        if ( name.length > gp.length && name.indexOf( gp ) === 0 ) {
+            name = name.substr( gp.length );
         }
         var suffixes = [ '_modal_font_size', '_typography', '_font_size', '_typo' ];
         for ( var i = 0; i < suffixes.length; i++ ) {
@@ -1498,10 +1514,11 @@ var CustomifyAutoCSS = window.CustomifyAutoCSS || null;
             }
         }
 
-        // Vars mode is opt-in per field — only fields whose setting
-        // `name` starts with `global_typography_` emit :root vars.
-        // Per-component typography falls through to selector-scoped
-        // output.
+        // Only foundational typography (Base body, shared Heading,
+        // h1–h6 scale) emits :root tokens. Component-leaf global
+        // typography (site title, tagline, widget title) and
+        // per-component typography fall through to selector-scoped
+        // literal output here.
         if ( ! that.typography_field_uses_vars( field ) ) {
             _.each( devices_css, function( els, device ){
                 that.css[device] += " "+field['selector']+" {\r\n\t"+that.join( els, "\r\n\t" )+"\r\n}";
@@ -1510,10 +1527,12 @@ var CustomifyAutoCSS = window.CustomifyAutoCSS || null;
             return;
         }
 
-        // Vars mode: accumulate raw `--var: value;` lines into the
-        // per-device bucket. The flush step in run() wraps each
-        // non-empty bucket in a single :root { ... } block so multiple
-        // typography fields collapse into one rule per device.
+        // Vars mode: split per-property. Core props (family/weight/
+        // size/line-height) → :root vars. Cosmetic props (letter-spacing,
+        // text-decoration, text-transform, font-style) → selector-scoped
+        // literal CSS (no token). Keep in lockstep with PHP typography().
+        // Only font_size / line_height are device-scoped (both core), so
+        // every devices_css entry goes straight to :root vars.
         _.each( devices_css, function( els, device ){
             var vars = that.code_to_root_vars( field.name, els );
             if ( vars.length ) {
@@ -1524,7 +1543,23 @@ var CustomifyAutoCSS = window.CustomifyAutoCSS || null;
             }
         } );
 
-        var allVars = that.code_to_root_vars( field.name, code );
+        var cosmeticKeys = [ 'style', 'text_decoration', 'text_transform', 'letter_spacing' ];
+        var cosmetic = {};
+        var core = {};
+        _.each( code, function( line, key ){
+            if ( ! line ) { return; } // mirror PHP array_filter($code) — drop empty lines
+            if ( _.contains( cosmeticKeys, key ) ) {
+                cosmetic[ key ] = line;
+            } else {
+                core[ key ] = line;
+            }
+        } );
+
+        if ( ! _.isEmpty( cosmetic ) ) {
+            that.css[ 'all' ] += " " + field['selector'] + " {\r\n\t" + that.join( cosmetic, "\r\n\t" ) + "\r\n}";
+        }
+
+        var allVars = that.code_to_root_vars( field.name, core );
         if ( allVars.length ) {
             if ( that.css_root[ 'all' ] !== '' ) {
                 that.css_root[ 'all' ] += "\r\n\t";

--- a/src/frontend/scss/base/_base.scss
+++ b/src/frontend/scss/base/_base.scss
@@ -20,14 +20,13 @@
 
 body {
     color: $color_text;
-    font-family: var(--customify-typo-base-p-font-family, #{$font_main});
-    font-weight: var(--customify-typo-base-p-font-weight, 400);
-    font-size: var(--customify-typo-base-p-font-size, inherit);
-    line-height: var(--customify-typo-base-p-line-height, 1.618);
-    letter-spacing: var(--customify-typo-base-p-letter-spacing, normal);
-    font-style: var(--customify-typo-base-p-font-style, normal);
-    text-decoration: var(--customify-typo-base-p-text-decoration, none);
-    text-transform: var(--customify-typo-base-p-text-transform, none);
+    // Core typography tokens only. Cosmetic props (letter-spacing,
+    // font-style, text-decoration, text-transform) are emitted as
+    // selector-scoped literal CSS by the generator, only when set.
+    font-family: var(--customify-typo-body-font-family, #{$font_main});
+    font-weight: var(--customify-typo-body-font-weight, 400);
+    font-size: var(--customify-typo-body-font-size, inherit);
+    line-height: var(--customify-typo-body-line-height, 1.618);
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
@@ -48,8 +47,8 @@ h6,
 .h4,
 .h5,
 .h6 {
-    font-weight: var(--customify-typo-base-heading-font-weight, 400);
-    font-family: var(--customify-typo-base-heading-font-family, #{$font_main});
+    font-weight: var(--customify-typo-heading-font-weight, 400);
+    font-family: var(--customify-typo-heading-font-family, #{$font_main});
     margin: 0 0 ms(-3);
     color: $color_heading;
     clear: both;

--- a/src/frontend/scss/header/builder_items/_logo_site_identity.scss
+++ b/src/frontend/scss/header/builder_items/_logo_site_identity.scss
@@ -16,19 +16,21 @@
         line-height: 1;
     }
     .site-title {
-        font-size: var(--customify-typo-site-tt-title-font-size, 1.5em);
+        // Leaf component — not tokenized. font-family reuses the shared
+        // heading token; size/weight/line-height are literal defaults the
+        // generator overrides with selector-scoped CSS when the user sets
+        // Site Title typography.
+        font-family: var(--customify-typo-heading-font-family, inherit);
+        font-size: 1.5em;
+        font-weight: 600;
+        line-height: 1.216;
         margin: 0;
-        font-weight: var(--customify-typo-site-tt-title-font-weight, 600);
-        line-height: var(--customify-typo-site-tt-title-line-height, 1.216);
-        font-family: var(--customify-typo-site-tt-title-font-family, inherit);
-        letter-spacing: var(--customify-typo-site-tt-title-letter-spacing, normal);
-        text-decoration: var(--customify-typo-site-tt-title-text-decoration, none);
-        text-transform: var(--customify-typo-site-tt-title-text-transform, none);
-        font-style: var(--customify-typo-site-tt-title-font-style, normal);
     }
     .site-description {
+        // Leaf component — not tokenized. Inherits the body font; the
+        // generator emits selector-scoped CSS when the user sets Tagline
+        // typography.
         margin: 5px 0px 7px 0px;
-        @include customify-typography('site-tt-desc');
     }
     &.logo-left {
         .logo-link {

--- a/src/frontend/scss/utils/_mixins.scss
+++ b/src/frontend/scss/utils/_mixins.scss
@@ -81,35 +81,3 @@
     }
 }
 
-/************************
-   Customify Typography
-*************************/
-
-// Emit Customizer typography consumer rules for a typography setting
-// whose semantic name is $name (kebab — e.g. "site-tt-desc",
-// "header-menus", "footer-copyright"). PHP generator publishes the
-// matching --customify-typo-{name}-{prop} variables at :root (and
-// inside per-device media queries for font-size / line-height).
-//
-// Pass $props to limit which properties get consumers — useful when
-// a selector only needs family/weight/size (e.g. tagline). Default
-// covers every property the typography field schema can produce.
-@mixin customify-typography(
-    $name,
-    $props: (font-family, font-weight, font-size, line-height, letter-spacing, text-decoration, text-transform, font-style)
-) {
-    $fallbacks: (
-        font-family: inherit,
-        font-weight: inherit,
-        font-size: inherit,
-        line-height: inherit,
-        letter-spacing: normal,
-        text-decoration: none,
-        text-transform: none,
-        font-style: normal,
-    );
-    @each $prop in $props {
-        #{$prop}: var(--customify-typo-#{$name}-#{$prop}, #{map.get($fallbacks, $prop)});
-    }
-}
-

--- a/src/frontend/scss/widgets/_widgets.scss
+++ b/src/frontend/scss/widgets/_widgets.scss
@@ -1,13 +1,14 @@
 /* Widget Common */
 .widget-title {
-	font-size: var(--customify-typo-base-widget-title-font-size, 16px);
-	text-transform: var(--customify-typo-base-widget-title-text-transform, uppercase);
-	font-weight: var(--customify-typo-base-widget-title-font-weight, 500);
-	font-family: var(--customify-typo-base-widget-title-font-family, inherit);
-	line-height: var(--customify-typo-base-widget-title-line-height, inherit);
-	letter-spacing: var(--customify-typo-base-widget-title-letter-spacing, normal);
-	text-decoration: var(--customify-typo-base-widget-title-text-decoration, none);
-	font-style: var(--customify-typo-base-widget-title-font-style, normal);
+	// Leaf component — not tokenized. font-family reuses the shared
+	// heading token; size/weight/line-height/uppercase are literal
+	// defaults the generator overrides with selector-scoped CSS when the
+	// user sets Widget Title typography.
+	font-family: var(--customify-typo-heading-font-family, inherit);
+	font-size: 16px;
+	font-weight: 500;
+	line-height: inherit;
+	text-transform: uppercase;
 	color: currentColor;
 	margin-bottom: 20px;
 }


### PR DESCRIPTION
## Summary

Tightens the typography CSS-variable surface (a noisy per-property fan-out across all Global Typography settings) down to a principled **2-tier token model**. Net: **46 → 18** `:root` tokens, all genuinely foundational; everything else renders as literal CSS without minting a token.

| Tier | Roles | Emit |
|---|---|---|
| **Foundation** (1-to-many — inherited/shared site-wide) | `body`, shared `heading` family/weight, `h1`–`h6` type scale | `:root { --customify-typo-* }` tokens (8 settings → 18 tokens) |
| **Leaf** (1-to-1) | site title, tagline, widget title + all per-component typography | selector-scoped **literal** CSS; site-title/widget-title **reuse** `--customify-typo-heading-font-family`, tagline inherits body |

## What changed
- **Per-property split** for tokenized fields: core props (family/weight/size/line-height) → `:root` tokens; cosmetic props (letter-spacing, text-decoration, text-transform, font-style) → selector-scoped literal, only when the user sets them. Settings stay fully functional without token noise.
- **Clean semantic names** (`body`/`heading`/`h1..h6`) via one shared map `Customify_Customizer_Auto_CSS::TYPO_VAR_MAP` — single source of truth for the route gate (`typography_field_uses_vars`) and var naming (`typography_var_name`). Drops the fragile prefix/suffix-strip heuristic (kept only as the documented opt-in fallback). **JS mirror** (`auto-css.js` `TYPO_VAR_MAP`) in lockstep.
- **Removed** the now-unused `customify-typography` SCSS mixin.
- **font-style** emit now gated on the per-role `fields` config (brings PHP into lockstep with JS).
- **Docs**: rewrote `SPEC-typography.md`; synced `SPEC-customizer.md` + `api-reference.md`.

## 30k-site safety
Typography vars are **unshipped** (post-#410 work, not live on the install base), so token names/shape change freely. Confirmed **output-identical vs shipped v0.4.18** behavior:
- Generated inline CSS + computed styles verified in-browser (e.g. heading font "Aboreto" flows into headings + site-title/widget-title; body letter-spacing renders as literal `body{letter-spacing}`).
- 18-token inventory verified in the built CSS; gate + var_name byte-identical for all 20 settings incl. the opt-in fallback (`header-button`, `search-icon`, …).
- The public `customify/customizer/auto_css` filter payload (array of `'prop: value;'` strings) is **untouched**.

## Adversarial review
Two multi-agent review passes were run:
1. **Reconsider** — 6 cleanup findings vetted for 30k-safety (one, the build-then-parse round-trip, was **deliberately left** because restructuring would change the public `auto_css` filter payload).
2. **Review** — 5-dimension adversarial pass over the full diff. The one HIGH "letter-spacing dead token" finding was empirically **disproven** (letter_spacing has no `device_settings` → routes to literal, renders fine). The "tagline/widget-title default change" findings were measured vs the *unshipped* #410 state; vs shipped **v0.4.18** these changes **restore** prior behavior. Doc-accuracy nits found by review were fixed.

## Notes for reviewers
- `build/` is gitignored — CI/release regenerates compiled assets from these sources.
- `inc/admin/editor.php`'s `.wp-block-post-title` selector-rewrite is now a dormant no-op for the foundation fields (post-title still tracks heading typography via the `<h1>` consumer) — documented; optional dead-code cleanup left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
