### PR TITLE
fix(customizer): move Buttons & Form Fields section below Typography

### DIFF
--- a/inc/customizer/class-customizer.php
+++ b/inc/customizer/class-customizer.php
@@ -1330,15 +1330,15 @@ class  Customify_Customizer {
 				'title'    => __( 'General Options', 'customify' ),
 				'priority' => 50,
 				'panels'   => array(
-					// Buttons & Form Fields and Colors are top-level SECTIONS
-					// (not panels) — the get_section() fallback in
-					// register_panel_groups() positions them deterministically by
-					// list order: 'customify_buttons_forms' first (priority 60),
-					// then 'customify_colors' (70). Replaces the now-removed empty
-					// `styling_panel`.
-					'customify_buttons_forms',
+					// Colors is a top-level SECTION (not a panel) — the
+					// get_section() fallback in register_panel_groups() positions
+					// it (and the Buttons & Form Fields section) by list order:
+					// 'customify_colors' (priority 60), 'typography_panel' (70),
+					// then 'customify_buttons_forms' (80, below Typography).
+					// Replaces the now-removed empty `styling_panel`.
 					'customify_colors',
 					'typography_panel',
+					'customify_buttons_forms',
 				),
 			),
 			'layouts'         => array(

--- a/inc/customizer/configs/buttons-forms.php
+++ b/inc/customizer/configs/buttons-forms.php
@@ -105,15 +105,16 @@ if ( ! function_exists( 'customify_customizer_buttons_forms_config' ) ) {
 
 			// ──────────────────────────────────────────────────────────
 			// Top-level Section "Buttons & Form Fields" (root, not in any
-			// panel). Positioned as the FIRST entry of the "General Options"
+			// panel). Positioned as the LAST entry of the "General Options"
 			// panel group by get_panel_groups(), which overrides this priority
-			// to 60 (above Colors at 70). The 58 here is only the pre-override
-			// value used before register_panel_groups() runs at 99999.
+			// to 80 (below Colors 60 and Typography 70). The 85 here is only the
+			// pre-override fallback used before register_panel_groups() runs at
+			// 99999 — kept above Colors/Typography so it still sorts last there.
 			// ──────────────────────────────────────────────────────────
 			array(
 				'name'     => $section,
 				'type'     => 'section',
-				'priority' => 58,
+				'priority' => 85,
 				'title'    => __( 'Buttons & Form Fields', 'customify' ),
 			),
 

--- a/inc/customizer/configs/colors.php
+++ b/inc/customizer/configs/colors.php
@@ -77,12 +77,11 @@ if ( ! function_exists( 'customify_customizer_colors_config' ) ) {
 			// ──────────────────────────────────────────────────────────
 			// Top-level Section "Colors" (root, not in any panel).
 			// ──────────────────────────────────────────────────────────
-			// Position: the SECOND entry of the "General Options" panel group
+			// Position: the FIRST entry of the "General Options" panel group
 			// (divider at 50) by get_panel_groups() in
-			// inc/customizer/class-customizer.php, which assigns it priority 70
-			// at customize_register:99999 (Buttons & Form Fields takes 60 ahead
-			// of it) — sidebar order reads
-			// General Options → Buttons & Form Fields → Colors → Typography → Layouts ….
+			// inc/customizer/class-customizer.php, which assigns it priority 60
+			// at customize_register:99999 — sidebar order reads
+			// General Options → Colors → Typography → Buttons & Form Fields → Layouts ….
 			// The 65 below is only a fallback for the unlikely case the group
 			// registration is filtered out; the group mechanism overrides it.
 			array(


### PR DESCRIPTION
Follow-up to #424. Reorders the **General Options** panel group so the new section sits **after** Colors and Typography:

`General Options → Colors (60) → Typography (70) → Buttons & Form Fields (80)`

Also bumps the section's own pre-override fallback priority (58 → 85) and updates the positioning comments. Verified live: customizer sidebar order correct (`wp.customize.section('customify_buttons_forms').priority() === 80`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)