### PR TITLE
feat(woo): native off-canvas cart drawer for the header cart item

### DIFF
--- a/inc/compatibility/woocommerce/config/header/cart.php
+++ b/inc/compatibility/woocommerce/config/header/cart.php
@@ -33,6 +33,21 @@ class Customify_Builder_Item_WC_Cart {
 	 */
 	public function __construct() {
 		$this->label = __( 'Shopping Cart', 'customify' );
+
+		// Cart drawer: when the Cart Behavior is set to Drawer, suppress the
+		// inline hover dropdown (through the public render_dropdown seam) and
+		// print the off-canvas panel near </body>.
+		add_filter( 'customify/wc_cart/render_dropdown', array( $this, 'maybe_suppress_dropdown' ), 10, 2 );
+
+		// Don't ship the drawer's inline dynamic CSS to sites that aren't using
+		// the drawer: its style controls carry defaults that Customify's auto-CSS
+		// would otherwise print (inert) on every WooCommerce page. Kept in drawer
+		// mode and in the Customizer preview so switching behavior previews live.
+		add_filter( 'customify/customizer/auto_css', array( $this, 'gate_drawer_auto_css' ), 10, 2 );
+
+		if ( ! is_admin() ) {
+			add_action( 'wp_footer', array( $this, 'render_cart_drawer' ) );
+		}
 	}
 
 	/**
@@ -282,11 +297,35 @@ class Customify_Builder_Item_WC_Cart {
 				),
 			),
 
+			// -------------------------------------------------------- Cart behavior
+			// Off-canvas drawer as an alternative to the hover dropdown. Default
+			// 'dropdown' keeps every existing site identical.
 			array(
-				'name'    => "{$this->name}_d_h",
+				'name'    => "{$this->name}_behavior_h",
 				'type'    => 'heading',
 				'section' => $this->section,
-				'title'   => __( 'Dropdown Settings', 'customify' ),
+				'title'   => __( 'Cart Behavior', 'customify' ),
+			),
+
+			array(
+				'name'    => "{$this->name}_behavior",
+				'type'    => 'select',
+				'section' => $this->section,
+				'title'   => __( 'Behavior', 'customify' ),
+				'default' => 'dropdown',
+				'choices' => array(
+					'dropdown' => __( 'Dropdown', 'customify' ),
+					'drawer'   => __( 'Off-Canvas Drawer', 'customify' ),
+				),
+			),
+
+			// ----------------------------------------------------- Dropdown (gated)
+			array(
+				'name'     => "{$this->name}_d_h",
+				'type'     => 'heading',
+				'section'  => $this->section,
+				'title'    => __( 'Dropdown Settings', 'customify' ),
+				'required' => array( "{$this->name}_behavior", '=', 'dropdown' ),
 			),
 
 			array(
@@ -297,6 +336,7 @@ class Customify_Builder_Item_WC_Cart {
 				'selector'        => '.builder-header-' . $this->id . '-item',
 				'render_callback' => $fn,
 				'default'         => array(),
+				'required'        => array( "{$this->name}_behavior", '=', 'dropdown' ),
 				'choices'         => array(
 					'left'  => __( 'Left', 'customify' ),
 					'right' => __( 'Right', 'customify' ),
@@ -314,6 +354,128 @@ class Customify_Builder_Item_WC_Cart {
 				'selector'        => '.builder-header-' . $this->id . '-item  .cart-dropdown-box',
 				'css_format'      => 'width: {{value}};',
 				'default'         => array(),
+				'required'        => array( "{$this->name}_behavior", '=', 'dropdown' ),
+			),
+
+			// ------------------------------------------------------- Drawer (gated)
+			// width / bg / backdrop / radius / offset are Customizer-owned; their
+			// defaults emit as dynamic CSS on first paint (see _wc-cart-drawer.scss),
+			// so the SCSS never hardcodes them.
+			array(
+				'name'     => "{$this->name}_drawer_h",
+				'type'     => 'heading',
+				'section'  => $this->section,
+				'title'    => __( 'Drawer Settings', 'customify' ),
+				'required' => array( "{$this->name}_behavior", '=', 'drawer' ),
+			),
+
+			array(
+				'name'     => "{$this->name}_drawer_position",
+				'type'     => 'select',
+				'section'  => $this->section,
+				'title'    => __( 'Drawer Position', 'customify' ),
+				'default'  => 'right',
+				'required' => array( "{$this->name}_behavior", '=', 'drawer' ),
+				'choices'  => array(
+					'right' => __( 'Right', 'customify' ),
+					'left'  => __( 'Left', 'customify' ),
+				),
+			),
+
+			array(
+				'name'            => "{$this->name}_drawer_width",
+				'type'            => 'slider',
+				'section'         => $this->section,
+				'title'           => __( 'Drawer Width', 'customify' ),
+				'unit'            => '%',
+				'min'             => 20,
+				'max'             => 100,
+				'device_settings' => true,
+				'default'         => array(
+					'desktop' => 26,
+					'tablet'  => 65,
+					'mobile'  => 90,
+				),
+				'selector'        => '.customify-cart-drawer',
+				'css_format'      => 'width: {{value_no_unit}}%;',
+				'required'        => array( "{$this->name}_behavior", '=', 'drawer' ),
+			),
+
+			array(
+				'name'     => "{$this->name}_drawer_auto_open",
+				'type'     => 'checkbox',
+				'section'  => $this->section,
+				'title'    => __( 'Auto-open on Add to Cart', 'customify' ),
+				'default'  => 0,
+				'required' => array( "{$this->name}_behavior", '=', 'drawer' ),
+			),
+
+			array(
+				'name'            => "{$this->name}_drawer_offset",
+				'type'            => 'css_ruler',
+				'section'         => $this->section,
+				'title'           => __( 'Drawer Offset', 'customify' ),
+				'description'     => __( 'Gap from the screen edges. Set values to float the drawer away from the edge.', 'customify' ),
+				'device_settings' => true,
+				'default'         => array(
+					'desktop' => array( 'unit' => 'px', 'top' => 18, 'right' => 18, 'bottom' => 18, 'left' => 18, 'link' => 1 ),
+					'tablet'  => array( 'unit' => 'px', 'top' => 18, 'right' => 18, 'bottom' => 18, 'left' => 18, 'link' => 1 ),
+					'mobile'  => array( 'unit' => 'px', 'top' => 18, 'right' => 18, 'bottom' => 18, 'left' => 18, 'link' => 1 ),
+				),
+				'selector'        => '.customify-cart-drawer',
+				'css_format'      => array(
+					'top'    => 'margin-top: {{value}};',
+					'right'  => 'margin-right: {{value}};',
+					'bottom' => 'margin-bottom: {{value}};',
+					'left'   => 'margin-left: {{value}};',
+				),
+				'required'        => array( "{$this->name}_behavior", '=', 'drawer' ),
+			),
+
+			array(
+				'name'       => "{$this->name}_drawer_radius",
+				'type'       => 'slider',
+				'section'    => $this->section,
+				'title'      => __( 'Corner Radius', 'customify' ),
+				'unit'       => 'px',
+				'min'        => 0,
+				'max'        => 40,
+				'default'    => array( 'value' => 7, 'unit' => 'px' ),
+				'selector'   => '.customify-cart-drawer',
+				'css_format' => 'border-radius: {{value_no_unit}}px;',
+				'required'   => array( "{$this->name}_behavior", '=', 'drawer' ),
+			),
+
+			array(
+				'name'       => "{$this->name}_drawer_backdrop",
+				'type'       => 'color',
+				'section'    => $this->section,
+				'title'      => __( 'Backdrop Color', 'customify' ),
+				'default'    => 'rgba(0,0,0,0.5)',
+				'selector'   => '.customify-cart-drawer-overlay',
+				'css_format' => 'background-color: {{value}};',
+				'required'   => array( "{$this->name}_behavior", '=', 'drawer' ),
+			),
+
+			array(
+				'name'       => "{$this->name}_drawer_bg",
+				'type'       => 'color',
+				'section'    => $this->section,
+				'title'      => __( 'Panel Background', 'customify' ),
+				'default'    => '#ffffff',
+				'selector'   => '.customify-cart-drawer',
+				'css_format' => 'background-color: {{value}};',
+				'required'   => array( "{$this->name}_behavior", '=', 'drawer' ),
+			),
+
+			array(
+				'name'       => "{$this->name}_drawer_head_color",
+				'type'       => 'color',
+				'section'    => $this->section,
+				'title'      => __( 'Heading Color', 'customify' ),
+				'selector'   => '.customify-cart-drawer__head',
+				'css_format' => 'color: {{value}};',
+				'required'   => array( "{$this->name}_behavior", '=', 'drawer' ),
 			),
 
 		);
@@ -462,6 +624,96 @@ class Customify_Builder_Item_WC_Cart {
 		}
 
 		echo '</div>';
+	}
+
+	/**
+	 * When the Cart Behavior is set to Drawer, don't print the inline hover
+	 * dropdown — the off-canvas drawer takes over the cart item. Routed through
+	 * the public `customify/wc_cart/render_dropdown` seam so third-party
+	 * consumers keep working.
+	 *
+	 * @param bool                                $render Whether to print the inline dropdown.
+	 * @param Customify_Builder_Item_WC_Cart|null $item   The cart builder item (unused).
+	 *
+	 * @return bool
+	 */
+	public function maybe_suppress_dropdown( $render, $item = null ) {
+		if ( 'drawer' === Customify()->get_setting( "{$this->name}_behavior" ) ) {
+			return false;
+		}
+
+		return $render;
+	}
+
+	/**
+	 * Suppress the drawer style controls' dynamic CSS when the drawer isn't the
+	 * active behavior, so a dropdown-mode site (the 30k default) doesn't ship
+	 * inert `.customify-cart-drawer{…}` inline rules on every page. Still emitted
+	 * in drawer mode and in the Customizer preview so switching previews live.
+	 * Only the `wc_cart_drawer_*` fields are touched; every other field passes
+	 * through unchanged.
+	 *
+	 * @param array $code_array The generated CSS pieces for a field.
+	 * @param array $field      The field config.
+	 *
+	 * @return array
+	 */
+	public function gate_drawer_auto_css( $code_array, $field ) {
+		if ( empty( $field['name'] ) || 0 !== strpos( $field['name'], "{$this->name}_drawer_" ) ) {
+			return $code_array;
+		}
+		if ( is_customize_preview() ) {
+			return $code_array;
+		}
+		if ( 'drawer' !== Customify()->get_setting( "{$this->name}_behavior" ) ) {
+			return array();
+		}
+
+		return $code_array;
+	}
+
+	/**
+	 * Print the off-canvas drawer panel + overlay once, near </body>, when the
+	 * Cart Behavior is Drawer. Skipped on Cart/Checkout (nothing to preview
+	 * there — the cart link just follows its href). The body reuses WooCommerce
+	 * core's own `.widget_shopping_cart_content` + woocommerce_mini_cart() so
+	 * the AJAX fragments keep it in live sync on add/remove.
+	 */
+	public function render_cart_drawer() {
+		if ( ! function_exists( 'WC' ) || is_cart() || is_checkout() ) {
+			return;
+		}
+
+		if ( 'drawer' !== Customify()->get_setting( "{$this->name}_behavior" ) ) {
+			return;
+		}
+
+		$position = 'left' === Customify()->get_setting( "{$this->name}_drawer_position" ) ? 'left' : 'right';
+		?>
+		<div class="customify-cart-drawer-overlay" hidden></div>
+		<aside id="customify-cart-drawer" class="customify-cart-drawer" data-position="<?php echo esc_attr( $position ); ?>"
+			role="dialog" aria-modal="true" aria-label="<?php esc_attr_e( 'Shopping cart', 'customify' ); ?>" hidden>
+			<div class="customify-cart-drawer__head">
+				<span class="customify-cart-drawer__title"><?php esc_html_e( 'Shopping Cart', 'customify' ); ?></span>
+				<?php // Same markup/class as the Quick View close (theme's a.remove2x) so it looks identical. ?>
+				<a href="#" class="remove2x customify-cart-drawer__close" role="button" aria-label="<?php esc_attr_e( 'Close', 'customify' ); ?>">&times;</a>
+			</div>
+			<div class="customify-cart-drawer__body">
+				<?php
+				// Match WooCommerce core's own fragment exactly (see
+				// WC_AJAX::get_refreshed_fragments): a `.widget_shopping_cart_content`
+				// wrapper around woocommerce_mini_cart(). Keeps the AJAX live-sync
+				// working AND avoids the second "Cart" heading that
+				// the_widget( 'WC_Widget_Cart' ) prints.
+				?>
+				<div class="widget_shopping_cart_content"><?php woocommerce_mini_cart(); ?></div>
+			</div>
+			<?php // Shown only when the cart is empty (JS toggles .is-cart-empty). ?>
+			<div class="customify-cart-drawer__continue">
+				<a href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" class="button"><?php esc_html_e( 'Continue Shopping', 'customify' ); ?></a>
+			</div>
+		</aside>
+		<?php
 	}
 }
 

--- a/inc/compatibility/woocommerce/woocommerce.php
+++ b/inc/compatibility/woocommerce/woocommerce.php
@@ -343,6 +343,10 @@ class Customify_WC {
 			$args['wc_open_cart'] = true;
 		}
 
+		// Cart drawer auto-open (only meaningful when Cart Behavior = drawer;
+		// the drawer JS reads this off the localized Customify_JS object).
+		$args['wc_cart_drawer_auto_open'] = (bool) Customify()->get_setting( 'wc_cart_drawer_auto_open' );
+
 		return $args;
 	}
 

--- a/src/frontend/js/compatibility/cart-drawer.js
+++ b/src/frontend/js/compatibility/cart-drawer.js
@@ -1,0 +1,239 @@
+/**
+ * WooCommerce Cart Drawer (off-canvas) — frontend behavior.
+ *
+ * Independent state (`is-cart-drawer` on <html>/<body>) so it never collides
+ * with the theme's mobile-menu off-canvas (`is-menu-sidebar`). Opens from the
+ * header cart trigger, syncs its body from WooCommerce's own AJAX fragments.
+ *
+ * Only acts when the drawer panel (#customify-cart-drawer) is present — the
+ * header cart item prints it only when Cart Behavior = Drawer, so in Dropdown
+ * mode this file binds nothing and the native hover dropdown is untouched.
+ */
+(function ($) {
+	'use strict';
+
+	// Auto-open reads the theme's localized Customify_JS object (same one the
+	// sibling woocommerce.js reads for wc_open_cart). Guarded so a missing
+	// object doesn't break the drawer.
+	var CJS = ( window.Customify_JS && typeof window.Customify_JS === 'object' ) ? window.Customify_JS : {};
+	var autoOpen = !! CJS.wc_cart_drawer_auto_open;
+
+	var FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+	var drawer, overlay, lastFocused, autoOpenArmed = false;
+
+	function getScrollbarWidth() {
+		return window.innerWidth - document.documentElement.clientWidth;
+	}
+
+	function lockScroll() {
+		var sw = getScrollbarWidth();
+		if ( sw > 0 ) {
+			document.documentElement.style.setProperty( '--customify-scrollbar-width', sw + 'px' );
+		}
+		document.documentElement.classList.add( 'is-cart-drawer' );
+		document.body.classList.add( 'is-cart-drawer' );
+	}
+
+	function unlockScroll() {
+		document.documentElement.classList.remove( 'is-cart-drawer' );
+		document.body.classList.remove( 'is-cart-drawer' );
+		document.documentElement.style.removeProperty( '--customify-scrollbar-width' );
+	}
+
+	function isOpen() {
+		return drawer && drawer.classList.contains( 'is-open' );
+	}
+
+	/**
+	 * @param {boolean} focusDisabled When true (auto-open), don't steal focus
+	 *                                from the page the shopper is browsing.
+	 */
+	function open( focusDisabled ) {
+		if ( ! drawer || isOpen() ) {
+			return;
+		}
+
+		lastFocused = document.activeElement;
+
+		drawer.hidden = false;
+		overlay.hidden = false;
+		drawer.removeAttribute( 'inert' );
+
+		// Forced synchronous reflow so the transition runs even in a background
+		// tab — requestAnimationFrame doesn't fire while the tab is hidden
+		// (same convention as the theme's typography-control.js).
+		void drawer.offsetWidth;
+
+		drawer.classList.add( 'is-open' );
+		overlay.classList.add( 'is-open' );
+		lockScroll();
+
+		if ( ! focusDisabled ) {
+			var closeBtn = drawer.querySelector( '.customify-cart-drawer__close' );
+			if ( closeBtn ) {
+				closeBtn.focus();
+			}
+		}
+	}
+
+	function close() {
+		if ( ! drawer || ! isOpen() ) {
+			return;
+		}
+
+		drawer.classList.remove( 'is-open' );
+		overlay.classList.remove( 'is-open' );
+		unlockScroll();
+		drawer.setAttribute( 'inert', '' );
+
+		// Remove from the a11y tree after the slide-out. A timeout (rather than
+		// transitionend) also covers prefers-reduced-motion, where no
+		// transition fires.
+		window.setTimeout( function () {
+			if ( ! isOpen() ) {
+				drawer.hidden = true;
+				overlay.hidden = true;
+			}
+		}, 300 );
+
+		if ( lastFocused && typeof lastFocused.focus === 'function' ) {
+			lastFocused.focus();
+		}
+	}
+
+	function trapFocus( e ) {
+		if ( e.key !== 'Tab' || ! isOpen() ) {
+			return;
+		}
+
+		var f = drawer.querySelectorAll( FOCUSABLE );
+		if ( ! f.length ) {
+			return;
+		}
+
+		var first = f[ 0 ];
+		var last = f[ f.length - 1 ];
+
+		if ( e.shiftKey && document.activeElement === first ) {
+			e.preventDefault();
+			last.focus();
+		} else if ( ! e.shiftKey && document.activeElement === last ) {
+			e.preventDefault();
+			first.focus();
+		}
+	}
+
+	function onKeydown( e ) {
+		if ( ( e.key === 'Escape' || e.key === 'Esc' ) && isOpen() ) {
+			e.preventDefault();
+			close();
+		} else {
+			trapFocus( e );
+		}
+	}
+
+	// Flag the drawer as empty (drives the "Continue Shopping" button) whenever
+	// WC's mini-cart shows its empty message.
+	function updateEmptyState() {
+		if ( ! drawer ) {
+			return;
+		}
+		drawer.classList.toggle(
+			'is-cart-empty',
+			!! drawer.querySelector( '.woocommerce-mini-cart__empty-message' )
+		);
+	}
+
+	function bind() {
+		// Belt-and-suspenders against a double enqueue: bind the delegated
+		// handlers / auto-open listeners only once.
+		if ( window.__customifyCartDrawerBound ) {
+			return;
+		}
+
+		drawer = document.getElementById( 'customify-cart-drawer' );
+		overlay = document.querySelector( '.customify-cart-drawer-overlay' );
+
+		// Drawer only renders when Cart Behavior = Drawer. In Dropdown mode
+		// there's nothing to bind — leave the native dropdown alone.
+		if ( ! drawer || ! overlay ) {
+			return;
+		}
+
+		window.__customifyCartDrawerBound = true;
+
+		drawer.setAttribute( 'inert', '' );
+
+		// Open from the header cart item; keep the href as a no-JS fallback.
+		$( document ).on( 'click', '.builder-header-wc_cart-item .cart-item-link', function ( e ) {
+			e.preventDefault();
+			open( false );
+		} );
+
+		overlay.addEventListener( 'click', close );
+
+		var closeBtn = drawer.querySelector( '.customify-cart-drawer__close' );
+		if ( closeBtn ) {
+			closeBtn.addEventListener( 'click', function ( e ) {
+				e.preventDefault(); // it's an <a href="#"> (matches Quick View's close)
+				close();
+			} );
+		}
+
+		// Show "Continue Shopping" only while the cart is empty — re-check on
+		// load and on every WC cart change.
+		updateEmptyState();
+		$( document.body ).on( 'wc_fragments_refreshed wc_fragments_loaded added_to_cart removed_from_cart', updateEmptyState );
+
+		// Capture phase so ESC wins over other handlers.
+		document.addEventListener( 'keydown', onKeydown, true );
+
+		// Auto-open after add-to-cart — wait for fresh fragments so the drawer
+		// shows updated contents, and don't yank focus off the page. Two-step:
+		// arm on added_to_cart, open on the fragment refresh. The setTimeout is
+		// a script-order safety net: WooCommerce can fire wc_fragments_loaded
+		// synchronously inside the SAME added_to_cart dispatch, before this arm
+		// handler runs — the fragment listener would then miss it. WC replaces
+		// the fragments BEFORE firing added_to_cart, so opening on the next tick
+		// still shows fresh contents; the fragment listener handles the normal
+		// case and clears the flag so this never double-opens.
+		if ( autoOpen ) {
+			$( document.body ).on( 'added_to_cart', function () {
+				autoOpenArmed = true;
+				window.setTimeout( function () {
+					if ( autoOpenArmed ) {
+						autoOpenArmed = false;
+						open( true );
+					}
+				}, 0 );
+			} );
+
+			$( document.body ).on( 'wc_fragments_refreshed wc_fragments_loaded', function () {
+				if ( autoOpenArmed ) {
+					autoOpenArmed = false;
+					open( true );
+				}
+			} );
+		}
+
+		// Tear down a stuck-open drawer restored from the bfcache (back button).
+		window.addEventListener( 'pageshow', function ( e ) {
+			if ( e.persisted && isOpen() ) {
+				drawer.classList.remove( 'is-open' );
+				overlay.classList.remove( 'is-open' );
+				drawer.hidden = true;
+				overlay.hidden = true;
+				drawer.setAttribute( 'inert', '' );
+				unlockScroll();
+			}
+		} );
+	}
+
+	if ( document.readyState !== 'loading' ) {
+		bind();
+	} else {
+		document.addEventListener( 'DOMContentLoaded', bind );
+	}
+
+})( jQuery );

--- a/src/frontend/scss/compatibility/wc/_wc-cart-drawer.scss
+++ b/src/frontend/scss/compatibility/wc/_wc-cart-drawer.scss
@@ -1,0 +1,323 @@
+//
+// WooCommerce Cart Drawer (off-canvas).
+//
+// Position is PHYSICAL (left / right) and kept physical in RTL — so we do NOT
+// ship a cart-drawer-rtl.css: rtlcss would flip `right`/`left` and the
+// translate sign, sliding the panel in from the wrong edge. Internal content
+// is mirrored by WooCommerce / the theme's own RTL rules.
+//
+// Body reuses WooCommerce core's own fragment shape:
+//   .widget_shopping_cart_content > woocommerce_mini_cart()
+// so add/remove auto-syncs via WC AJAX fragments and there is no duplicate
+// widget title.
+//
+// width / background-color / border-radius / offset / backdrop are NOT set
+// here: they come from the Shopping Cart item's Customizer controls, which
+// emit their defaults as dynamic CSS on first paint (so a fresh install still
+// renders correctly) and override on save. Hardcoding them here too would make
+// this stylesheet the only source when a value is empty, or fight the dynamic
+// CSS at equal specificity — so we leave them to the controls.
+//
+
+$cd-z:          100000;
+$cd-transition: 0.3s cubic-bezier(0.79, 0.14, 0.15, 0.86);
+$cd-border:     rgba(0, 0, 0, 0.08);
+
+.customify-cart-drawer-overlay {
+    position: fixed;
+    inset: 0;
+    // background-color comes from the Customizer (Backdrop Color) default.
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+    z-index: $cd-z - 1;
+    cursor: pointer;
+
+    &.is-open {
+        opacity: 1;
+        visibility: visible;
+    }
+}
+
+.customify-cart-drawer {
+    position: fixed;
+    top: 0;
+    bottom: 0;              // top + bottom drive the height, so a top/bottom
+    right: 0;               // Offset margin can inset the panel from the edges.
+    max-width: 100%;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;       // clip to the (optional) Corner Radius.
+    box-shadow: 0 0 40px rgba(0, 0, 0, 0.18);
+    // width + background-color come from the Customizer (Drawer Width / Panel
+    // Background), which always emits its defaults. Not hardcoded here so those
+    // controls win — the theme's dynamic CSS loads before this stylesheet.
+    z-index: $cd-z;
+    font-size: 15px;
+    color: $color_text;
+    transition: transform $cd-transition;
+
+    // Parked off-screen until `.is-open`; translate3d keeps it on the GPU. Use
+    // a plain 120% (not calc) — Chrome won't animate a transition between a
+    // calc() transform and a plain one, and 120% clears any Offset margin so no
+    // sliver peeks while parked.
+    &[data-position="right"] {
+        right: 0;
+        left: auto;
+        transform: translate3d(120%, 0, 0);
+    }
+
+    &[data-position="left"] {
+        left: 0;
+        right: auto;
+        transform: translate3d(-120%, 0, 0);
+    }
+
+    // will-change only while open, so a closed drawer doesn't hold a
+    // compositor layer for the life of every page.
+    &.is-open {
+        transform: translate3d(0, 0, 0);
+        will-change: transform;
+    }
+
+    // ---------------------------------------------------------------- header
+    &__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex: 0 0 auto;
+        padding: 1.15em 1.5em;
+        border-bottom: 1px solid $cd-border;
+    }
+
+    &__title {
+        margin: 0;
+        font-size: 1em;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+    }
+
+    // ------------------------------------------------------------------ body
+    &__body {
+        flex: 1 1 auto;
+        display: flex;
+        min-height: 0;
+        padding: 0;
+    }
+
+    // "Continue Shopping" — shown only when the cart is empty (JS toggles
+    // .is-cart-empty on the panel); pinned at the bottom like the cart footer.
+    &__continue {
+        flex: 0 0 auto;
+        display: none;
+        padding: 1.15em 1.5em 1.5em;
+        border-top: 1px solid $cd-border;
+
+        .button {
+            display: block;
+            width: 100%;
+            margin: 0;
+            text-align: center;
+        }
+    }
+
+    &.is-cart-empty &__continue {
+        display: block;
+    }
+}
+
+//
+// Close button — the markup uses the theme's global `a.remove2x`, so it is
+// visually identical to the Quick View modal's close (white circle + ×). We
+// add nothing but flow/anchor tidy-ups here; all the look comes from a.remove2x.
+//
+.customify-cart-drawer .customify-cart-drawer__close {
+    flex: 0 0 auto;
+    text-decoration: none;
+}
+
+//
+// Mini-cart body. Descendant selectors (scoped under .customify-cart-drawer)
+// so we out-specify the theme's widget styling. The product list scrolls; the
+// subtotal + action buttons stay pinned at the bottom.
+//
+.customify-cart-drawer {
+    .widget_shopping_cart_content {
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 auto;
+        min-height: 0;
+        width: 100%;
+    }
+
+    .woocommerce-mini-cart {
+        flex: 1 1 auto;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+        margin: 0;
+        padding: 0 1.5em;
+        list-style: none;
+    }
+
+    .woocommerce-mini-cart-item {
+        position: relative;
+        display: block;
+        // left = thumbnail (48px) + gap; right = remove button (22px) + gap.
+        padding: 1.1em 2.25em 1.1em 4em;
+        margin: 0;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.07);
+
+        // Product name link. The theme's mini-cart.php puts it inside
+        // .mini_cart_item__info; the thumbnail is a SEPARATE
+        // a.mini_cart_item__thumb, so scope here to avoid styling that too.
+        .mini_cart_item__info a:not(.remove) {
+            display: block;
+            font-weight: 500;
+            line-height: 1.35;
+            text-decoration: none;
+        }
+
+        img {
+            position: absolute;
+            left: 0;
+            top: 50%;
+            transform: translateY(-50%);
+            width: 48px;
+            height: 48px;
+            margin: 0;
+            object-fit: cover;
+            border-radius: 4px;
+        }
+
+        .quantity {
+            display: block;
+            margin-top: 0.3em;
+            font-size: 0.88em;
+            color: $color_meta;
+        }
+
+        // Variable-product attributes (Size / Color …). Strip the theme's
+        // floated + left-bordered widget styling so they read as a compact
+        // inline list under the product name.
+        dl.variation {
+            margin: 0.35em 0 0;
+            padding: 0;
+            border: 0;
+            font-size: 0.85em;
+            color: $color_meta;
+
+            dt,
+            dd {
+                display: inline;
+                float: none;
+                margin: 0;
+                padding: 0;
+                font-weight: 400;
+            }
+
+            dd {
+                margin-right: 0.6em;
+
+                p {
+                    display: inline;
+                    margin: 0;
+                }
+            }
+        }
+
+        // Remove (×): the look (white circle + shadow ring + ×) comes from the
+        // theme's global `a.remove` — identical to the header dropdown. We only
+        // place it, vertically centred against the row.
+        a.remove.remove_from_cart_button {
+            position: absolute;
+            top: 50%;
+            right: 0;
+            transform: translateY(-50%);
+        }
+    }
+
+    .woocommerce-mini-cart__empty-message {
+        // Sole child of the flex column when the cart is empty — `margin:auto`
+        // vertically centres it instead of pinning it to the top.
+        margin: auto 0;
+        padding: 2.5em 1.5em;
+        text-align: center;
+        color: $color_meta;
+    }
+
+    // Footer wrapper (theme template wraps total + buttons in
+    // div.wc-mini-cart-footer, which already carries a divider border-top).
+    // Own the single border here and give it the drawer's shared 1.5em inset
+    // so Subtotal/buttons line up with the header title and the item column.
+    .wc-mini-cart-footer {
+        flex: 0 0 auto;
+        margin: 0;
+        padding: 1.15em 1.5em 1.5em;
+        border-top: 1px solid $cd-border;
+    }
+
+    .woocommerce-mini-cart__total {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        margin: 0 0 1em;
+        padding: 0;
+        border: 0;              // no second border — the footer wrapper owns it
+        font-size: 1em;
+
+        strong {
+            font-weight: 600;
+        }
+
+        .amount {
+            font-weight: 700;
+            font-size: 1.1em;
+        }
+    }
+
+    .woocommerce-mini-cart__buttons {
+        display: flex;
+        flex-direction: column;
+        gap: 0.6em;
+        margin: 0;
+        padding: 0;
+
+        .button {
+            display: block;
+            width: 100%;
+            margin: 0;
+            text-align: center;
+        }
+    }
+}
+
+// Push the panel below the admin bar for logged-in users.
+.admin-bar .customify-cart-drawer {
+    top: 32px;
+
+    @media screen and (max-width: 782px) {
+        top: 46px;
+    }
+}
+
+// Scroll-lock: freeze the page behind the drawer and pad for the removed
+// scrollbar so the layout doesn't shift.
+html.is-cart-drawer,
+html.is-cart-drawer body {
+    overflow: hidden;
+}
+
+html.is-cart-drawer body {
+    // Logical property so the pad lands on the scrollbar's side in both LTR
+    // and RTL (RTL puts the viewport scrollbar on the left).
+    padding-inline-end: var(--customify-scrollbar-width, 0);
+}
+
+// Respect users who ask for less motion — skip the slide/fade entirely.
+@media (prefers-reduced-motion: reduce) {
+    .customify-cart-drawer,
+    .customify-cart-drawer-overlay {
+        transition: none;
+    }
+}

--- a/src/frontend/scss/compatibility/woocommerce.scss
+++ b/src/frontend/scss/compatibility/woocommerce.scss
@@ -16,6 +16,7 @@
 @import "wc/wc-forms";
 @import "wc/wc-reviews";
 @import "wc/wc-cart-checkout";
+@import "wc/wc-cart-drawer";
 
 
 /* Sale on badge */

--- a/src/frontend/woocommerce.js
+++ b/src/frontend/woocommerce.js
@@ -1,3 +1,4 @@
 import './scss/compatibility/woocommerce.scss';
 import './scss/compatibility/woocommerce-smallscreen.scss';
 import './js/compatibility/woocommerce.js';
+import './js/compatibility/cart-drawer.js';


### PR DESCRIPTION
## Off-canvas cart drawer (native)

Adds an off-canvas cart drawer as an alternative to the header cart item's hover **dropdown**, selectable via a new **Cart Behavior** control (Dropdown | Off-Canvas Drawer) on the Shopping Cart header item. Previously prototyped in Customify Pro, now a native free-theme feature.

### Behaviour
- **Default `dropdown`** → existing sites render identically.
- Set to **drawer** → the inline dropdown is suppressed (through the public `customify/wc_cart/render_dropdown` seam) and a slide-in panel renders at `wp_footer`. Body reuses WC core's `.widget_shopping_cart_content` + `woocommerce_mini_cart()`, so add/remove stays live-synced via WC AJAX fragments. Close button reuses the theme's `a.remove2x`.

### Settings (section `wc_cart`, gated by behaviour)
`wc_cart_behavior`, `wc_cart_drawer_{position,width,auto_open,offset,radius,backdrop,bg,head_color}`; the existing dropdown fields are gated to `dropdown`.

### Files
- new: `src/frontend/scss/compatibility/wc/_wc-cart-drawer.scss` (+ import), `src/frontend/js/compatibility/cart-drawer.js` (+ import into `src/frontend/woocommerce.js`)
- `inc/compatibility/woocommerce/config/header/cart.php` (settings + render + footer panel + auto-css gate), `inc/compatibility/woocommerce/woocommerce.php` (localize `auto_open`)

### 30k-site safety (audited)
Default `dropdown` unchanged; additive-only setting keys; no DB write/query/migration; drawer CSS fully scoped under `.customify-cart-drawer*` (no leak onto the dropdown mini-cart); drawer style controls' dynamic CSS is gated to drawer mode, so a pristine dropdown site ships **zero** inert inline CSS. Verified on an unset-behaviour site: dropdown renders unchanged, no footer panel, drawer JS inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
