### PR TITLE
style(forms): soften search outline + add field depth; fix WC block qty stepper

### DIFF
--- a/src/frontend/scss/base/_forms.scss
+++ b/src/frontend/scss/base/_forms.scss
@@ -36,7 +36,7 @@ textarea,
     color: $color_text;
     background-color: transparent;
     border: 1px solid $color_border_medium;
-    box-shadow: none;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06) inset;
     padding: 0 0.75em;
     height: 2.6em;
     width: 100%;
@@ -53,7 +53,7 @@ textarea,
 }
 
 select {
-    box-shadow: none;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06) inset;
     background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='16'%20height='16'%20viewBox='0%200%2016%2016'%3E%3Cpath%20d='M4%206l4%204%204-4'%20fill='none'%20stroke='%23666'%20stroke-width='1.6'%20stroke-linecap='round'%20stroke-linejoin='round'/%3E%3C/svg%3E");
     background-position: center right 8px;
     background-repeat: no-repeat;

--- a/src/frontend/scss/compatibility/wc/_woocommerce-main.scss
+++ b/src/frontend/scss/compatibility/wc/_woocommerce-main.scss
@@ -138,6 +138,37 @@ p.demo_store,
         }
     }
 
+    // Block cart/checkout quantity stepper (Cart/Checkout blocks). The +/- are
+    // bare <button>s carrying a `wc-block-…` class (NOT `wp-block-…`), so the
+    // global theme button rule's `:not([class*="wp-block-"])` carve-out does
+    // NOT exclude them — its hover state leaks in and sets
+    // `color: --customify-on-primary` (white) + a `currentColor`-based
+    // state-layer `background-image` gradient. That turns the ＋/－ glyph white
+    // (invisible) and paints a gray fill behind it. Neutralize like .input-pm-act
+    // so the glyph stays visible and the stepper stays flat (no hover fill),
+    // matching the single-product stepper.
+    //
+    // Specificity note: the theme's state-layer rule is
+    // `button:not(…):not(.menu-mobile-toggle, .search-submit):hover` = (0,3,1),
+    // so the extra `.wc-block-components-quantity-selector` ancestor below is
+    // REQUIRED to reach (0,4,0) and actually drop the gradient — a single-class
+    // override (0,3,0) loses to it and the gray fill survives.
+    .wc-block-components-quantity-selector .wc-block-components-quantity-selector__button {
+        &:hover,
+        &:focus,
+        &:active {
+            color: $color_text;
+            background: none;
+            background-image: none;
+            // Kill both focus indicators: the theme button `outline` AND the
+            // Cart-block's own `box-shadow: currentColor 0 0 1px 1px inset` ring
+            // (cart.css, (0,3,0)) — the (0,4,0) selector here outranks it — so
+            // the +/- stay borderless like the single-product stepper.
+            outline: none;
+            box-shadow: none;
+        }
+    }
+
     .blockUI.blockOverlay {
         position: relative;
         z-index: 35 !important;

--- a/src/frontend/scss/header/builder_items/_search.scss
+++ b/src/frontend/scss/header/builder_items/_search.scss
@@ -82,8 +82,15 @@
 	}
 
 	.search-form-fields {
-		border: 1px solid $color_border_medium;
-		box-shadow: none;
+		// Softened outline for the header chrome. The generic form fields keep
+		// the stronger $color_border_medium (~22%), but on the header/sidebar
+		// search that read too gray — so use the faint hairline $color_border
+		// (~9%) plus a LIGHT inset shadow (half the legacy 0.12 strength) to
+		// restore the subtle recessed depth of the pre-0.4 look without the
+		// heavy gray edge. 30k-safe: resting state lands close to the old box,
+		// just lighter.
+		border: 1px solid $color_border;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06) inset;
 		border-radius: 3px;
 		height: 100%;
 		transition: border-color 0.15s ease, box-shadow 0.15s ease;
@@ -96,13 +103,15 @@
 		width: 100%;
 		height: 2.4em;
 		// Modal/popover search has NO .search-form-fields wrapper, so the field
-		// itself carries the outlined border + focus ring. The inline-box variant
-		// (.header-search_box-item) overrides this to border:0 since its wrapper
-		// carries them.
-		border: 1px solid $color_border_medium;
+		// itself carries the outlined border + focus ring. Same softened look as
+		// the wrapper above (faint hairline + light inset shadow) — lighter than
+		// the generic ~22% field border so the header chrome doesn't read gray.
+		// The inline-box variant (.header-search_box-item) overrides this to
+		// border:0 since its wrapper carries them.
+		border: 1px solid $color_border;
 		border-radius: 3px;
 		background-color: transparent;
-		box-shadow: none;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06) inset;
 		transition: border-color 0.15s ease, box-shadow 0.15s ease;
 
 		&:focus {

--- a/src/frontend/scss/widgets/_widgets.scss
+++ b/src/frontend/scss/widgets/_widgets.scss
@@ -219,6 +219,22 @@
 			.search-field {
 				width: 100%;
 				display: block;
+				// Soften the sidebar search box to match the header search item:
+				// faint hairline ($color_border ~9%) + a light inset shadow
+				// instead of the generic field's stronger ~22% border, so the
+				// sidebar search reads lighter (not gray) while the other form
+				// fields keep their default border. Mirrors
+				// builder_items/_search.scss.
+				border: 1px solid $color_border;
+				border-radius: 3px;
+				background-color: transparent;
+				box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06) inset;
+				transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+				&:focus {
+					background-color: transparent;
+					border-color: color-mix(in srgb, currentcolor 50%, transparent);
+				}
 			}
 
 			.search-submit {


### PR DESCRIPTION
Frontend SCSS only — no Customizer config, markup, storage, or JS changes. Tightens the modernized form/search look so the resting-state shift is gentler on the 30k installed base, and fixes a leaked button hover on the WooCommerce **block** cart quantity stepper.

## Changes

**1. Form fields — `base/_forms.scss`**
Add a subtle `box-shadow: inset 0 1px 2px rgba(0,0,0,.06)` to inputs / `select` / `textarea` for a soft recessed depth. Border stays at `$color_border_medium` (~22%) — **unchanged**.

**2. Header + sidebar search — `header/builder_items/_search.scss`, `widgets/_widgets.scss`**
The header/sidebar search chrome read too gray. Swap the ~22% `$color_border_medium` edge for the faint `$color_border` (~9%) hairline + the same light inset shadow → lands close to the pre-0.4 box but lighter. The sidebar **widget** search (`.sidebar-search-form .search-field`) is a generic field the header rule never reached, so it's softened alongside to match.

**3. WC block cart quantity stepper — `compatibility/wc/_woocommerce-main.scss`**
The +/- are bare `<button>`s with a `wc-block-…` class, which the global theme button rule's `:not([class*="wp-block-"])` carve-out does **not** exclude. Its hover/focus leaked in and:
- set `color` → on-primary **white** → the ＋/－ glyph vanished,
- painted a `currentColor` state-layer **gradient** (gray fill) on hover,
- left the cart.css **inset focus ring** (the dark box after clicking).

Neutralized via a `(0,4,0)` selector (needed to out-rank the theme's `(0,3,1)` state-layer and cart.css's `(0,3,0)` ring) so the stepper stays flat with a visible glyph — matching the single-product `.input-pm-act` stepper.

## Verification
- Computed-style + zoom verified on `customify-free` (cart, kitchen-sink, single post): form/search borders & shadows resolve as intended; generic field border stays 22%; block-cart +/- hover & focus now flat with no fill, no ring, glyph visible.
- 30k-safety: resting state stays close to current (search slightly lighter, fields gain a faint depth); no token, config, or markup changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)