### PR TITLE
style(typography): trim + even out the default heading scale

### DIFF
--- a/inc/customizer/configs/typography.php
+++ b/inc/customizer/configs/typography.php
@@ -298,41 +298,42 @@ if ( ! function_exists( 'customify_customizer_typography_config' ) ) {
 			'text_transform'  => false,
 		);
 
-		// Display-only defaults per level — the compiled `_base.scss`
-		// fallbacks (h1/h2 carry per-device variants; h4 is the modular
-		// scale value 1.41575em, rounded for display). Keep in lockstep
-		// with the SCSS.
+		// Display-only defaults per level — must match the compiled `_base.scss`
+		// fallbacks (h1/h2 carry per-device variants). Keep in lockstep with the
+		// SCSS. The scale was trimmed/evened (h1 2.42→2.2, h2 2.1→1.8, h3/h4 off
+		// the modular scale onto explicit ems, h6 0.95→1.0) for a lighter,
+		// smoother heading rhythm — see _base.scss.
 		$h_display = array(
 			'h1' => array(
 				'font_size'   => array(
-					'desktop' => '2.42em',
-					'tablet'  => '2.1em',
-					'mobile'  => '1.8em',
+					'desktop' => '2.2em',
+					'tablet'  => '1.9em',
+					'mobile'  => '1.65em',
 				),
 				'line_height' => '1.216',
 			),
 			'h2' => array(
 				'font_size'   => array(
-					'desktop' => '2.1em',
-					'tablet'  => '1.9em',
-					'mobile'  => '1.7em',
+					'desktop' => '1.8em',
+					'tablet'  => '1.6em',
+					'mobile'  => '1.5em',
 				),
 				'line_height' => '1.216',
 			),
 			'h3' => array(
-				'font_size'   => '1.618em',
+				'font_size'   => '1.55em',
 				'line_height' => '1.3',
 			),
 			'h4' => array(
-				'font_size'   => '1.42em',
+				'font_size'   => '1.35em',
 				'line_height' => '1.3',
 			),
 			'h5' => array(
-				'font_size'   => '1.1em',
+				'font_size'   => '1.15em',
 				'line_height' => '1.3',
 			),
 			'h6' => array(
-				'font_size'   => '0.95em',
+				'font_size'   => '1.0em',
 				'line_height' => '1.3',
 			),
 		);

--- a/src/frontend/scss/base/_base.scss
+++ b/src/frontend/scss/base/_base.scss
@@ -56,19 +56,19 @@ h6,
 
 h1,
 .h1 {
-    font-size: var(--customify-typo-h1-font-size, 2.42em);
+    font-size: var(--customify-typo-h1-font-size, 2.2em);
     line-height: var(--customify-typo-h1-line-height, 1.216);
     @include for_device(tablet) {
-        font-size: var(--customify-typo-h1-font-size, 2.1em);
+        font-size: var(--customify-typo-h1-font-size, 1.9em);
     }
     @include for_device(mobile) {
-        font-size: var(--customify-typo-h1-font-size, 1.8em);
+        font-size: var(--customify-typo-h1-font-size, 1.65em);
     }
 }
 
 h2,
 .h2 {
-    font-size: var(--customify-typo-h2-font-size, 2.1em);
+    font-size: var(--customify-typo-h2-font-size, 1.8em);
     line-height: var(--customify-typo-h2-line-height, 1.216);
     &+h3 {
         border-top: 1px solid $color_border;
@@ -81,22 +81,22 @@ h2,
         border-top-color: $color_border;
     }
     @include for_device(tablet) {
-        font-size: var(--customify-typo-h2-font-size, 1.9em);
+        font-size: var(--customify-typo-h2-font-size, 1.6em);
     }
     @include for_device(mobile) {
-        font-size: var(--customify-typo-h2-font-size, 1.7em);
+        font-size: var(--customify-typo-h2-font-size, 1.5em);
     }
 }
 
 h3,
 .h3 {
-    font-size: var(--customify-typo-h3-font-size, ms(2));
+    font-size: var(--customify-typo-h3-font-size, 1.55em);
     line-height: var(--customify-typo-h3-line-height, 1.3);
 }
 
 h4,
 .h4 {
-    font-size: var(--customify-typo-h4-font-size, ms(1));
+    font-size: var(--customify-typo-h4-font-size, 1.35em);
     line-height: var(--customify-typo-h4-line-height, 1.3);
 }
 
@@ -107,13 +107,13 @@ h4,
 // size adopt these defaults; any saved value still wins via the CSS variable.
 h5,
 .h5 {
-    font-size: var(--customify-typo-h5-font-size, 1.1em);
+    font-size: var(--customify-typo-h5-font-size, 1.15em);
     line-height: var(--customify-typo-h5-line-height, 1.3);
 }
 
 h6,
 .h6 {
-    font-size: var(--customify-typo-h6-font-size, 0.95em);
+    font-size: var(--customify-typo-h6-font-size, 1.0em);
     line-height: var(--customify-typo-h6-line-height, 1.3);
 }
 


### PR DESCRIPTION
Default heading sizes ran on the large side and stepped unevenly. This trims the top end and smooths the rhythm. **Typography SCSS + config only** — no markup/JS/storage changes.

## Why
Compared default heading scales across themes (em-normalized):

| | **Customify (before)** | Astra | GeneratePress |
|---|---|---|---|
| h1 | 2.42 | 2.0 | 2.47 |
| h2 | 2.1 | 1.7 | 2.06 |
| h3 | 1.62 | 1.5 | 1.71 |
| h4 | 1.42 | 1.3 | 1.41 |
| h5 | 1.1 | 1.2 | 1.18 |
| h6 | 0.95 | 1.1 | 1.0 |

Customify sat in the "large" group (≈ GeneratePress, well above Astra) and the steps were uneven: h1→h2 only 1.15× then a 1.30× drop to h3, and h6 (0.95) fell *below* body size.

## Change (desktop em; h1/h2 keep responsive variants)

| | before → after | tablet | mobile |
|---|---|---|---|
| h1 | 2.42 → **2.2** | 2.1→1.9 | 1.8→1.65 |
| h2 | 2.1 → **1.8** | 1.9→1.6 | 1.7→1.5 |
| h3 | 1.62 → **1.55** | | |
| h4 | 1.42 → **1.35** | | |
| h5 | 1.1 → **1.15** | | |
| h6 | 0.95 → **1.0** | | |

Now a steady ~1.15–1.22× descent. h3/h4 move off the modular-scale function (`ms()`) onto explicit ems so the scale is literal and even. Line-heights unchanged.

## 30k-safety
Heading typography `:root` vars are **unset** on sites that never customized headings (verified), so the `_base.scss` fallbacks are what renders — this is an intentional default refresh, visible on default sites. Any **saved** per-level heading size still wins via its CSS variable, untouched. `typography.php` `$h_display` updated in lockstep so the Customizer shows the new defaults.

## Verification (computed px on `customify-free`, base 16px)
h1 38.7→**35.2**, h2 33.6→**28.8**, h3 25.9→**24.8**, h4 22.7→**21.6**, h5 17.6→**18.4**, h6 15.2→**16.0**. Screenshot reviewed on the kitchen-sink style guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)