### PR TITLE
fix(footer): remove noisy per-item dividers on footer widget menus

### DIFF
--- a/src/frontend/scss/footer/_footer-common.scss
+++ b/src/frontend/scss/footer/_footer-common.scss
@@ -179,6 +179,49 @@
 	}
 }
 
+// Footer widget lists read as clean, spaced links — not a divider stack.
+// The generic widget-area rule (widgets/_widgets.scss) draws a border-bottom
+// hairline under every list item, and its `:last-child { border: none }` reset
+// is ineffective here because it targets the <li> while the border lives on the
+// <a> — so even the last link keeps a trailing line. In a short, curated footer
+// column that repeated hairline reads as noise (and gets worse when a site has
+// set a non-faint Border palette color, which feeds $color_border). Drop the
+// dividers in the footer, along with the 0.6em bottom padding that only existed
+// to clear that line. Sidebar widget lists intentionally keep their dividers —
+// they aid scanning of long category/archive lists in a narrow column.
+.site-footer .widget-area {
+	.widget_pages li a,
+	.widget_categories li a,
+	.widget_archive li a,
+	.widget_meta li a,
+	.widget_nav_menu li a,
+	.widget_product_categories li a,
+	.widget_recent_entries li a,
+	.widget_rss li a {
+		padding-bottom: 0;
+		border-bottom: 0;
+	}
+
+	.widget_recent_comments li {
+		border-bottom: 0;
+	}
+
+	// Once the divider and its clearance padding are gone, the leftover 0.6em
+	// li-margin plus that padding used to stack to ~1.2em between links, which
+	// read as too tall/airy for a footer nav. Collapse it to a single ~0.75em
+	// gap so each column reads as one grouped set of links. .widget_rss is left
+	// out — its entries carry a title + date and keep their own larger rhythm.
+	.widget_pages li,
+	.widget_categories li,
+	.widget_archive li,
+	.widget_meta li,
+	.widget_nav_menu li,
+	.widget_product_categories li,
+	.widget_recent_entries li {
+		margin-bottom: 0.75em;
+	}
+}
+
 .footer-copyright {
 	font-size: 0.875em;
 }


### PR DESCRIPTION
## Problem

Footer nav-menu / list widgets draw a `border-bottom` hairline under **every** item — including the last one, because the generic `.widget-area` `:last-child { border: none }` reset targets the `<li>` while the border actually lives on the `<a>`. In a short, curated footer column (e.g. Overview / Need Help? / Info) that stack of hairlines reads as visual **noise**, and it gets worse when a site sets a non-faint **Border** palette color (which feeds `$color_border`).

There is no Customizer control for this divider — it's baked into `widgets/_widgets.scss` — so a scoped CSS fix is the right lever.

## Fix

Scoped to `.site-footer .widget-area` only (sidebar/header widgets untouched):

1. **Drop the divider** on footer list-widget items (`border-bottom: 0`).
2. **Drop the vestigial `padding-bottom: 0.6em`** that only existed to clear that line.
3. **Tighten spacing**: with the divider + clearance padding gone, the leftover `0.6em` li-margin + `0.6em` padding stacked to ~1.2em (~19px) between links, which read as too tall/airy. Collapsed to a single **`0.75em`** (~12px) gap so each column reads as one grouped set of links.

Sidebar widget lists **keep** their dividers (they aid scanning of long category/archive lists in a narrow column). `.widget_rss` is excluded from the tighten — its entries carry a title + date and keep their own larger rhythm.

## Before / After

| | Before | After |
|---|---|---|
| Divider under each item | yes (incl. last item) | none |
| `a` padding-bottom | 0.6em (vestigial) | 0 |
| Inter-item gap | ~19px | ~12px (`0.75em`) |

Verified on a local Customify site (default Customizer + custom skins) with a footer built from three nav-menu columns; rendered from the real webpack build. Change is CSS-only, scoped to the footer, no storage/selector renames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)