### PR TITLE
style: forms, typography & header-popover polish

### DIFF
--- a/src/frontend/scss/base/_forms.scss
+++ b/src/frontend/scss/base/_forms.scss
@@ -52,6 +52,24 @@ textarea,
     }
 }
 
+// Small / native-UI controls shouldn't be forced full-width — a date, number,
+// time or color picker stretched to 100% looks wrong and fights inline form
+// layouts. Match Astra, which only makes text-like fields, textarea & search
+// full-width: revert these to their natural control width. The text-like inputs
+// (text/email/url/password/search/tel), select & textarea keep `width: 100%`
+// from the group rule above, so comment/contact forms — what the 30k base
+// relies on — are unaffected.
+input[type="number"],
+input[type="date"],
+input[type="month"],
+input[type="week"],
+input[type="time"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="color"] {
+    width: auto;
+}
+
 select {
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06) inset;
     background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='16'%20height='16'%20viewBox='0%200%2016%2016'%3E%3Cpath%20d='M4%206l4%204%204-4'%20fill='none'%20stroke='%23666'%20stroke-width='1.6'%20stroke-linecap='round'%20stroke-linejoin='round'/%3E%3C/svg%3E");

--- a/src/frontend/scss/base/_forms.scss
+++ b/src/frontend/scss/base/_forms.scss
@@ -15,6 +15,28 @@ form {
     margin-bottom: 2em;
 }
 
+// Bundled normalize (v4–v7) forces `font-family: sans-serif` on form controls,
+// so inputs / selects / textareas / <button>s ignore the site typeface and fall
+// back to the generic sans stack. Restore inheritance — what normalize v8 and
+// Astra both do — so form controls render in the theme font like everything
+// else. (Verified: without this, an <input>/<select>/<button> computes
+// `font-family: sans-serif` while <body> uses the configured font.)
+input,
+select,
+textarea,
+button {
+    font-family: inherit;
+}
+
+// The broad button rule further down sets `display: inline-flex`; its
+// specificity (0,1,1) outranks the UA/normalize `[hidden] { display: none }`
+// (0,1,0), so a `<button hidden>` — or any element a theme display rule
+// targets — stays visible despite the valid HTML `hidden` attribute. Force
+// `[hidden]` to win so plugins/markup can rely on it.
+[hidden] {
+    display: none !important;
+}
+
 input[type="text"],
 input[type="email"],
 input[type="url"],


### PR DESCRIPTION
A single polish pass over default form controls, the heading scale, and the header popovers (mini-cart / search / nav submenu). **Frontend SCSS + one JS handler only** — no Customizer config*, markup, storage, or token renames. (*one config file: `typography.php` display-defaults kept in lockstep with the heading SCSS.)

Consolidates what were separate PRs #432 (heading) and #433 (popovers) into this one. Follows merged #430 (search-field softening + WC qty stepper).

## 1. Form controls — `base/_forms.scss`
- **Natural width for non-text controls**: `number / date / month / week / time / datetime(-local) / color` **and `select`** no longer forced to `width:100%` — they size to content (capped by `max-width:100%`). A forced-100% select was stretching and breaking sidebar/filter layouts. Text/email/url/password/search/tel + textarea keep full width (comment/contact forms unaffected). Matches Astra.
- **Theme font on form controls**: the bundled normalize (v4–v7) forced `font-family: sans-serif` on `button/input/select/textarea`; restore `font-family: inherit` (normalize v8 / Astra) so they use the site typeface.
- **Honor `[hidden]`**: the broad button rule's `display:inline-flex` (0,1,1) outranked `[hidden]{display:none}` (0,1,0), so `<button hidden>` stayed visible — forced `[hidden]{display:none!important}`.
- Subtle `inset 0 1px 2px rgba(0,0,0,.06)` depth on inputs/select/textarea (border unchanged at ~22%).

## 2. Heading scale — `base/_base.scss` + `typography.php` (display-defaults, lockstep)
Trimmed + evened the default scale (was on the large side ≈ GeneratePress, uneven steps): h1 2.42→**2.2**, h2 2.1→**1.8**, h3 1.62→**1.55**, h4 1.42→**1.35**, h5 1.1→**1.15**, h6 0.95→**1.0** (h1/h2 keep responsive variants). h3/h4 moved off `ms()` onto explicit ems for an even ~1.15–1.22× rhythm. Heading vars are unset on un-customized sites → these SCSS fallbacks render; saved per-level sizes still win.

## 3. Header popovers — `utils/_vars.scss`, `_search.scss`, `_wc-cart.scss`, `_navigation.scss`, `theme.js`
- **Radius** 0/0/2px → **6px** (shared `$popover_radius`).
- **Border** clean: transparent by default (`$popover_border`) — no gray hairline from the global divider Border slot. A user-set popover/item border still shows and the **caret matches it** (the item control emits border-color onto `.header-search-modal` + its `:before`).
- **Caret** kept but refined: smaller 12px diamond, rounded tip, bg-matched, transparent edges by default.
- **Shadow** unified + softened: `$boxshadow_dropdown` → `0 6px 20px -6px rgba(17,24,39,.12), 0 2px 6px -4px rgba(17,24,39,.07)` (two-layer, ~12%); nav submenu switched onto the shared token.
- **Search popover auto-focus**: clicking the search icon now focuses the input (handler had blur/focus inverted); focuses synchronously, not via rAF (rAF is suspended in background tabs).

## 30k-safety
Default restyle visible on un-customized sites; no settings/markup/tokens changed; saved overrides still win. Backgrounds left hard-coded opaque on purpose (header items expose their own background settings).

## Verification
All verified via computed-style + screenshots on `customify-free` (kitchen-sink, cart, search/mini-cart popovers, a faceted-filter select): widths, font inheritance, `[hidden]` hiding, heading px, popover radius/shadow/caret/clean-border, and search-field focus-on-open (incl. background-tab case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)