### PR TITLE
fix(customizer): widget edit-shortcut opens force-hidden footer/header widget areas

### DIFF
--- a/src/backend/customizer/js/customizer.js
+++ b/src/backend/customizer/js/customizer.js
@@ -327,6 +327,46 @@
 					}, 350);
 					return;
 				}
+			} else {
+				// No instantiated control matched. This is the common case for a
+				// widget partial (e.g. widget[nav_menu-2]): WP creates widget form
+				// controls lazily, and the footer/header sidebar section that holds
+				// them is force-hidden — so control.each above finds nothing and
+				// the pencil would silently no-op (the widget-title edit shortcut
+				// "does nothing" while the sibling nav_menu_instance shortcut still
+				// opens the Menus panel). Derive the containing sidebar section from
+				// the widget→sidebar map and open it via the builder, then scroll to
+				// that section's widgets-area control.
+				var widgetMatch = /^widget_(.+)\[(\d+)\]$/.exec(settingId);
+				if (widgetMatch) {
+					var widgetId = widgetMatch[1] + "-" + widgetMatch[2];
+					var sidebarId;
+					parentWin.wp.customize.each(function(setting) {
+						if (sidebarId) return;
+						var sidebarMatch = /^sidebars_widgets\[(.+)\]$/.exec(setting.id);
+						if (
+							sidebarMatch &&
+							Array.isArray(setting.get()) &&
+							setting.get().indexOf(widgetId) !== -1
+						) {
+							sidebarId = sidebarMatch[1];
+						}
+					});
+					var sbSectionId = sidebarId ? "sidebar-widgets-" + sidebarId : null;
+					var sbSection   = sbSectionId && parentWin.wp.customize.section(sbSectionId);
+					if (sbSection && sbSection._customifyForceHide) {
+						parentWin.customifyBuilderOpenSection(sbSectionId);
+						setTimeout(function() {
+							var wc = parentWin.wp.customize.control(
+								"sidebars_widgets[" + sidebarId + "]"
+							);
+							if (wc && typeof wc.focus === "function") {
+								wc.focus();
+							}
+						}, 350);
+						return;
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
## Problem

In the Customizer preview, clicking the pencil **edit-shortcut on a footer (or header) nav-menu widget's title** did nothing — a dead click — while the sibling `nav_menu_instance` shortcut on the first menu item still opened the Menus panel. Reported during footer review; **preview-only, not on the live site.**

## Root cause (confirmed live)

The footer/header widget sidebar sections (`sidebar-widgets-*`) are **force-hidden** by the layout builder (`_customifyForceHide`) so they only surface via the builder gear icon. WP creates widget **form controls lazily** — so for a hidden, never-expanded section the control (`widget_nav_menu[N]`) doesn't exist yet. The theme's existing `showControl` override maps a partial → section by scanning `wp.customize.control`, finds no instantiated control, and falls through to WP's default path, which then tries to focus a control that doesn't exist → silent no-op.

Verified in a live Customizer session: `wp.customize.control('widget_nav_menu[2]') === undefined`, section `sidebar-widgets-footer-1` has `_customifyForceHide === true`.

## Fix

In the `showControl` override, add a fallback for when no control matches: if the partial's setting is a widget (`widget_<base>[<n>]`), derive the widget's sidebar from the `sidebars_widgets[*]` settings map, and if that section is force-hidden, route through `customifyBuilderOpenSection(sectionId)` + focus the section's widgets-area control — **the same path the builder's own gear icon uses.**

- Non-widget partials → unchanged (fall through to default).
- Widgets in normal, non-hidden sidebars → unchanged (fall through to default).
- Works for header widget areas too, not just footer.

## Verification

Live Customizer, patched bundle deployed: a clean `widget[nav_menu-3]` (force-hidden, collapsed, inactive) → after `showControl()` the `sidebar-widgets-footer-2` section is **expanded + active**, landing on the widget area — matching the builder gear behavior. Breadcrumb confirms "Customizing ▸ Footer ▸ Footer Sidebar 2".

🤖 Generated with [Claude Code](https://claude.com/claude-code)