### PR TITLE
Fix WooCommerce block quantity and variation styles

### DIFF
--- a/src/frontend/js/compatibility/woocommerce.js
+++ b/src/frontend/js/compatibility/woocommerce.js
@@ -82,6 +82,13 @@ jQuery(document).ready(function($) {
 	$.fn._wc_plus_minus = function() {
 		this.each(function() {
 			var input = $(this);
+
+			// WooCommerce add-to-cart blocks own their quantity markup and
+			// interactivity. Do not wrap the input or add a theme +/- pair.
+			if (input.closest(".wc-block-add-to-cart-form, .wc-block-add-to-cart-with-options").length) {
+				return;
+			}
+
 			var check = input.data("qty-added") || false;
 			if (!check) {
 				input.data("qty-added", 1);

--- a/src/frontend/scss/compatibility/wc/_wc-product.scss
+++ b/src/frontend/scss/compatibility/wc/_wc-product.scss
@@ -323,6 +323,11 @@ div.product {
             td,
             th {
                 border: 0;
+                // Add To Cart blocks reuse WooCommerce's classic variations
+                // table outside a native single-product page. Neutralize the
+                // theme's global table surface and spacing in both contexts.
+                background-color: transparent;
+                padding: 0;
                 vertical-align: top;
                 line-height: 2em;
             }

--- a/src/frontend/scss/compatibility/wc/_wc-product.scss
+++ b/src/frontend/scss/compatibility/wc/_wc-product.scss
@@ -344,8 +344,9 @@ div.product {
                 margin-right: 1em;
                 color: #444444;
             }
-            td.label {
-                padding-right: 1em;
+            td.label,
+            th.label {
+                padding-inline-end: 1em;
             }
         }
 
@@ -399,6 +400,14 @@ div.product {
             }
         }
     }
+}
+
+// The block can render this table in a narrow content column. Let the select
+// size to its option text and reserve enough room for the native arrow.
+div.product.wc-block-add-to-cart-form form.cart .variations select {
+    min-width: 12em;
+    padding-inline-end: 2em;
+    width: auto;
 }
 
 span.onsale {

--- a/src/frontend/scss/compatibility/wc/_woocommerce-main.scss
+++ b/src/frontend/scss/compatibility/wc/_woocommerce-main.scss
@@ -169,6 +169,15 @@ p.demo_store,
         }
     }
 
+    // Customify gives number fields a fixed height, while the Add To Cart
+    // stepper adds vertical padding to its quantity input. WooCommerce also
+    // switches that input to content-box, which otherwise adds both values
+    // together and stretches the whole purchase row.
+    .wc-block-add-to-cart-form--stepper .wc-block-components-quantity-selector input.qty {
+        box-sizing: border-box;
+        height: auto;
+    }
+
     .blockUI.blockOverlay {
         position: relative;
         z-index: 35 !important;
@@ -618,5 +627,4 @@ td.product-quantity {
     margin: 0.5em 0 0;
     display: block;
 }
-
 

--- a/src/frontend/scss/compatibility/wc/_woocommerce-main.scss
+++ b/src/frontend/scss/compatibility/wc/_woocommerce-main.scss
@@ -170,12 +170,14 @@ p.demo_store,
     }
 
     // Customify gives number fields a fixed height, while the Add To Cart
-    // stepper adds vertical padding to its quantity input. WooCommerce also
-    // switches that input to content-box, which otherwise adds both values
-    // together and stretches the whole purchase row.
-    .wc-block-add-to-cart-form--stepper .wc-block-components-quantity-selector input.qty {
+    // stepper adds vertical padding to its quantity input. Keep the input from
+    // setting the grid row height so the stepper follows the adjacent button.
+    .wc-block-add-to-cart-form.wc-block-add-to-cart-form--stepper
+    .wc-block-components-quantity-selector
+    input[type="number"].input-text.qty.text {
         box-sizing: border-box;
-        height: auto;
+        height: 100%;
+        padding-block: 0;
     }
 
     .blockUI.blockOverlay {
@@ -627,4 +629,3 @@ td.product-quantity {
     margin: 0.5em 0 0;
     display: block;
 }
-


### PR DESCRIPTION
## Summary
- skip Customify quantity injection inside WooCommerce owned add-to-cart blocks
- normalize variation table surfaces and spacing outside native single-product templates
- align block stepper sizing with the adjacent add-to-cart button
- improve variation label spacing and select arrow clearance

## QA
- npm run build passes with existing asset-size warnings only
- Woo Add To Cart block Stepper keeps exactly two Woo controls and runs 1 to 2 to 1
- Woo Add To Cart block Input remains a native number input with no injected controls
- classic variable product keeps exactly two Customify controls and runs 1 to 2 to 1
- Variation Swatches for WooCommerce 2.3.0 renders and selects M S XS in both block and classic layouts
- no frontend console errors in tested block and classic pages

## Scope
Source-only theme changes. No product or plugin data is part of this PR.