### PR TITLE
fix(woo): theme compat for WooCommerce blocks in the Blocksify general builder

### DIFF
--- a/src/frontend/scss/base/_forms.scss
+++ b/src/frontend/scss/base/_forms.scss
@@ -135,31 +135,34 @@ select {
     }
 }
 
-// `[class*="wp-block-"]` in the :not() lists peels off ANY element whose
-// class contains a `wp-block-*` token — that's how WP default blocks
-// (Search submit, File download, Embed "Try again", Latest Posts CTA,
-// etc.) render their internal chrome buttons. Editor canvas + frontend
-// both stop applying the broad theme button styling to those, while the
-// intentionally-styled content buttons (`.wp-block-button__link`,
-// `.wp-element-button`, `.wc-block-cart__submit .wp-element-button`)
-// stay listed explicitly so they still pick up the theme look.
+// `[class*="wp-block-"]` (and `[class*="wc-block-"]`) in the :not() lists
+// peel off ANY element whose class contains a `wp-block-*` / `wc-block-*`
+// token — that's how WP default blocks (Search submit, File download,
+// Embed "Try again", Latest Posts CTA, etc.) AND WooCommerce blocks
+// (product-filters overlay open/close toggles, etc.) render their internal
+// chrome buttons. Editor canvas + frontend both stop applying the broad
+// theme button styling to those, while the intentionally-styled content
+// buttons (`.wp-block-button__link`, `.wp-element-button`,
+// `.wc-block-cart__submit .wp-element-button`) stay listed explicitly so
+// they still pick up the theme look.
 // The single-class exclusions kept below (`.components-button`,
 // `.customize-partial-edit-shortcut-button`, `.lightbox-trigger`,
-// `.ed_button`, `.menu-mobile-toggle`) are not `wp-block-` prefixed,
-// so they still need their own slot.
+// `.ed_button`, `.menu-mobile-toggle`) are not block-prefixed, so they
+// still need their own slot.
 .button:not(
     [class*="wp-block-"],
+    [class*="wc-block-"],
     .menu-mobile-toggle,
     .components-button,
     .customize-partial-edit-shortcut-button
 ),
-button:not(.components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"]),
-input[type="button"]:not(.ed_button, [class*="wp-block-"]),
-input[type="reset"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
+button:not(.components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"], [class*="wc-block-"]),
+input[type="button"]:not(.ed_button, [class*="wp-block-"], [class*="wc-block-"]),
+input[type="reset"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]),
 .wc-block-cart__submit .wp-element-button,
 .wp-block-button__link,
 .wp-element-button:not(.components-button),
-input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]) {
+input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]) {
     border: none;
     cursor: pointer;
     padding: 0px 1.3em;
@@ -224,17 +227,17 @@ input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-bu
     }
 }
 
-// Same `[class*="wp-block-"]` carve-out as above so WP default-block
-// chrome doesn't inherit the primary-color background fill.
-.button:not([class*="wp-block-"]),
-button:not(.menu-mobile-toggle, .components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"]),
-input[type="button"]:not(.ed_button, [class*="wp-block-"]),
-.button:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
-input[type="button"]:not(.ed_button, .components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
-input[type="reset"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
+// Same `[class*="wp-block-"]` / `[class*="wc-block-"]` carve-out as above
+// so WP / WooCommerce block chrome doesn't inherit the primary-color fill.
+.button:not([class*="wp-block-"], [class*="wc-block-"]),
+button:not(.menu-mobile-toggle, .components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"], [class*="wc-block-"]),
+input[type="button"]:not(.ed_button, [class*="wp-block-"], [class*="wc-block-"]),
+.button:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]),
+input[type="button"]:not(.ed_button, .components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]),
+input[type="reset"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]),
 .wp-block-button__link,
 .wp-element-button:not(.components-button),
-input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]) {
+input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]) {
     color: var(--customify-btn-on-primary, #ffffff);
     background: $color_primary;
     &:focus {
@@ -242,10 +245,10 @@ input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-bu
     }
 }
 
-.button[disabled]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
-button[disabled]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
-button.disabled:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]),
-.button.disabled:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"]) {
+.button[disabled]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]),
+button[disabled]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]),
+button.disabled:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]),
+.button.disabled:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]) {
     opacity: 0.5;
 }
 

--- a/src/frontend/scss/compatibility/wc/_woocommerce-layout.scss
+++ b/src/frontend/scss/compatibility/wc/_woocommerce-layout.scss
@@ -98,9 +98,6 @@
 .woocommerce-result-count {
     margin-left: auto;
     margin-right: 1em;
-    @include for_device(mobile) {
-        display: none;
-    }
 }
 
 .woocommerce, .woocommerce-page {
@@ -301,4 +298,29 @@
             }
         }
     }
+}
+
+// ── Blocksify general WC builder — placed-block tweaks ───────────────────────
+// "Sort by" label spacing on the catalog-sorting BLOCK. Margin on the LABEL so
+// hiding the label (block "useLabel" off) leaves the select untouched.
+.wc-block-catalog-sorting .woocommerce-ordering label {
+    margin-inline-end: 0.5em;
+}
+
+// Un-trap the WooCommerce product-filters overlay from a Blocksify Section's
+// stacking context (.bsy-section__inner has position:relative; z-index:2 for its
+// shape/bg layering, which traps the overlay's position:fixed below the header).
+// Drop the stacking context only WHILE the overlay is open — the full-screen
+// modal covers the section content anyway, and z-index:2 restores on close.
+// (Ideally lives in Blocksify for cross-theme coverage; kept in theme for now.)
+.bsy-section__inner:has(.wc-block-product-filters.is-overlay-opened) {
+    z-index: auto;
+}
+
+// Price-filter min/max inputs ($20 / $247): WC sets border-color:currentColor
+// (the dark text colour) → too heavy. Follow the theme's input border instead.
+// `body` prefix beats WC's inlined block rule (specificity 0,3,1); border-color
+// only, so the slider box sizing/radius stays WC's.
+body .wc-block-product-filter-price-slider .text input[type="text"] {
+    border-color: $color_border;
 }

--- a/woocommerce/loop/result-count.php
+++ b/woocommerce/loop/result-count.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
-<p class="woocommerce-result-count text-uppercase text-xsmall" role="status" aria-relevant="all" <?php echo ( empty( $orderedby ) || 1 === intval( $total ) ) ? '' : 'data-is-sorted-by="true"'; ?>>
+<p class="woocommerce-result-count" role="status" aria-relevant="all" <?php echo ( empty( $orderedby ) || 1 === intval( $total ) ) ? '' : 'data-is-sorted-by="true"'; ?>>
 	<?php
 	// phpcs:disable WordPress.Security
 	if ( 1 === intval( $total ) ) {


### PR DESCRIPTION
## Context
When WooCommerce blocks (`product-filters`, `catalog-sorting`, `product-results-count`, price filter) are placed inside a **Blocksify Dynamic Template** that replaces the shop/archive (the "general WC builder"), several Customify rules conflict with them. Each is fixed at the source.

## Changes
- **`_base.scss`** — add `[class*="wc-block-"]` to the generic `button:not(...)` carve-outs (mirrors the existing `wp-block-` carve-out). The theme was hijacking WC block chrome buttons with the primary-button fill and overriding WC's `display:none`, so the product-filters **overlay open/close toggle showed (blue) on desktop** when WC hides it. WC content buttons keep the theme look via `wp-element-button`.
- **`_woocommerce-layout.scss`**
  - Remove the `≤568px` `display:none` on `.woocommerce-result-count` → **Product Results Count visible on mobile**.
  - Catalog-sorting **"Sort by" label**: `margin-inline-end` on the *label* so the gap follows the label (hiding the label leaves the select clean).
  - **`:has()` un-trap**: while a product-filters overlay is open, drop the Blocksify Section inner's stacking context so the overlay's fixed modal escapes and covers the header instead of being trapped below it. Restores on close.
  - **Price-filter min/max inputs**: follow the theme's input `border-color` instead of WC's `currentColor` (the dark text colour, too heavy).
- **`woocommerce/loop/result-count.php`** — drop the hardcoded `text-uppercase text-xsmall` classes so the result-count doesn't inherit the uppercase/tiny styling (affects both the block and the classic loop — same template).

## Notes for review
- The `:has()` rule references a **Blocksify** class (`.bsy-section__inner`). It's builder-compat and could alternatively live in the Blocksify plugin (so it works on every theme). Kept here for now — flag if you'd rather it move.
- **Source-only PR** — `build/` is gitignored and regenerated by the build pipeline; do **not** rebuild locally on a checked-out artifact (it diverges all build output). Run `npm run build` only in a clean release flow.
- Verified live on a WC 10.8.1 Studio site with a Blocksify Dynamic Template replacing `/shop/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)