### PR TITLE
Add contextual content area spacing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,7 @@ The big picture — request flow + which subsystem owns which path. Deep-dive ea
 | Concern | SPEC |
 |---|---|
 | Singleton, layout, element classes, template hierarchy | [`SPEC-bootstrap.md`](SPEC-bootstrap.md) |
+| Context-aware content area vertical spacing | [`SPEC-content-area-spacing.md`](SPEC-content-area-spacing.md) |
 | webpack entries, asset.php sidecar, CSS handle | [`SPEC-asset-pipeline.md`](SPEC-asset-pipeline.md) |
 | Customizer config + auto-CSS + JS contexts | [`SPEC-customizer.md`](SPEC-customizer.md) |
 | 6-slot color palette + `:root` token pipeline | [`SPEC-customizer-colors.md`](SPEC-customizer-colors.md) |
@@ -93,6 +94,7 @@ Each SPEC owns one subsystem end-to-end: storage shape, render pipeline, design 
 | File | Subsystem |
 |---|---|
 | [`SPEC-bootstrap.md`](SPEC-bootstrap.md) | Singleton bootstrap, layout system, element classes, template hierarchy |
+| [`SPEC-content-area-spacing.md`](SPEC-content-area-spacing.md) | Global spacing magnitude, request contexts, CPT/taxonomy inheritance |
 | [`SPEC-asset-pipeline.md`](SPEC-asset-pipeline.md) | webpack, `index.asset.php` pattern, CSS handle, `src/` vs `build/` vs `assets/` |
 | [`SPEC-customizer.md`](SPEC-customizer.md) | Customizer architecture, config-driven registration, auto-CSS, fonts, controls |
 | [`SPEC-customizer-colors.md`](SPEC-customizer-colors.md) | 6-slot palette, `:root` token pipeline, `theme.json` sync, picker UI |

--- a/docs/SPEC-content-area-spacing.md
+++ b/docs/SPEC-content-area-spacing.md
@@ -46,8 +46,9 @@ Pages, Blog Posts, Blog Archives, Search and 404 modes.
 controls. The CPT source is `customify_get_content_post_types()`, so internal
 utility types and plugin-specific exclusions remain centralized. A CPT archive
 control is added only when the type has a real archive and Customify owns that
-archive. WooCommerce's Product archive keeps its established shop-page
-ownership and falls back to Blog Archives.
+archive. WooCommerce's Product archive and product-only taxonomies keep their
+established ownership, receive no context setting, and leave the global spacing
+unchanged.
 
 ---
 
@@ -60,8 +61,9 @@ ownership and falls back to Blog Archives.
 3. Page or blog-post single.
 4. Supported CPT archive.
 5. Custom taxonomy owned by exactly one supported archive CPT.
-6. Built-in/shared/unresolved archive → Blog Archives.
-7. Supported CPT single.
+6. Archive/taxonomy owned by an excluded integration → no context setting.
+7. Built-in/shared/unresolved archive → Blog Archives.
+8. Supported CPT single.
 
 `customify_resolve_content_area_spacing_mode()` then applies this precedence:
 

--- a/docs/SPEC-content-area-spacing.md
+++ b/docs/SPEC-content-area-spacing.md
@@ -1,0 +1,118 @@
+# SPEC — Content Area Spacing
+
+Context-aware control of Customify's existing vertical spacing around `#main`
+and the primary/secondary sidebars. This is a theme-level layout feature: it
+uses the real WordPress request context and has no page-builder or plugin-
+template coupling.
+
+---
+
+## 1. Storage shape
+
+`site_content_padding` remains the responsive `css_ruler` that owns the actual
+top/bottom spacing magnitude. Its theme-mod ID, value shape, selector and CSS
+output are unchanged; only its Customizer section moved to
+`Layouts → Content Area Spacing`.
+
+Context controls store one of `inherit`, `both`, `top`, `bottom`, or `disabled`:
+
+| Context | Theme mod |
+|---|---|
+| Pages | `page_content_area_spacing` |
+| Blog posts | `posts_content_area_spacing` |
+| Blog archives | `posts_archives_content_area_spacing` |
+| Search | `search_content_area_spacing` |
+| 404 | `404_content_area_spacing` |
+| CPT single | `{post_type}_content_area_spacing` |
+| CPT archive | `{post_type}_archive_content_area_spacing` |
+
+Every new setting defaults to `inherit`. No migration is required: an existing
+site with no saved context mod gets the same global CSS and body classes as
+before this feature.
+
+The existing singular post meta
+`_customify_disable_content_vertical_padding=1` remains supported and has
+absolute precedence over the context setting.
+
+---
+
+## 2. Customizer UI
+
+The `Content Area Spacing` section lives under the existing `Layouts` panel.
+The `General` group contains the unchanged global spacing magnitude followed by
+Pages, Blog Posts, Blog Archives, Search and 404 modes.
+
+`Post Type Settings` is a heading control above dynamically generated CPT
+controls. The CPT source is `customify_get_content_post_types()`, so internal
+utility types and plugin-specific exclusions remain centralized. A CPT archive
+control is added only when the type has a real archive and Customify owns that
+archive. WooCommerce's Product archive keeps its established shop-page
+ownership and falls back to Blog Archives.
+
+---
+
+## 3. Request resolution
+
+`customify_get_content_area_spacing_context()` maps the real request:
+
+1. Search and 404.
+2. Blog home.
+3. Page or blog-post single.
+4. Supported CPT archive.
+5. Custom taxonomy owned by exactly one supported archive CPT.
+6. Built-in/shared/unresolved archive → Blog Archives.
+7. Supported CPT single.
+
+`customify_resolve_content_area_spacing_mode()` then applies this precedence:
+
+1. Existing singular disable meta → `disabled`.
+2. Context theme mod.
+3. Invalid/empty value → `inherit`.
+
+Taxonomies shared by multiple post types intentionally fall back to Blog
+Archives. This avoids guessing ownership and matches the sidebar resolver.
+
+---
+
+## 4. Render pipeline
+
+`inherit` and `both` add no body class; the existing `site_content_padding` CSS
+continues to provide both sides. Other modes emit only the class needed to zero
+one or both components:
+
+| Mode | Body class | Effect |
+|---|---|---|
+| `top` | `content-area-spacing-top-only` | zero bottom |
+| `bottom` | `content-area-spacing-bottom-only` | zero top |
+| `disabled` | `disable-content-vertical-padding` | zero both |
+
+The disabled mode deliberately reuses the legacy public class. Static rules
+live in `src/frontend/scss/layouts/_layouts.scss`; the global spacing value is
+not duplicated or replaced.
+
+---
+
+## 5. Extension hooks
+
+| Filter | Purpose |
+|---|---|
+| `customify/content_area_spacing/archive_post_types` | Change CPT archives owned by the spacing UI/resolver. |
+| `customify/content_area_spacing/context` | Map an unusual route to a core context or direct setting name. |
+| `customify/content_area_spacing/mode` | Filter a non-legacy resolved mode. |
+| `customify/content_area_spacing/components` | Filter final `top` / `bottom` booleans. |
+| `customify/content_area_spacing/body_classes` | Extend the minimal spacing body classes. |
+
+The legacy singular disable meta returns before the mode/components filters so
+its existing precedence cannot be weakened accidentally.
+
+---
+
+## 6. Verification
+
+Focused resolver coverage lives in `tests/content-area-spacing-test.php` and
+includes page, blog post, CPT single, CPT archive, owning taxonomy, shared
+taxonomy, search, 404 and legacy meta precedence. Run:
+
+```bash
+php tests/content-area-spacing-test.php
+```

--- a/docs/SPEC-data-migration-policy.md
+++ b/docs/SPEC-data-migration-policy.md
@@ -49,6 +49,14 @@ Three things matter most:
 | `{post_type}_sidebar_layout` | string | `content` | Per-CPT **single** sidebar layout (`is_singular()`). Dynamic — one key per content post type; `default` choice inherits the global `sidebar_layout` |
 | `{post_type}_archive_sidebar_layout` | string | `content` | Per-CPT **archive** sidebar layout (`is_post_type_archive()`). Dynamic — only registered for types with `has_archive`; excludes WC `product` (shop owned by WC). Defaults to no-sidebar like the per-CPT single; the `Default` choice (value `default`) inherits `posts_archives_sidebar_layout` |
 | `container_width` | int + unit (slider) | `1200px` | Site container max-width; MUST sync to `--wp--style--global--wide-size` |
+| `site_content_padding` | responsive CSS ruler | SCSS fallback | Existing top/bottom spacing magnitude for `#main` and both sidebars; ID and output unchanged when moved to the Content Area Spacing section |
+| `page_content_area_spacing` | string | `inherit` | Pages: `inherit` / `both` / `top` / `bottom` / `disabled` |
+| `posts_content_area_spacing` | string | `inherit` | Blog-post singles |
+| `posts_archives_content_area_spacing` | string | `inherit` | Blog home, built-in archives, and shared/unresolved taxonomies |
+| `search_content_area_spacing` | string | `inherit` | Search results |
+| `404_content_area_spacing` | string | `inherit` | 404 requests |
+| `{post_type}_content_area_spacing` | string | `inherit` | Per-CPT single; generated from `customify_get_content_post_types()` |
+| `{post_type}_archive_content_area_spacing` | string | `inherit` | Per-CPT archive when the type has a real archive owned by Customify |
 
 ### 2.2 Builder layouts
 
@@ -173,6 +181,7 @@ Per-post overrides. All Customify-managed meta keys use the `_customify_` prefix
 | `_customify_disable_header` | bool | `1` / `''` | [`inc/template-functions.php:312`](../inc/template-functions.php) |
 | `_customify_disable_{builder_id}` | bool | `1` / `''` | [`inc/template-functions.php:368`](../inc/template-functions.php) — `builder_id` is `header` / `footer` |
 | `_customify_disable_page_title` | bool | `1` / `''` | [`inc/template-functions.php:385`](../inc/template-functions.php) |
+| `_customify_disable_content_vertical_padding` | bool | `1` / `''` | Legacy singular override; remains highest precedence in [`inc/content-area-spacing.php`](../inc/content-area-spacing.php) |
 
 ### 4.2 Page header / cover overrides
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -24,6 +24,11 @@ For storage keys (`theme_mod` / `wp_options` / `post_meta`) see [`SPEC-data-migr
 | `customify_is_post_title_display` | filter | `bool` — render the page/post title? | [`inc/template-functions.php:391`](../inc/template-functions.php) |
 | `customify_is_builder_row_display` | filter | `bool` — render builder row? (`$builder_id`, `$row_id`, `$post_id` passed) | [`inc/template-functions.php:374`](../inc/template-functions.php) |
 | `customify_builder_row_display_get_post_id` | filter | `int` — post ID used for builder row display logic | [`inc/template-functions.php:365`](../inc/template-functions.php) |
+| `customify/content_area_spacing/archive_post_types` | filter | `array` — content CPT archives owned by the spacing UI/resolver | [`inc/content-area-spacing.php`](../inc/content-area-spacing.php) |
+| `customify/content_area_spacing/context` | filter | `array` — request context (`key`, `post_type`, `post_id`, `singular`, `setting`) | [`inc/content-area-spacing.php`](../inc/content-area-spacing.php) |
+| `customify/content_area_spacing/mode` | filter | `(string $mode, array $context, string $setting)` — non-legacy resolved mode | [`inc/content-area-spacing.php`](../inc/content-area-spacing.php) |
+| `customify/content_area_spacing/components` | filter | `(array $components, string $mode, array $context)` — top/bottom booleans | [`inc/content-area-spacing.php`](../inc/content-area-spacing.php) |
+| `customify/content_area_spacing/body_classes` | filter | `(array $classes, array $components, array $context)` | [`inc/content-area-spacing.php`](../inc/content-area-spacing.php) |
 
 Example — override layout for a specific page:
 

--- a/inc/class-customify.php
+++ b/inc/class-customify.php
@@ -493,6 +493,8 @@ class Customify
 			// Metabox settings.
 			'/inc/template-class.php',
 			// Template element classes.
+			'/inc/content-area-spacing.php',
+			// Context-aware content area vertical spacing.
 			'/inc/colors-palette.php',
 			// Colors palette CSS var emitter for the new top-level Colors section.
 			'/inc/color-palette-switcher.php',

--- a/inc/content-area-spacing.php
+++ b/inc/content-area-spacing.php
@@ -1,0 +1,346 @@
+<?php
+/**
+ * Context-aware content area vertical spacing.
+ *
+ * @package customify
+ */
+
+if ( ! function_exists( 'customify_get_content_area_spacing_choices' ) ) {
+	/**
+	 * Get the available content area spacing modes.
+	 *
+	 * @return array<string, string>
+	 */
+	function customify_get_content_area_spacing_choices() {
+		return array(
+			'inherit'  => __( 'Inherit', 'customify' ),
+			'both'     => __( 'Top & Bottom', 'customify' ),
+			'top'      => __( 'Top Only', 'customify' ),
+			'bottom'   => __( 'Bottom Only', 'customify' ),
+			'disabled' => __( 'Disabled', 'customify' ),
+		);
+	}
+}
+
+if ( ! function_exists( 'customify_get_content_area_spacing_archive_post_types' ) ) {
+	/**
+	 * Get content post types whose archives are owned by Customify.
+	 *
+	 * WooCommerce owns the Product archive through its existing shop-page
+	 * integration, so it intentionally continues to inherit the general archive
+	 * setting instead of receiving a dead per-CPT control.
+	 *
+	 * @return array<string, array{name:string, singular_name:string}>
+	 */
+	function customify_get_content_area_spacing_archive_post_types() {
+		$post_types = customify_get_content_post_types();
+
+		foreach ( array_keys( $post_types ) as $post_type ) {
+			$object = get_post_type_object( $post_type );
+			if ( 'product' === $post_type || ! $object || ! $object->has_archive ) {
+				unset( $post_types[ $post_type ] );
+			}
+		}
+
+		/**
+		 * Filter content post types that receive an archive spacing setting.
+		 *
+		 * @param array $post_types Map of post type slug to labels array.
+		 */
+		return apply_filters( 'customify/content_area_spacing/archive_post_types', $post_types );
+	}
+}
+
+if ( ! function_exists( 'customify_get_content_area_spacing_setting_name' ) ) {
+	/**
+	 * Map a request context to its Customizer setting name.
+	 *
+	 * @param array $context Content area spacing context.
+	 * @return string
+	 */
+	function customify_get_content_area_spacing_setting_name( $context ) {
+		$key       = isset( $context['key'] ) ? (string) $context['key'] : '';
+		$post_type = isset( $context['post_type'] ) && is_scalar( $context['post_type'] )
+			? sanitize_key( (string) $context['post_type'] )
+			: '';
+
+		switch ( $key ) {
+			case 'page':
+				return 'page_content_area_spacing';
+			case 'post':
+				return 'posts_content_area_spacing';
+			case 'blog_archive':
+				return 'posts_archives_content_area_spacing';
+			case 'search':
+				return 'search_content_area_spacing';
+			case '404':
+				return '404_content_area_spacing';
+			case 'post_type_single':
+				return $post_type ? $post_type . '_content_area_spacing' : '';
+			case 'post_type_archive':
+				return $post_type ? $post_type . '_archive_content_area_spacing' : '';
+			default:
+				return '';
+		}
+	}
+}
+
+if ( ! function_exists( 'customify_get_content_area_spacing_context' ) ) {
+	/**
+	 * Resolve the current request to a content area spacing context.
+	 *
+	 * @return array{key:string,post_type:string,post_id:int,singular:bool,setting:string}
+	 */
+	function customify_get_content_area_spacing_context() {
+		$context = array(
+			'key'       => 'none',
+			'post_type' => '',
+			'post_id'   => 0,
+			'singular'  => false,
+			'setting'   => '',
+		);
+
+		if ( is_search() ) {
+			$context['key'] = 'search';
+		} elseif ( is_404() ) {
+			$context['key'] = '404';
+		} elseif ( is_home() ) {
+			$context['key'] = 'blog_archive';
+		} elseif ( is_page() ) {
+			$context['key']       = 'page';
+			$context['post_type'] = 'page';
+			$context['post_id']   = (int) get_the_ID();
+			$context['singular']  = true;
+		} elseif ( is_singular( 'post' ) ) {
+			$context['key']       = 'post';
+			$context['post_type'] = 'post';
+			$context['post_id']   = (int) get_the_ID();
+			$context['singular']  = true;
+		} elseif ( is_post_type_archive() ) {
+			$post_type = get_query_var( 'post_type' );
+			if ( is_array( $post_type ) ) {
+				$post_type = 1 === count( $post_type ) ? reset( $post_type ) : '';
+			}
+			if ( ! $post_type ) {
+				$queried   = get_queried_object();
+				$post_type = ( $queried instanceof WP_Post_Type ) ? $queried->name : '';
+			}
+
+			$archive_post_types = customify_get_content_area_spacing_archive_post_types();
+			if ( $post_type && isset( $archive_post_types[ $post_type ] ) ) {
+				$context['key']       = 'post_type_archive';
+				$context['post_type'] = $post_type;
+			} else {
+				$context['key'] = 'blog_archive';
+			}
+		} elseif ( is_tax() ) {
+			$queried       = get_queried_object();
+			$taxonomy      = ( $queried instanceof WP_Term ) ? $queried->taxonomy : '';
+			$post_type     = $taxonomy ? customify_get_taxonomy_archive_post_type( $taxonomy ) : '';
+			$archive_types = customify_get_content_area_spacing_archive_post_types();
+
+			if ( $post_type && isset( $archive_types[ $post_type ] ) ) {
+				$context['key']       = 'post_type_archive';
+				$context['post_type'] = $post_type;
+			} else {
+				$context['key'] = 'blog_archive';
+			}
+		} elseif ( is_category() || is_tag() || is_archive() ) {
+			$context['key'] = 'blog_archive';
+		} elseif ( is_singular() ) {
+			$post_type     = get_post_type();
+			$content_types = customify_get_content_post_types();
+
+			$context['post_type'] = $post_type;
+			$context['post_id']   = (int) get_the_ID();
+			$context['singular']  = true;
+
+			if ( $post_type && isset( $content_types[ $post_type ] ) ) {
+				$context['key'] = 'post_type_single';
+			}
+		}
+
+		/**
+		 * Filter the content area spacing request context.
+		 *
+		 * Plugins with unusual front-end routes can supply a core context key and
+		 * post type, or provide a custom setting name directly.
+		 *
+		 * @param array $context Request context data.
+		 */
+		$context = apply_filters( 'customify/content_area_spacing/context', $context );
+		$context = is_array( $context ) ? $context : array();
+
+		$context = wp_parse_args(
+			$context,
+			array(
+				'key'       => 'none',
+				'post_type' => '',
+				'post_id'   => 0,
+				'singular'  => false,
+				'setting'   => '',
+			)
+		);
+
+		$context['key']       = is_scalar( $context['key'] ) ? sanitize_key( (string) $context['key'] ) : 'none';
+		$context['post_type'] = is_scalar( $context['post_type'] ) ? sanitize_key( (string) $context['post_type'] ) : '';
+		$context['post_id']   = is_scalar( $context['post_id'] ) ? absint( $context['post_id'] ) : 0;
+		$context['singular']  = (bool) $context['singular'];
+		$context['setting']   = is_scalar( $context['setting'] ) ? sanitize_key( (string) $context['setting'] ) : '';
+
+		if ( ! $context['setting'] ) {
+			$context['setting'] = customify_get_content_area_spacing_setting_name( $context );
+		}
+
+		return $context;
+	}
+}
+
+if ( ! function_exists( 'customify_sanitize_content_area_spacing_mode' ) ) {
+	/**
+	 * Sanitize a content area spacing mode.
+	 *
+	 * @param mixed $mode Candidate mode.
+	 * @return string
+	 */
+	function customify_sanitize_content_area_spacing_mode( $mode ) {
+		$mode    = is_string( $mode ) ? $mode : '';
+		$allowed = array( 'inherit', 'both', 'top', 'bottom', 'disabled' );
+
+		return in_array( $mode, $allowed, true ) ? $mode : 'inherit';
+	}
+}
+
+if ( ! function_exists( 'customify_content_area_spacing_has_legacy_disable' ) ) {
+	/**
+	 * Check the existing per-post disable flag for a singular context.
+	 *
+	 * @param array $context Content area spacing context.
+	 * @return bool
+	 */
+	function customify_content_area_spacing_has_legacy_disable( $context ) {
+		if ( empty( $context['singular'] ) || empty( $context['post_id'] ) ) {
+			return false;
+		}
+
+		$value = get_post_meta(
+			(int) $context['post_id'],
+			'_customify_disable_content_vertical_padding',
+			true
+		);
+		return '1' === (string) $value;
+	}
+}
+
+if ( ! function_exists( 'customify_resolve_content_area_spacing_mode' ) ) {
+	/**
+	 * Resolve the current content area spacing mode.
+	 *
+	 * The legacy singular post meta is an absolute override. All new settings
+	 * default to inherit, which preserves the existing global padding output.
+	 *
+	 * @param array|null $context Optional explicit context, primarily for integrations.
+	 * @return string
+	 */
+	function customify_resolve_content_area_spacing_mode( $context = null ) {
+		$context = is_array( $context ) ? $context : customify_get_content_area_spacing_context();
+
+		if ( customify_content_area_spacing_has_legacy_disable( $context ) ) {
+			return 'disabled';
+		}
+
+		$setting = isset( $context['setting'] ) && is_scalar( $context['setting'] )
+			? sanitize_key( (string) $context['setting'] )
+			: '';
+		if ( ! $setting ) {
+			$setting = customify_get_content_area_spacing_setting_name( $context );
+		}
+
+		$mode = $setting ? Customify()->get_setting( $setting ) : 'inherit';
+		$mode = customify_sanitize_content_area_spacing_mode( $mode );
+
+		/**
+		 * Filter the resolved content area spacing mode.
+		 *
+		 * The legacy per-post disable flag returns before this filter by design.
+		 *
+		 * @param string $mode    Resolved mode.
+		 * @param array  $context Request context data.
+		 * @param string $setting Customizer setting name, or an empty string.
+		 */
+		$mode = apply_filters( 'customify/content_area_spacing/mode', $mode, $context, $setting );
+
+		return customify_sanitize_content_area_spacing_mode( $mode );
+	}
+}
+
+if ( ! function_exists( 'customify_get_content_area_spacing_components' ) ) {
+	/**
+	 * Resolve whether the top and bottom spacing components are enabled.
+	 *
+	 * @param array|null $context Optional explicit context.
+	 * @return array{top:bool,bottom:bool}
+	 */
+	function customify_get_content_area_spacing_components( $context = null ) {
+		$context = is_array( $context ) ? $context : customify_get_content_area_spacing_context();
+		$legacy  = customify_content_area_spacing_has_legacy_disable( $context );
+		$mode    = $legacy ? 'disabled' : customify_resolve_content_area_spacing_mode( $context );
+
+		$components = array(
+			'top'    => in_array( $mode, array( 'inherit', 'both', 'top' ), true ),
+			'bottom' => in_array( $mode, array( 'inherit', 'both', 'bottom' ), true ),
+		);
+
+		if ( ! $legacy ) {
+			/**
+			 * Filter the enabled content area spacing components.
+			 *
+			 * @param array  $components Enabled top and bottom components.
+			 * @param string $mode       Resolved mode.
+			 * @param array  $context    Request context data.
+			 */
+			$components = apply_filters( 'customify/content_area_spacing/components', $components, $mode, $context );
+		}
+		$components = is_array( $components ) ? $components : array();
+
+		return array(
+			'top'    => ! empty( $components['top'] ),
+			'bottom' => ! empty( $components['bottom'] ),
+		);
+	}
+}
+
+if ( ! function_exists( 'customify_get_content_area_spacing_body_classes' ) ) {
+	/**
+	 * Get body classes required by the resolved spacing components.
+	 *
+	 * @param array|null $context Optional explicit context.
+	 * @return string[]
+	 */
+	function customify_get_content_area_spacing_body_classes( $context = null ) {
+		$context    = is_array( $context ) ? $context : customify_get_content_area_spacing_context();
+		$components = customify_get_content_area_spacing_components( $context );
+		$classes    = array();
+
+		if ( ! $components['top'] && ! $components['bottom'] ) {
+			$classes[] = 'disable-content-vertical-padding';
+		} elseif ( $components['top'] && ! $components['bottom'] ) {
+			$classes[] = 'content-area-spacing-top-only';
+		} elseif ( ! $components['top'] && $components['bottom'] ) {
+			$classes[] = 'content-area-spacing-bottom-only';
+		}
+
+		/**
+		 * Filter content area spacing body classes.
+		 *
+		 * @param string[] $classes    Spacing body classes.
+		 * @param array    $components Enabled top and bottom components.
+		 * @param array    $context    Request context data.
+		 */
+		$classes = apply_filters( 'customify/content_area_spacing/body_classes', $classes, $components, $context );
+
+		return is_array( $classes )
+			? array_values( array_filter( array_map( 'sanitize_html_class', $classes ) ) )
+			: array();
+	}
+}

--- a/inc/content-area-spacing.php
+++ b/inc/content-area-spacing.php
@@ -27,8 +27,7 @@ if ( ! function_exists( 'customify_get_content_area_spacing_archive_post_types' 
 	 * Get content post types whose archives are owned by Customify.
 	 *
 	 * WooCommerce owns the Product archive through its existing shop-page
-	 * integration, so it intentionally continues to inherit the general archive
-	 * setting instead of receiving a dead per-CPT control.
+	 * integration, so it intentionally receives no per-CPT control here.
 	 *
 	 * @return array<string, array{name:string, singular_name:string}>
 	 */
@@ -48,6 +47,31 @@ if ( ! function_exists( 'customify_get_content_area_spacing_archive_post_types' 
 		 * @param array $post_types Map of post type slug to labels array.
 		 */
 		return apply_filters( 'customify/content_area_spacing/archive_post_types', $post_types );
+	}
+}
+
+if ( ! function_exists( 'customify_content_area_spacing_archive_owned_elsewhere' ) ) {
+	/**
+	 * Check whether a content CPT archive was excluded from Customify ownership.
+	 *
+	 * Removing a real archive from the filtered archive list is the generic
+	 * product seam for integrations that own that request context themselves.
+	 *
+	 * @param string     $post_type         Post type slug.
+	 * @param array|null $archive_post_types Optional resolved archive list.
+	 * @return bool
+	 */
+	function customify_content_area_spacing_archive_owned_elsewhere( $post_type, $archive_post_types = null ) {
+		$content_post_types = customify_get_content_post_types();
+		$archive_post_types = is_array( $archive_post_types )
+			? $archive_post_types
+			: customify_get_content_area_spacing_archive_post_types();
+		$object             = get_post_type_object( $post_type );
+
+		return isset( $content_post_types[ $post_type ] )
+			&& $object
+			&& $object->has_archive
+			&& ! isset( $archive_post_types[ $post_type ] );
 	}
 }
 
@@ -130,6 +154,10 @@ if ( ! function_exists( 'customify_get_content_area_spacing_context' ) ) {
 			if ( $post_type && isset( $archive_post_types[ $post_type ] ) ) {
 				$context['key']       = 'post_type_archive';
 				$context['post_type'] = $post_type;
+			} elseif ( customify_content_area_spacing_archive_owned_elsewhere( $post_type, $archive_post_types ) ) {
+				// Leave the context setting empty for archives owned by an
+				// established integration such as WooCommerce's Shop.
+				$context['post_type'] = $post_type;
 			} else {
 				$context['key'] = 'blog_archive';
 			}
@@ -143,7 +171,19 @@ if ( ! function_exists( 'customify_get_content_area_spacing_context' ) ) {
 				$context['key']       = 'post_type_archive';
 				$context['post_type'] = $post_type;
 			} else {
-				$context['key'] = 'blog_archive';
+				$taxonomy_object = $taxonomy ? get_taxonomy( $taxonomy ) : false;
+				$object_types    = $taxonomy_object
+					? array_values( array_unique( array_filter( (array) $taxonomy_object->object_type ) ) )
+					: array();
+				$sole_post_type  = 1 === count( $object_types ) ? reset( $object_types ) : '';
+
+				if ( customify_content_area_spacing_archive_owned_elsewhere( $sole_post_type, $archive_types ) ) {
+					// A taxonomy owned by an externally managed CPT archive keeps
+					// the untouched global spacing unless that integration opts in.
+					$context['post_type'] = $sole_post_type;
+				} else {
+					$context['key'] = 'blog_archive';
+				}
 			}
 		} elseif ( is_category() || is_tag() || is_archive() ) {
 			$context['key'] = 'blog_archive';

--- a/inc/customizer/configs/layouts.php
+++ b/inc/customizer/configs/layouts.php
@@ -29,6 +29,15 @@ if ( ! function_exists( 'customify_customizer_layouts_config' ) ) {
 				'theme_supports' => '',
 				'title'          => __( 'Global', 'customify' ),
 			),
+
+			// Content area spacing section.
+			array(
+				'name'           => 'content_area_spacing_section',
+				'type'           => 'section',
+				'panel'          => 'layout_panel',
+				'theme_supports' => '',
+				'title'          => __( 'Content Area Spacing', 'customify' ),
+			),
 			array(
 				'name'        => 'site_layout',
 				'type'        => 'radio_group',
@@ -171,9 +180,16 @@ if ( ! function_exists( 'customify_customizer_layouts_config' ) ) {
 			),
 
 			array(
+				'name'    => 'content_area_spacing_h_general',
+				'type'    => 'heading',
+				'section' => 'content_area_spacing_section',
+				'title'   => __( 'General', 'customify' ),
+			),
+
+			array(
 				'name'            => 'site_content_padding',
 				'type'            => 'css_ruler',
-				'section'         => 'global_layout_section',
+				'section'         => 'content_area_spacing_section',
 				'title'           => __( 'Site content padding', 'customify' ),
 				'device_settings' => true,
 				'fields_disabled' => array(
@@ -185,6 +201,47 @@ if ( ! function_exists( 'customify_customizer_layouts_config' ) ) {
 					'bottom' => 'padding-bottom: {{value}};',
 				),
 				'selector'        => '#sidebar-secondary, #sidebar-primary, #main',
+			),
+
+			array(
+				'name'    => 'page_content_area_spacing',
+				'type'    => 'select',
+				'default' => 'inherit',
+				'section' => 'content_area_spacing_section',
+				'title'   => __( 'Pages', 'customify' ),
+				'choices' => customify_get_content_area_spacing_choices(),
+			),
+			array(
+				'name'    => 'posts_content_area_spacing',
+				'type'    => 'select',
+				'default' => 'inherit',
+				'section' => 'content_area_spacing_section',
+				'title'   => __( 'Blog Posts', 'customify' ),
+				'choices' => customify_get_content_area_spacing_choices(),
+			),
+			array(
+				'name'    => 'posts_archives_content_area_spacing',
+				'type'    => 'select',
+				'default' => 'inherit',
+				'section' => 'content_area_spacing_section',
+				'title'   => __( 'Blog Archives', 'customify' ),
+				'choices' => customify_get_content_area_spacing_choices(),
+			),
+			array(
+				'name'    => 'search_content_area_spacing',
+				'type'    => 'select',
+				'default' => 'inherit',
+				'section' => 'content_area_spacing_section',
+				'title'   => __( 'Search', 'customify' ),
+				'choices' => customify_get_content_area_spacing_choices(),
+			),
+			array(
+				'name'    => '404_content_area_spacing',
+				'type'    => 'select',
+				'default' => 'inherit',
+				'section' => 'content_area_spacing_section',
+				'title'   => __( '404', 'customify' ),
+				'choices' => customify_get_content_area_spacing_choices(),
 			),
 
 			// Page layout.
@@ -288,9 +345,41 @@ if ( ! function_exists( 'customify_customizer_layouts_config' ) ) {
 			),
 		);
 
-		$post_types = customify_get_content_post_types();
+		$post_types                 = customify_get_content_post_types();
+		$archive_spacing_post_types = customify_get_content_area_spacing_archive_post_types();
 
 		if ( count( $post_types ) ) {
+			$config[] = array(
+				'name'    => 'content_area_spacing_h_post_types',
+				'type'    => 'heading',
+				'section' => 'content_area_spacing_section',
+				'title'   => __( 'Post Type Settings', 'customify' ),
+			);
+
+			foreach ( $post_types as $pt => $label ) {
+				$config[] = array(
+					'name'    => "{$pt}_content_area_spacing",
+					'type'    => 'select',
+					'default' => 'inherit',
+					'section' => 'content_area_spacing_section',
+					/* translators: %s: singular post type label. */
+					'title'   => sprintf( __( 'Single %s', 'customify' ), $label['singular_name'] ),
+					'choices' => customify_get_content_area_spacing_choices(),
+				);
+
+				if ( isset( $archive_spacing_post_types[ $pt ] ) ) {
+					$config[] = array(
+						'name'    => "{$pt}_archive_content_area_spacing",
+						'type'    => 'select',
+						'default' => 'inherit',
+						'section' => 'content_area_spacing_section',
+						/* translators: %s: singular post type label. */
+						'title'   => sprintf( __( '%s Archive', 'customify' ), $label['singular_name'] ),
+						'choices' => customify_get_content_area_spacing_choices(),
+					);
+				}
+			}
+
 			$config[] = array(
 				'name'    => 'post_types_sidebar_h_tb',
 				'type'    => 'heading',

--- a/inc/element-classes.php
+++ b/inc/element-classes.php
@@ -63,16 +63,12 @@ if ( ! function_exists( 'customify_body_classes' ) ) {
 			}
 		}
 
-		// Per-page opt-in to strip the default vertical padding around
-		// #main / #sidebar-primary / #sidebar-secondary. Designed for
-		// landing pages that build with full-bleed sections — the
-		// theme's reading-room padding produces dead bands between the
-		// header and the first section otherwise. Default behavior
-		// (padding on) preserved for content pages.
-		if ( is_singular() ) {
-			$disable_padding = get_post_meta( get_the_ID(), '_customify_disable_content_vertical_padding', true );
-			if ( '1' === (string) $disable_padding ) {
-				$classes[] = 'disable-content-vertical-padding';
+		// Context settings default to inherit, so sites that have not opted in
+		// receive no new body class. The resolver also preserves the existing
+		// singular per-post disable flag as the highest-priority override.
+		foreach ( customify_get_content_area_spacing_body_classes() as $spacing_class ) {
+			if ( ! in_array( $spacing_class, $classes, true ) ) {
+				$classes[] = $spacing_class;
 			}
 		}
 

--- a/languages/customify.pot
+++ b/languages/customify.pot
@@ -4170,3 +4170,31 @@ msgstr[1] ""
 msgctxt "submit button"
 msgid "Search"
 msgstr ""
+
+#: inc/customizer/configs/layouts.php:243
+msgid "404"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:39
+msgid "Content Area Spacing"
+msgstr ""
+
+#: inc/content-area-spacing.php:17
+msgid "Top & Bottom"
+msgstr ""
+
+#: inc/content-area-spacing.php:18
+msgid "Top Only"
+msgstr ""
+
+#: inc/content-area-spacing.php:19
+msgid "Bottom Only"
+msgstr ""
+
+#: inc/content-area-spacing.php:20
+msgid "Disabled"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:227
+msgid "Blog Archives"
+msgstr ""

--- a/src/frontend/scss/layouts/_layouts.scss
+++ b/src/frontend/scss/layouts/_layouts.scss
@@ -138,6 +138,18 @@ body.disable-content-vertical-padding {
     }
 }
 
+body.content-area-spacing-top-only {
+    #sidebar-secondary, #sidebar-primary, #main {
+        padding-bottom: 0;
+    }
+}
+
+body.content-area-spacing-bottom-only {
+    #sidebar-secondary, #sidebar-primary, #main {
+        padding-top: 0;
+    }
+}
+
 
 .sidebar-content-sidebar {
     #main {
@@ -293,5 +305,4 @@ body.disable-content-vertical-padding {
         display: inline-block;
     }
 }
-
 

--- a/tests/content-area-spacing-test.php
+++ b/tests/content-area-spacing-test.php
@@ -1,0 +1,360 @@
+<?php
+/**
+ * Focused runtime tests for the content area spacing resolver.
+ *
+ * Run with: php tests/content-area-spacing-test.php
+ */
+
+class WP_Post_Type {
+	public $name;
+	public $has_archive;
+
+	public function __construct( $name, $has_archive ) {
+		$this->name        = $name;
+		$this->has_archive = $has_archive;
+	}
+}
+
+class WP_Term {
+	public $taxonomy;
+
+	public function __construct( $taxonomy ) {
+		$this->taxonomy = $taxonomy;
+	}
+}
+
+$GLOBALS['customify_test_request'] = array();
+$GLOBALS['customify_test_mods']    = array();
+$GLOBALS['customify_test_meta']    = array();
+$GLOBALS['customify_test_types']   = array(
+	'book'    => new WP_Post_Type( 'book', true ),
+	'profile' => new WP_Post_Type( 'profile', false ),
+	'product' => new WP_Post_Type( 'product', true ),
+);
+$GLOBALS['customify_test_taxonomies'] = array(
+	'book_genre' => array( 'book' ),
+	'shared'     => array( 'book', 'post' ),
+);
+
+function __( $text ) {
+	return $text;
+}
+
+function apply_filters( $hook, $value ) {
+	return $value;
+}
+
+function sanitize_key( $value ) {
+	return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $value ) );
+}
+
+function sanitize_html_class( $value ) {
+	return preg_replace( '/[^A-Za-z0-9_\-]/', '', (string) $value );
+}
+
+function absint( $value ) {
+	return abs( (int) $value );
+}
+
+function wp_parse_args( $args, $defaults ) {
+	return array_merge( $defaults, $args );
+}
+
+function customify_test_flag( $name ) {
+	return ! empty( $GLOBALS['customify_test_request'][ $name ] );
+}
+
+function is_search() {
+	return customify_test_flag( 'search' );
+}
+
+function is_404() {
+	return customify_test_flag( '404' );
+}
+
+function is_home() {
+	return customify_test_flag( 'home' );
+}
+
+function is_page() {
+	return customify_test_flag( 'page' );
+}
+
+function is_singular( $post_type = '' ) {
+	if ( ! customify_test_flag( 'singular' ) ) {
+		return false;
+	}
+
+	return ! $post_type || $post_type === get_post_type();
+}
+
+function is_post_type_archive() {
+	return customify_test_flag( 'post_type_archive' );
+}
+
+function is_tax() {
+	return customify_test_flag( 'tax' );
+}
+
+function is_category() {
+	return customify_test_flag( 'category' );
+}
+
+function is_tag() {
+	return customify_test_flag( 'tag' );
+}
+
+function is_archive() {
+	return customify_test_flag( 'archive' );
+}
+
+function get_the_ID() {
+	return isset( $GLOBALS['customify_test_request']['post_id'] ) ? $GLOBALS['customify_test_request']['post_id'] : 0;
+}
+
+function get_post_type() {
+	return isset( $GLOBALS['customify_test_request']['post_type'] ) ? $GLOBALS['customify_test_request']['post_type'] : '';
+}
+
+function get_query_var( $key ) {
+	return isset( $GLOBALS['customify_test_request'][ $key ] ) ? $GLOBALS['customify_test_request'][ $key ] : '';
+}
+
+function get_queried_object() {
+	return isset( $GLOBALS['customify_test_request']['queried_object'] ) ? $GLOBALS['customify_test_request']['queried_object'] : null;
+}
+
+function get_post_type_object( $post_type ) {
+	return isset( $GLOBALS['customify_test_types'][ $post_type ] ) ? $GLOBALS['customify_test_types'][ $post_type ] : null;
+}
+
+function get_post_meta( $post_id, $key ) {
+	return isset( $GLOBALS['customify_test_meta'][ $post_id ][ $key ] ) ? $GLOBALS['customify_test_meta'][ $post_id ][ $key ] : '';
+}
+
+function customify_get_content_post_types() {
+	return array(
+		'book'    => array(
+			'name'          => 'Books',
+			'singular_name' => 'Book',
+		),
+		'profile' => array(
+			'name'          => 'Profiles',
+			'singular_name' => 'Profile',
+		),
+		'product' => array(
+			'name'          => 'Products',
+			'singular_name' => 'Product',
+		),
+	);
+}
+
+function customify_get_taxonomy_archive_post_type( $taxonomy ) {
+	$object_types = isset( $GLOBALS['customify_test_taxonomies'][ $taxonomy ] )
+		? $GLOBALS['customify_test_taxonomies'][ $taxonomy ]
+		: array();
+
+	if ( 1 !== count( $object_types ) ) {
+		return '';
+	}
+
+	$post_type = reset( $object_types );
+	$object    = get_post_type_object( $post_type );
+	return 'product' !== $post_type && $object && $object->has_archive ? $post_type : '';
+}
+
+class Customify_Content_Area_Spacing_Test_Theme {
+	public function get_setting( $setting ) {
+		return isset( $GLOBALS['customify_test_mods'][ $setting ] )
+			? $GLOBALS['customify_test_mods'][ $setting ]
+			: 'inherit';
+	}
+}
+
+function Customify() {
+	static $theme;
+	if ( ! $theme ) {
+		$theme = new Customify_Content_Area_Spacing_Test_Theme();
+	}
+	return $theme;
+}
+
+require dirname( __DIR__ ) . '/inc/content-area-spacing.php';
+
+function customify_test_reset( $request, $mods = array(), $meta = array() ) {
+	$GLOBALS['customify_test_request'] = $request;
+	$GLOBALS['customify_test_mods']    = $mods;
+	$GLOBALS['customify_test_meta']    = $meta;
+}
+
+function customify_test_assert_same( $expected, $actual, $message ) {
+	if ( $expected !== $actual ) {
+		fwrite(
+			STDERR,
+			$message . "\nExpected: " . var_export( $expected, true ) . "\nActual: " . var_export( $actual, true ) . "\n"
+		);
+		exit( 1 );
+	}
+}
+
+customify_test_reset(
+	array(
+		'page'      => true,
+		'singular'  => true,
+		'post_type' => 'page',
+		'post_id'   => 11,
+	)
+);
+$context = customify_get_content_area_spacing_context();
+customify_test_assert_same( 'page_content_area_spacing', $context['setting'], 'Pages resolve to the page setting.' );
+customify_test_assert_same( 'inherit', customify_resolve_content_area_spacing_mode( $context ), 'Unsaved page settings inherit.' );
+customify_test_assert_same( array(), customify_get_content_area_spacing_body_classes( $context ), 'Unsaved settings add no body class.' );
+
+customify_test_reset(
+	array(
+		'singular'  => true,
+		'post_type' => 'post',
+		'post_id'   => 12,
+	),
+	array( 'posts_content_area_spacing' => 'top' )
+);
+$context = customify_get_content_area_spacing_context();
+customify_test_assert_same( 'post', $context['key'], 'Blog posts resolve to the post context.' );
+customify_test_assert_same( array( 'content-area-spacing-top-only' ), customify_get_content_area_spacing_body_classes( $context ), 'Top-only suppresses bottom spacing.' );
+
+customify_test_reset( array( 'home' => true ) );
+$context = customify_get_content_area_spacing_context();
+customify_test_assert_same( 'posts_archives_content_area_spacing', $context['setting'], 'The blog home resolves to Blog Archives.' );
+
+customify_test_reset(
+	array(
+		'singular'  => true,
+		'post_type' => 'book',
+		'post_id'   => 13,
+	),
+	array( 'book_content_area_spacing' => 'bottom' )
+);
+$context = customify_get_content_area_spacing_context();
+customify_test_assert_same( 'book_content_area_spacing', $context['setting'], 'CPT singles resolve dynamically.' );
+customify_test_assert_same( array( 'content-area-spacing-bottom-only' ), customify_get_content_area_spacing_body_classes( $context ), 'Bottom-only suppresses top spacing.' );
+
+customify_test_reset(
+	array(
+		'post_type_archive' => true,
+		'post_type'         => 'book',
+	),
+	array( 'book_archive_content_area_spacing' => 'disabled' )
+);
+$context = customify_get_content_area_spacing_context();
+customify_test_assert_same( 'book_archive_content_area_spacing', $context['setting'], 'CPT archives resolve dynamically.' );
+customify_test_assert_same( array( 'disable-content-vertical-padding' ), customify_get_content_area_spacing_body_classes( $context ), 'Disabled reuses the legacy body class.' );
+
+customify_test_reset(
+	array(
+		'post_type_archive' => true,
+		'post_type'         => 'product',
+	)
+);
+$context = customify_get_content_area_spacing_context();
+customify_test_assert_same( 'posts_archives_content_area_spacing', $context['setting'], 'The WooCommerce-owned archive keeps the general archive fallback.' );
+
+customify_test_reset(
+	array(
+		'tax'            => true,
+		'queried_object' => new WP_Term( 'book_genre' ),
+	)
+);
+$context = customify_get_content_area_spacing_context();
+customify_test_assert_same( 'book_archive_content_area_spacing', $context['setting'], 'A taxonomy owned by one CPT inherits its archive.' );
+
+customify_test_reset(
+	array(
+		'tax'            => true,
+		'queried_object' => new WP_Term( 'shared' ),
+	)
+);
+$context = customify_get_content_area_spacing_context();
+customify_test_assert_same( 'posts_archives_content_area_spacing', $context['setting'], 'Shared taxonomies fall back to blog archives.' );
+
+customify_test_reset( array( 'search' => true ), array( 'search_content_area_spacing' => 'disabled' ) );
+$context = customify_get_content_area_spacing_context();
+customify_test_assert_same( 'search_content_area_spacing', $context['setting'], 'Search resolves to its own setting.' );
+
+customify_test_reset( array( '404' => true ), array( '404_content_area_spacing' => 'top' ) );
+$context = customify_get_content_area_spacing_context();
+customify_test_assert_same( '404_content_area_spacing', $context['setting'], '404 resolves to its own setting.' );
+
+customify_test_reset(
+	array(
+		'singular'  => true,
+		'post_type' => 'book',
+		'post_id'   => 14,
+	),
+	array( 'book_content_area_spacing' => 'both' ),
+	array(
+		14 => array( '_customify_disable_content_vertical_padding' => '1' ),
+	)
+);
+$context = customify_get_content_area_spacing_context();
+customify_test_assert_same( 'disabled', customify_resolve_content_area_spacing_mode( $context ), 'Legacy meta wins over a context setting.' );
+customify_test_assert_same( array( 'disable-content-vertical-padding' ), customify_get_content_area_spacing_body_classes( $context ), 'Legacy meta keeps its existing body class.' );
+
+customify_test_reset(
+	array(
+		'singular'  => true,
+		'post_type' => 'utility',
+		'post_id'   => 15,
+	),
+	array(),
+	array(
+		15 => array( '_customify_disable_content_vertical_padding' => '1' ),
+	)
+);
+$context = customify_get_content_area_spacing_context();
+customify_test_assert_same( 'none', $context['key'], 'Unsupported singular types do not receive a context setting.' );
+customify_test_assert_same( array( 'disable-content-vertical-padding' ), customify_get_content_area_spacing_body_classes( $context ), 'Legacy meta remains effective on unsupported singular types.' );
+
+$inherit_requests = array(
+	'page'           => array(
+		'page'      => true,
+		'singular'  => true,
+		'post_type' => 'page',
+		'post_id'   => 21,
+	),
+	'blog post'      => array(
+		'singular'  => true,
+		'post_type' => 'post',
+		'post_id'   => 22,
+	),
+	'blog home'      => array( 'home' => true ),
+	'CPT single'     => array(
+		'singular'  => true,
+		'post_type' => 'book',
+		'post_id'   => 23,
+	),
+	'CPT archive'    => array(
+		'post_type_archive' => true,
+		'post_type'         => 'book',
+	),
+	'owned taxonomy' => array(
+		'tax'            => true,
+		'queried_object' => new WP_Term( 'book_genre' ),
+	),
+	'shared taxonomy' => array(
+		'tax'            => true,
+		'queried_object' => new WP_Term( 'shared' ),
+	),
+	'search'          => array( 'search' => true ),
+	'404'             => array( '404' => true ),
+);
+
+foreach ( $inherit_requests as $label => $request ) {
+	customify_test_reset( $request );
+	customify_test_assert_same(
+		array(),
+		customify_get_content_area_spacing_body_classes(),
+		'Unsaved inherit adds no body class for ' . $label . '.'
+	);
+}
+
+echo "Content area spacing tests passed.\n";

--- a/tests/content-area-spacing-test.php
+++ b/tests/content-area-spacing-test.php
@@ -32,8 +32,9 @@ $GLOBALS['customify_test_types']   = array(
 	'product' => new WP_Post_Type( 'product', true ),
 );
 $GLOBALS['customify_test_taxonomies'] = array(
-	'book_genre' => array( 'book' ),
-	'shared'     => array( 'book', 'post' ),
+	'book_genre'  => array( 'book' ),
+	'product_cat' => array( 'product' ),
+	'shared'      => array( 'book', 'post' ),
 );
 
 function __( $text ) {
@@ -126,6 +127,14 @@ function get_queried_object() {
 
 function get_post_type_object( $post_type ) {
 	return isset( $GLOBALS['customify_test_types'][ $post_type ] ) ? $GLOBALS['customify_test_types'][ $post_type ] : null;
+}
+
+function get_taxonomy( $taxonomy ) {
+	if ( ! isset( $GLOBALS['customify_test_taxonomies'][ $taxonomy ] ) ) {
+		return false;
+	}
+
+	return (object) array( 'object_type' => $GLOBALS['customify_test_taxonomies'][ $taxonomy ] );
 }
 
 function get_post_meta( $post_id, $key ) {
@@ -253,10 +262,25 @@ customify_test_reset(
 	array(
 		'post_type_archive' => true,
 		'post_type'         => 'product',
-	)
+	),
+	array( 'posts_archives_content_area_spacing' => 'disabled' )
 );
 $context = customify_get_content_area_spacing_context();
-customify_test_assert_same( 'posts_archives_content_area_spacing', $context['setting'], 'The WooCommerce-owned archive keeps the general archive fallback.' );
+customify_test_assert_same( 'none', $context['key'], 'The WooCommerce-owned archive has no Customify spacing context.' );
+customify_test_assert_same( '', $context['setting'], 'The WooCommerce-owned archive does not read Blog Archives.' );
+customify_test_assert_same( array(), customify_get_content_area_spacing_body_classes( $context ), 'Disabling Blog Archives does not change Shop spacing.' );
+
+customify_test_reset(
+	array(
+		'tax'            => true,
+		'queried_object' => new WP_Term( 'product_cat' ),
+	),
+	array( 'posts_archives_content_area_spacing' => 'disabled' )
+);
+$context = customify_get_content_area_spacing_context();
+customify_test_assert_same( 'none', $context['key'], 'A product-only taxonomy has no Customify spacing context.' );
+customify_test_assert_same( '', $context['setting'], 'A product-only taxonomy does not read Blog Archives.' );
+customify_test_assert_same( array(), customify_get_content_area_spacing_body_classes( $context ), 'Disabling Blog Archives does not change product taxonomy spacing.' );
 
 customify_test_reset(
 	array(


### PR DESCRIPTION
## Summary

- move the existing `site_content_padding` control into a dedicated Layouts > Content Area Spacing section without changing its ID or CSS output
- add inherit-first spacing modes for built-in request contexts and dynamically discovered public content CPT singles/archives
- resolve CPT taxonomies, legacy singular meta precedence, and WooCommerce-owned Product archives at the theme product level
- add stable body classes, focused resolver coverage, public filter docs, storage registry updates, and POT strings

## Backward compatibility

- every new theme mod defaults to `inherit`
- unsaved contexts add no body class and retain the existing global top/bottom padding output
- `_customify_disable_content_vertical_padding=1` remains the highest-priority override and reuses `disable-content-vertical-padding`
- no Blocksify or builder-specific coupling

## Verification

- `php tests/content-area-spacing-test.php` — pass
- PHP lint over all repository PHP files — pass
- WordPress-Core PHPCS (runtime files, warnings excluded as CI does) — pass
- `npm run build` — pass; existing webpack asset-size warnings only
- `npm run makepot` — pass; POT updated minimally to avoid unrelated generator churn
- `npm run lint:js` — baseline failure: 9,429 errors in untouched JS files
- `composer validate --strict` — baseline exit 2: existing stale lockfile and wildcard Dashboard Kit constraint
