### PR TITLE
chore(release): bump version to 0.4.22 + changelog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,19 @@
+= 0.4.22 =
+* NEW: Native off-canvas cart drawer for the WooCommerce header cart item.
+* NEW: Contextual Content Area Spacing — per-context top/bottom content padding (blog, archives, singles, CPTs, WooCommerce) under Layouts, inherit-first defaults.
+* NEW: Customizer fonts loaded into the block editor canvas for typography parity.
+* IMPROVED: Font Awesome CSS loads async, main stylesheet gains fetchpriority, plus small accessibility fixes.
+* IMPROVED: Block vertical rhythm driven by --wp--style--block-gap; root blockGap disabled so element margins own spacing.
+* IMPROVED: Requires PHP lowered to 5.3 so PHP 7.x sites can install.
+* FIXED: Color palette lost when switching palette presets in the Customizer.
+* FIXED: WooCommerce block quantity stepper and variation table styling; block-owned quantity controls no longer skinned by the theme.
+* FIXED: Header cart dropdown/drawer not reacting to WooCommerce block cart add/remove events.
+* FIXED: WooCommerce blocks theme compatibility inside the general builder.
+* FIXED: Sidebar layout not applying on CPT taxonomy archives.
+* FIXED: Footer widget menus — noisy per-item dividers removed, widget-list gap tuned.
+* FIXED: Customizer widget edit-shortcut now opens force-hidden footer/header widget areas.
+* FIXED: alignleft/alignright images float again instead of stretching full width.
+
 = 0.4.21 =
 * NEW: Buttons & Form Fields Customizer section with modernized default style, teal brand color, and refreshed social icons.
 * NEW: Typography presets — font-pair quick picks with native tooltips.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "customify",
-    "version": "0.4.21",
+    "version": "0.4.22",
     "main": "Gruntfile.js",
     "engines": {
         "node": ">= 0.10.0"

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: custom-background, custom-logo, custom-menu, custom-logo, featured-images,
 Requires at least: 6.0
 Tested up to: 7.0
 Requires PHP: 5.3
-Stable tag: 0.4.21
+Stable tag: 0.4.22
 
 == Description ==
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://pressmaximum.com/customify
 Author: WPCustomify
 Author URI: https://pressmaximum.com
 Description: Customify is fast, lightweight, responsive and super flexible multipurpose theme built with SEO, speed, and usability in mind. Unleash the power of your imagination with a true WYSIWYG Header & Footer builder (inside the WordPress Customizer) built exclusively for this theme. The theme works great with any of your favorite page builder likes Elementor, Beaver Builder, SiteOrigin, Thrive Architect, Divi, Visual Composer, etc. Combined with the Header & Footer builder, you can build any type of websites like shop, business agencies, corporate, portfolio, education, university portal, consulting, church, restaurant, medical and so on. Customify is compatible with all well-coded plugins, including major ones like WooCommerce, OrbitFox, Yoast, BuddyPress, bbPress, etc. Learn more about the theme and ready to import demo sites at https://pressmaximum.com/customify
-Version: 0.4.21
+Version: 0.4.22
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: customify


### PR DESCRIPTION
## Summary
- Bump version to **0.4.22** in `style.css`, `readme.txt` (Stable tag), and `package.json`
- Add `changelog.txt` entry for 0.4.22 covering everything merged into DEV since v0.4.21 (PRs #436–#438, #442, #443, #445–#447, #450, #452–#454 + direct commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)