### PR TITLE
Fix Customizer and WooCommerce styling

### DIFF
--- a/docs/SPEC-data-migration-policy.md
+++ b/docs/SPEC-data-migration-policy.md
@@ -383,7 +383,7 @@ Customify's `image` control stores `{ id, mime, url }` object — NOT a plain at
 
 ### Issue #4 — Composite control sub-key drift
 
-The `styling` composite control's enabled sub-fields change between feature contexts (e.g. `header_transparent_styling` disables `padding`, `margin`, `text_color`, etc.). Saved values from a context that had sub-fields A+B+C should not break when re-read in a context that only allows A+B. Sanitize accepts wider shape than emits.
+The `styling` composite control's enabled sub-fields change between feature contexts (e.g. `header_transparent_styling` disables `padding`, `margin`, `link_color`, etc.). Saved values from a context that had sub-fields A+B+C should not break when re-read in a context that only allows A+B. Sanitize accepts wider shape than emits.
 
 ### Issue #5 — Customizer `get_setting()` returns registered default, not `null`
 

--- a/docs/SPEC-header-transparent.md
+++ b/docs/SPEC-header-transparent.md
@@ -64,7 +64,11 @@ All settings live under panel `header_settings`, section `header_transparent` ("
 | `header_{row}_transparent` | checkbox | **Enable transparent on this row** |
 | `header_{row}_transparent_styling` | styling | Background + border + colors; targets `.header--row.header-{row}.header--transparent .customify-container, …` |
 
-The styling control disables `padding`, `margin`, `text_color`, `link_color`, `bg_heading`, `bg_cover`, `bg_image`, `bg_repeat`, `border_radius`, `box_shadow`, and hover state — it is a deliberately minimal styling form because the row layout fields are owned by the builder's per-row settings.
+The styling control enables `text_color` and disables `padding`, `margin`, `link_color`, `bg_heading`, `bg_cover`, `bg_image`, `bg_repeat`, `border_radius`, `box_shadow`, and hover state — it is a deliberately minimal styling form because the row layout fields are owned by the builder's per-row settings.
+
+`text_color` uses a dedicated `#masthead:not(.sticky-active) .header--row.header-{row}.header--transparent …` selector list. It targets the row text plus each builder item's primary link/button, site title, top-level menu links, social/search/nav/cart icons, HTML/contact/icon-box links, CTA buttons, and search-box text. The ID-scoped selector deliberately outranks skin-mode and per-item normal/hover/active colors. It stops matching during `.sticky-active`, so sticky-header colors remain the only higher-priority color context. Dropdown/submenu links are intentionally not included.
+
+The regular `Header Top/Main/Bottom → Advanced Styling` rule also targets the transparent row's layout surface. When a Transparent Styling sub-field is empty, it emits no CSS and the regular row value remains visible and live-previewable. An explicit Transparent Styling value uses the ID-scoped, non-sticky selector above and overrides the inherited row value. During `.sticky-active`, the explicit Transparent rule stops matching and the regular row styling becomes the fallback.
 
 ### 3.2 Global settings
 
@@ -436,7 +440,7 @@ $logo_url   = Customify()->get_media( $logo_value, 'full' );       // string URL
 The styling control stores either:
 
 - `""` (empty string) when no fields have been set, or
-- an array with sub-keys for each enabled field (background, border, …). Per-row config in this feature disables most fields ([§3.1](#31-per-row-settings-repeated-for-top-main-bottom)), so only the active subset is ever populated.
+- an array with sub-keys for each enabled field (text color, background, border, …). The text color is stored at `normal.text_color`. Per-row config in this feature disables most fields ([§3.1](#31-per-row-settings-repeated-for-top-main-bottom)), so only the active subset is ever populated.
 
 Auto-CSS generation reads this shape via `Customify_Customizer_Auto_CSS` — no need to parse it manually in feature code.
 

--- a/docs/SPEC-typography.md
+++ b/docs/SPEC-typography.md
@@ -97,7 +97,7 @@ These live in the `typography_panel` section and start with `global_typography_`
 |---|---|---|
 | `global_typography_site_tt_title` | `.site-branding .site-title, .site-branding .site-title a` | reuses `var(--customify-typo-heading-font-family, inherit)` |
 | `global_typography_site_tt_desc` (tagline) | `.site-branding .site-description` | none — `.site-description` has no typography var consumer; inherits the body font |
-| `global_typography_base_widget_title` | `.site-content .widget-title` | reuses `var(--customify-typo-heading-font-family, inherit)` |
+| `global_typography_base_widget_title` | `.widget-area .widget-title` | reuses `var(--customify-typo-heading-font-family, inherit)` |
 
 All 11 panel settings (8 foundation + 3 leaf) live in the flattened `typography_panel` section (the former Base / Site Title & Tagline / Content sub-sections are now `heading` separators inside it).
 
@@ -216,7 +216,7 @@ For the 8 foundation settings, **SCSS owns the selector** — tokens at `:root` 
 
 **Leaf reuse note.** Leaf selectors don't mint their own tokens but two of them *reuse* the foundation heading token as their default font-family:
 
-- `.site-branding .site-title` (and `.widget-title` / `.site-content .widget-title`) default to `font-family: var(--customify-typo-heading-font-family, inherit)` — see [`header/builder_items/_logo_site_identity.scss`](../src/frontend/scss/header/builder_items/_logo_site_identity.scss) and [`widgets/_widgets.scss`](../src/frontend/scss/widgets/_widgets.scss). When the user sets Site Title / Widget Title typography, PHP emits selector-scoped literal CSS that overrides these defaults.
+- `.site-branding .site-title` and `.widget-title` default to `font-family: var(--customify-typo-heading-font-family, inherit)` — see [`header/builder_items/_logo_site_identity.scss`](../src/frontend/scss/header/builder_items/_logo_site_identity.scss) and [`widgets/_widgets.scss`](../src/frontend/scss/widgets/_widgets.scss). When the user sets Site Title / Widget Title typography, PHP emits selector-scoped literal CSS (`.widget-area .widget-title` for Widget Title) that overrides these defaults.
 - The tagline `.site-description` carries **no** typography var consumer (only `margin`); it inherits the body font and is overridden by the literal CSS that the Tagline field emits when set.
 
 **Consumer pattern — direct 2-arg `var(...)`.** Preferred for selectors that already had typography literals. Preserves breakpoint-specific fallbacks (e.g. h1 `font-size` differs per `@include for_device`):

--- a/inc/customizer/configs/header/panel.php
+++ b/inc/customizer/configs/header/panel.php
@@ -98,10 +98,18 @@ class Customify_Builder_Header extends Customify_Customize_Builder_Panel {
 			$color_mode = 'dark-mode';
 		}
 
-		$selector           = '.header--row.' . str_replace( '_', '-', $section );
-		$skin_selector      = '.header--row.' . str_replace( '_', '-', $section );
-		$skin_selector      = '.header--row:not(.header--transparent).' . str_replace( '_', '-', $section );
-		$skin_mode_selector = '.header--row-inner.' . str_replace( '_', '-', $section ) . '-inner';
+		$selector             = '.header--row.' . str_replace( '_', '-', $section );
+		$transparent_selector = "{$selector}.header--transparent";
+		$styling_selector     = implode(
+			', ',
+			array(
+				"{$selector}:not(.header--transparent) .header--row-inner",
+				"{$transparent_selector} .customify-container",
+				"{$transparent_selector}.layout-full-contained",
+				"{$transparent_selector}.layout-fullwidth",
+			)
+		);
+		$skin_mode_selector   = '.header--row-inner.' . str_replace( '_', '-', $section ) . '-inner';
 
 		$fn           = 'customify_customize_render_header';
 		$selector_all = '#masthead';
@@ -201,7 +209,7 @@ class Customify_Builder_Header extends Customify_Customize_Builder_Panel {
 				'description'      => sprintf( __( 'Advanced styling for %s', 'customify' ), $section_name ),
 				'live_title_field' => 'title',
 				'selector'         => array(
-					'normal' => "{$skin_selector} .header--row-inner",
+					'normal' => $styling_selector,
 				),
 				'css_format'       => 'styling',
 				'fields'           => array(

--- a/inc/customizer/configs/header/transparent.php
+++ b/inc/customizer/configs/header/transparent.php
@@ -49,6 +49,38 @@ class Customify_Header_Transparent {
 		$section      = 'header_transparent';
 		$row_selector = ".header--row.header-{$args['id']}.header--transparent";
 
+		// Explicit Transparent styling sits above inherited row/item styling.
+		// Excluding `.sticky-active` leaves the sticky header as the only
+		// higher-priority styling context.
+		$transparent_style_root = "#masthead:not(.sticky-active) {$row_selector}";
+		$text_color_selector    = implode(
+			', ',
+			array(
+				$transparent_style_root,
+				"{$transparent_style_root} .header--row-inner",
+				"{$transparent_style_root} .item--inner > a",
+				"{$transparent_style_root} .item--inner > button",
+				"{$transparent_style_root} .customify-builder-btn",
+				"{$transparent_style_root} .builder-contact--item",
+				"{$transparent_style_root} .builder-contact--item a",
+				"{$transparent_style_root} .site-title",
+				"{$transparent_style_root} .site-title a",
+				"{$transparent_style_root} .customify-builder-social-icons li a",
+				"{$transparent_style_root} .search-icon",
+				"{$transparent_style_root} .menu-mobile-toggle",
+				"{$transparent_style_root} .nav-menu > li > a",
+				"{$transparent_style_root} .icon-box a",
+				"{$transparent_style_root} .item--html a",
+				"{$transparent_style_root} .cart-item-link",
+				"{$transparent_style_root} .cart-item-link .cart-icon",
+				"{$transparent_style_root} .cart-item-link .cart-icon i",
+				"{$transparent_style_root} .cart-item-link .cart-icon svg",
+				"{$transparent_style_root} .header-search_box-item .search-field",
+				"{$transparent_style_root} .header-search_box-item .search-field::placeholder",
+				"{$transparent_style_root} .header-search_box-item .search-submit",
+			)
+		);
+
 		return array(
 			array(
 				'name'    => 'header_' . $args['id'] . '_transparent_h',
@@ -70,14 +102,15 @@ class Customify_Header_Transparent {
 				'description'      => sprintf( __( 'Transparent styling for %s', 'customify' ), $args['name'] ),
 				'live_title_field' => 'title',
 				'selector'         => array(
-					'normal' => "{$row_selector} .customify-container, {$row_selector}.layout-full-contained, {$row_selector}.layout-fullwidth",
+					'normal'            => "{$transparent_style_root} .customify-container, {$transparent_style_root}.layout-full-contained, {$transparent_style_root}.layout-fullwidth",
+					'normal_text_color' => $text_color_selector,
 				),
 				'css_format'       => 'styling',
 				'fields'           => array(
 					'normal_fields' => array(
 						'padding'       => false,
 						'margin'        => false,
-						'text_color'    => false,
+						'text_color'    => true,
 						'link_color'    => false,
 						'bg_heading'    => false,
 						'bg_cover'      => false,

--- a/inc/customizer/configs/typography.php
+++ b/inc/customizer/configs/typography.php
@@ -359,9 +359,9 @@ if ( ! function_exists( 'customify_customizer_typography_config' ) ) {
 			'type'             => 'typography',
 			'section'          => 'typography_panel',
 			'title'            => __( 'Widget Title', 'customify' ),
-			'description'      => __( 'Apply to all widget title in site content.', 'customify' ),
+			'description'      => __( 'Apply to widget titles in all widget areas.', 'customify' ),
 			'css_format'       => 'typography',
-			'selector'         => '.site-content .widget-title',
+			'selector'         => '.widget-area .widget-title',
 			// Mirrors widgets/_widgets.scss `.widget-title` literals.
 			'display_defaults' => array(
 				'font_size'   => '16px',

--- a/languages/customify.pot
+++ b/languages/customify.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Customify 0.4.21\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/customify\n"
-"POT-Creation-Date: 2026-06-19 16:51:42+00:00\n"
+"POT-Creation-Date: 2026-07-28 15:57:46+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -22,7 +22,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: .\n"
 "X-Poedit-Bookmarks: \n"
 "X-Textdomain-Support: yes\n"
-"X-Generator: grunt-wp-i18n 1.0.3\n"
+"X-Generator: grunt-wp-i18n 1.0.4\n"
 
 #: 404.php:19
 msgid "Oops! That page can&rsquo;t be found."
@@ -228,17 +228,17 @@ msgstr ""
 
 #: inc/admin/dashboard.php:332 inc/compatibility/breadcrumb.php:213
 #: inc/compatibility/woocommerce/config/catalog-designer.php:408
-#: inc/compatibility/woocommerce/config/header/cart.php:179
-#: inc/compatibility/woocommerce/config/header/cart.php:235
+#: inc/compatibility/woocommerce/config/header/cart.php:194
+#: inc/compatibility/woocommerce/config/header/cart.php:250
 #: inc/customizer/configs/blogs.php:371
 #: inc/customizer/configs/header/button.php:107
-#: inc/customizer/configs/header/panel.php:300
-#: inc/customizer/configs/header/transparent.php:69
+#: inc/customizer/configs/header/panel.php:308
+#: inc/customizer/configs/header/transparent.php:101
 msgid "Styling"
 msgstr ""
 
 #: inc/admin/dashboard.php:338 inc/compatibility/breadcrumb.php:203
-#: inc/compatibility/woocommerce/config/header/cart.php:206
+#: inc/compatibility/woocommerce/config/header/cart.php:221
 #: inc/customizer/configs/blogs.php:357
 #: inc/customizer/configs/header/button.php:96
 #: inc/customizer/configs/typography.php:164 inc/style-guide-template.php:554
@@ -375,7 +375,7 @@ msgstr ""
 msgid "Take advantage of the Blog Pro module to show off your posts in any layouts."
 msgstr ""
 
-#: inc/admin/dashboard.php:714 inc/customizer/configs/header/panel.php:200
+#: inc/admin/dashboard.php:714 inc/customizer/configs/header/panel.php:208
 msgid "Advanced Styling"
 msgstr ""
 
@@ -644,8 +644,8 @@ msgstr ""
 
 #: inc/class-customify.php:305 inc/class-customify.php:316
 #: inc/class-customify.php:330
-#: inc/compatibility/woocommerce/woocommerce.php:583
-#: inc/compatibility/woocommerce/woocommerce.php:594
+#: inc/compatibility/woocommerce/woocommerce.php:587
+#: inc/compatibility/woocommerce/woocommerce.php:598
 msgid "Add widgets here."
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr ""
 #: inc/customizer/configs/blogs.php:29 inc/customizer/configs/blogs.php:36
 #: inc/customizer/configs/footer/panel.php:151
 #: inc/customizer/configs/footer/panel.php:567
-#: inc/customizer/configs/header/panel.php:122
+#: inc/customizer/configs/header/panel.php:130
 #: inc/customizer/configs/page-header.php:231
 msgid "Layout"
 msgstr ""
@@ -720,7 +720,7 @@ msgid "Content Layout"
 msgstr ""
 
 #: inc/class-metabox.php:67 inc/customizer/configs/footer/panel.php:158
-#: inc/customizer/configs/header/panel.php:129
+#: inc/customizer/configs/header/panel.php:137
 #: inc/customizer/configs/layouts.php:42
 #: inc/customizer/configs/page-header.php:238
 msgid "Full Width"
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Disable Elements"
 msgstr ""
 
-#: inc/class-metabox.php:151 inc/customizer/configs/header/transparent.php:168
+#: inc/class-metabox.php:151 inc/customizer/configs/header/transparent.php:201
 msgid "Transparent Header"
 msgstr ""
 
@@ -922,6 +922,7 @@ msgid "Download"
 msgstr ""
 
 #: inc/color-palette-switcher.php:223
+#: inc/compatibility/woocommerce/config/header/cart.php:699
 #: inc/customizer/controls/class-control-repeater.php:33
 #: inc/panel-builder/class-abstract-layout-frontend.php:122
 #: inc/panel-builder/class-layout-builder.php:565
@@ -960,6 +961,20 @@ msgstr ""
 
 #: inc/color-palette-switcher.php:231
 msgid "Linked to palette"
+msgstr ""
+
+#: inc/color-palette-switcher.php:232
+msgid "Save current colors?"
+msgstr ""
+
+#: inc/color-palette-switcher.php:233
+msgid ""
+"These colors are not saved as a palette. Save them before switching so you "
+"can recover them later."
+msgstr ""
+
+#: inc/color-palette-switcher.php:234
+msgid "Save & switch"
 msgstr ""
 
 #: inc/colors-palette.php:1914
@@ -1075,15 +1090,15 @@ msgid "Hide on product tag"
 msgstr ""
 
 #: inc/compatibility/breadcrumb.php:188 inc/compatibility/breadcrumb.php:193
-#: inc/customizer/configs/header/transparent.php:180
-#: inc/customizer/configs/header/transparent.php:185
+#: inc/customizer/configs/header/transparent.php:213
+#: inc/customizer/configs/header/transparent.php:218
 #: inc/customizer/configs/page-header.php:254
 #: inc/customizer/configs/page-header.php:265
 msgid "Display"
 msgstr ""
 
 #: inc/compatibility/breadcrumb.php:189
-#: inc/customizer/configs/header/transparent.php:181
+#: inc/customizer/configs/header/transparent.php:214
 #: inc/customizer/configs/page-header.php:255
 msgid "Settings display for special pages."
 msgstr ""
@@ -1097,7 +1112,7 @@ msgid "Styling for breadcrumb"
 msgstr ""
 
 #: inc/compatibility/woocommerce/config/cart.php:46
-#: inc/compatibility/woocommerce/config/header/cart.php:76
+#: inc/compatibility/woocommerce/config/header/cart.php:91
 msgid "Cart"
 msgstr ""
 
@@ -1249,7 +1264,7 @@ msgid "Discount value"
 msgstr ""
 
 #: inc/compatibility/woocommerce/config/catalog-designer.php:400
-#: inc/customizer/configs/header/panel.php:266
+#: inc/customizer/configs/header/panel.php:274
 msgid "Display Type"
 msgstr ""
 
@@ -1286,88 +1301,89 @@ msgid "On Sale"
 msgstr ""
 
 #: inc/compatibility/woocommerce/config/header/cart.php:35
+#: inc/compatibility/woocommerce/config/header/cart.php:697
 msgid "Shopping Cart"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:75
+#: inc/compatibility/woocommerce/config/header/cart.php:90
 #: inc/customizer/configs/header/nav-icon.php:36
 msgid "Label"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:89
+#: inc/compatibility/woocommerce/config/header/cart.php:104
 #: inc/customizer/configs/header/button.php:57
 #: inc/customizer/configs/header/social-icons.php:104
 msgid "Icon"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:100
+#: inc/compatibility/woocommerce/config/header/cart.php:115
 #: inc/customizer/configs/header/button.php:69
 msgid "Before"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:101
+#: inc/compatibility/woocommerce/config/header/cart.php:116
 #: inc/customizer/configs/header/button.php:70
 msgid "After"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:103
+#: inc/compatibility/woocommerce/config/header/cart.php:118
 #: inc/customizer/configs/header/button.php:67
 #: inc/customizer/configs/header/search-box.php:131
 #: inc/customizer/configs/header/search-icon.php:245
 msgid "Icon Position"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:114
+#: inc/compatibility/woocommerce/config/header/cart.php:129
 msgid "Cart Page"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:115
+#: inc/compatibility/woocommerce/config/header/cart.php:130
 msgid "Checkout"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:117
+#: inc/compatibility/woocommerce/config/header/cart.php:132
 msgid "Link To"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:132
-#: inc/compatibility/woocommerce/config/header/cart.php:133
+#: inc/compatibility/woocommerce/config/header/cart.php:147
+#: inc/compatibility/woocommerce/config/header/cart.php:148
 #: inc/customizer/configs/header/nav-icon.php:52
 msgid "Show Label"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:144
+#: inc/compatibility/woocommerce/config/header/cart.php:159
 msgid "Sub Total"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:145
+#: inc/compatibility/woocommerce/config/header/cart.php:160
 msgid "Show Sub Total"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:161
-#: inc/compatibility/woocommerce/config/header/cart.php:262
+#: inc/compatibility/woocommerce/config/header/cart.php:176
+#: inc/compatibility/woocommerce/config/header/cart.php:277
 #: woocommerce/cart/cart.php:32 woocommerce/cart/cart.php:140
 msgid "Quantity"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:162
+#: inc/compatibility/woocommerce/config/header/cart.php:177
 msgid "Show Quantity"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:171
+#: inc/compatibility/woocommerce/config/header/cart.php:186
 #: inc/customizer/configs/blogs.php:245
 #: inc/customizer/configs/single-blog-post.php:150
 msgid "Separator"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:172
+#: inc/compatibility/woocommerce/config/header/cart.php:187
 msgid "/"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:216
+#: inc/compatibility/woocommerce/config/header/cart.php:231
 msgid "Icon Settings"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:225
+#: inc/compatibility/woocommerce/config/header/cart.php:240
 #: inc/customizer/configs/header/nav-icon.php:61
 #: inc/customizer/configs/header/search-box.php:103
 #: inc/customizer/configs/header/search-icon.php:65
@@ -1375,38 +1391,106 @@ msgstr ""
 msgid "Icon Size"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:236
+#: inc/compatibility/woocommerce/config/header/cart.php:251
 msgid "Advanced styling for cart icon"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:263
+#: inc/compatibility/woocommerce/config/header/cart.php:278
 msgid "Advanced styling for cart quantity"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:289
+#: inc/compatibility/woocommerce/config/header/cart.php:307
+msgid "Cart Behavior"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:314
+msgid "Behavior"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:317
+msgid "Dropdown"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:318
+msgid "Off-Canvas Drawer"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:327
 msgid "Dropdown Settings"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:296
+#: inc/compatibility/woocommerce/config/header/cart.php:335
 msgid "Dropdown Alignment"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:301
+#: inc/compatibility/woocommerce/config/header/cart.php:341
+#: inc/compatibility/woocommerce/config/header/cart.php:381
 #: inc/customizer/configs/header/logo.php:84
 #: inc/customizer/configs/related-posts.php:93
 #: inc/customizer/controls/class-control-css-ruler.php:70
 msgid "Left"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:302
+#: inc/compatibility/woocommerce/config/header/cart.php:342
+#: inc/compatibility/woocommerce/config/header/cart.php:380
 #: inc/customizer/configs/header/logo.php:85
 #: inc/customizer/configs/related-posts.php:94
 #: inc/customizer/controls/class-control-css-ruler.php:62
 msgid "Right"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:313
+#: inc/compatibility/woocommerce/config/header/cart.php:353
 msgid "Dropdown Width"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:368
+msgid "Drawer Settings"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:376
+msgid "Drawer Position"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:389
+msgid "Drawer Width"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:408
+msgid "Auto-open on Add to Cart"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:417
+msgid "Drawer Offset"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:418
+msgid ""
+"Gap from the screen edges. Set values to float the drawer away from the "
+"edge."
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:439
+msgid "Corner Radius"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:453
+msgid "Backdrop Color"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:464
+msgid "Panel Background"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:475
+msgid "Heading Color"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:695
+msgid "Shopping cart"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:713
+msgid "Continue Shopping"
 msgstr ""
 
 #: inc/compatibility/woocommerce/config/single-product.php:156
@@ -1517,19 +1601,19 @@ msgstr ""
 msgid "Your order"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:535
+#: inc/compatibility/woocommerce/woocommerce.php:539
 msgid "Display on product taxonomies (categories/tags,..)"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:543
+#: inc/compatibility/woocommerce/woocommerce.php:547
 msgid "Display on single product"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:581
+#: inc/compatibility/woocommerce/woocommerce.php:585
 msgid "WooCommerce Primary Sidebar"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:592
+#: inc/compatibility/woocommerce/woocommerce.php:596
 msgid "WooCommerce Secondary Sidebar"
 msgstr ""
 
@@ -1683,7 +1767,7 @@ msgid "Link Color"
 msgstr ""
 
 #: inc/customizer/class-customizer.php:702
-#: inc/customizer/configs/header/panel.php:432
+#: inc/customizer/configs/header/panel.php:440
 msgid "Margin"
 msgstr ""
 
@@ -2248,19 +2332,19 @@ msgid "Footer Top"
 msgstr ""
 
 #: inc/customizer/configs/footer/panel.php:157
-#: inc/customizer/configs/header/panel.php:128
+#: inc/customizer/configs/header/panel.php:136
 #: inc/customizer/configs/page-header.php:237
 msgid "Full width - Contained"
 msgstr ""
 
 #: inc/customizer/configs/footer/panel.php:159
-#: inc/customizer/configs/header/panel.php:130
+#: inc/customizer/configs/header/panel.php:138
 #: inc/customizer/configs/page-header.php:239
 msgid "Contained"
 msgstr ""
 
 #: inc/customizer/configs/footer/panel.php:168
-#: inc/customizer/configs/header/panel.php:139
+#: inc/customizer/configs/header/panel.php:147
 msgid ""
 "Layout <code>Full width - Contained</code> and <code>Full Width</code> will "
 "not fit browser width because you've selected <a class='focus-control' "
@@ -2269,8 +2353,8 @@ msgid ""
 msgstr ""
 
 #: inc/customizer/configs/footer/panel.php:180
-#: inc/customizer/configs/header/panel.php:182
-#: inc/customizer/configs/header/panel.php:282
+#: inc/customizer/configs/header/panel.php:190
+#: inc/customizer/configs/header/panel.php:290
 msgid "Skin Mode"
 msgstr ""
 
@@ -2289,12 +2373,12 @@ msgid ""
 msgstr ""
 
 #: inc/customizer/configs/footer/panel.php:229
-#: inc/customizer/configs/header/panel.php:223
+#: inc/customizer/configs/header/panel.php:231
 msgid "Column Settings"
 msgstr ""
 
 #: inc/customizer/configs/footer/panel.php:230
-#: inc/customizer/configs/header/panel.php:224
+#: inc/customizer/configs/header/panel.php:232
 msgid "Per-column direction, align, gap and padding."
 msgstr ""
 
@@ -2393,7 +2477,7 @@ msgstr ""
 
 #: inc/customizer/configs/header/logo.php:56
 #: inc/customizer/configs/header/logo.php:70
-#: inc/customizer/configs/header/panel.php:469
+#: inc/customizer/configs/header/panel.php:477
 #: inc/customizer/configs/layouts.php:55 inc/customizer/configs/layouts.php:228
 msgid "No"
 msgstr ""
@@ -2531,17 +2615,17 @@ msgstr ""
 
 #: inc/customizer/configs/header/panel.php:44
 #: inc/customizer/configs/header/panel.php:92
-#: inc/customizer/configs/header/transparent.php:194
+#: inc/customizer/configs/header/transparent.php:227
 msgid "Header Top"
 msgstr ""
 
 #: inc/customizer/configs/header/panel.php:45
-#: inc/customizer/configs/header/transparent.php:195
+#: inc/customizer/configs/header/transparent.php:228
 msgid "Header Main"
 msgstr ""
 
 #: inc/customizer/configs/header/panel.php:46
-#: inc/customizer/configs/header/transparent.php:196
+#: inc/customizer/configs/header/transparent.php:229
 msgid "Header Bottom"
 msgstr ""
 
@@ -2553,75 +2637,75 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
-#: inc/customizer/configs/header/panel.php:154
+#: inc/customizer/configs/header/panel.php:162
 msgid "Height"
 msgstr ""
 
-#: inc/customizer/configs/header/panel.php:172
+#: inc/customizer/configs/header/panel.php:180
 msgid "Column Gap"
 msgstr ""
 
-#: inc/customizer/configs/header/panel.php:173
+#: inc/customizer/configs/header/panel.php:181
 msgid "Spacing between header columns."
 msgstr ""
 
-#: inc/customizer/configs/header/panel.php:201
-#: inc/customizer/configs/header/panel.php:301
+#: inc/customizer/configs/header/panel.php:209
+#: inc/customizer/configs/header/panel.php:309
 msgid "Advanced styling for %s"
 msgstr ""
 
-#: inc/customizer/configs/header/panel.php:269
+#: inc/customizer/configs/header/panel.php:277
 msgid "Slide From Left"
 msgstr ""
 
-#: inc/customizer/configs/header/panel.php:270
+#: inc/customizer/configs/header/panel.php:278
 msgid "Slide From Right"
 msgstr ""
 
-#: inc/customizer/configs/header/panel.php:271
+#: inc/customizer/configs/header/panel.php:279
 msgid "Full-screen Overlay"
 msgstr ""
 
-#: inc/customizer/configs/header/panel.php:272
+#: inc/customizer/configs/header/panel.php:280
 msgid "Toggle Dropdown"
 msgstr ""
 
-#: inc/customizer/configs/header/panel.php:347
+#: inc/customizer/configs/header/panel.php:355
 msgid "Do not copy parent menu to submenu."
 msgstr ""
 
-#: inc/customizer/configs/header/panel.php:359
-#: inc/customizer/configs/header/panel.php:448
+#: inc/customizer/configs/header/panel.php:367
+#: inc/customizer/configs/header/panel.php:456
 msgid "Align"
 msgstr ""
 
-#: inc/customizer/configs/header/panel.php:367
+#: inc/customizer/configs/header/panel.php:375
 msgid "Off-canvas Settings"
 msgstr ""
 
-#: inc/customizer/configs/header/panel.php:368
+#: inc/customizer/configs/header/panel.php:376
 msgid "Align, gap and padding for the off-canvas."
 msgstr ""
 
-#: inc/customizer/configs/header/panel.php:416
+#: inc/customizer/configs/header/panel.php:424
 msgid "Item Layout"
 msgstr ""
 
-#: inc/customizer/configs/header/panel.php:466
+#: inc/customizer/configs/header/panel.php:474
 msgid "Merge Item"
 msgstr ""
 
-#: inc/customizer/configs/header/panel.php:467
+#: inc/customizer/configs/header/panel.php:475
 msgid ""
 "If you choose to merge this item, the alignment setting will inherit from "
 "the item you are merging."
 msgstr ""
 
-#: inc/customizer/configs/header/panel.php:470
+#: inc/customizer/configs/header/panel.php:478
 msgid "Merge with left item"
 msgstr ""
 
-#: inc/customizer/configs/header/panel.php:471
+#: inc/customizer/configs/header/panel.php:479
 msgid "Merge with right item"
 msgstr ""
 
@@ -2770,71 +2854,71 @@ msgstr ""
 msgid "Border & border radius"
 msgstr ""
 
-#: inc/customizer/configs/header/transparent.php:63
+#: inc/customizer/configs/header/transparent.php:95
 msgid "Transparent %s"
 msgstr ""
 
-#: inc/customizer/configs/header/transparent.php:70
+#: inc/customizer/configs/header/transparent.php:102
 msgid "Transparent styling for %s"
 msgstr ""
 
-#: inc/customizer/configs/header/transparent.php:106
+#: inc/customizer/configs/header/transparent.php:139
 msgid "Disable on index"
 msgstr ""
 
-#: inc/customizer/configs/header/transparent.php:111
+#: inc/customizer/configs/header/transparent.php:144
 msgid "Disable on categories"
 msgstr ""
 
-#: inc/customizer/configs/header/transparent.php:116
+#: inc/customizer/configs/header/transparent.php:149
 msgid "Disable on search"
 msgstr ""
 
-#: inc/customizer/configs/header/transparent.php:121
+#: inc/customizer/configs/header/transparent.php:154
 msgid "Disable on archive"
 msgstr ""
 
-#: inc/customizer/configs/header/transparent.php:126
+#: inc/customizer/configs/header/transparent.php:159
 msgid "Disable on single page"
 msgstr ""
 
-#: inc/customizer/configs/header/transparent.php:131
+#: inc/customizer/configs/header/transparent.php:164
 msgid "Disable on single post"
 msgstr ""
 
-#: inc/customizer/configs/header/transparent.php:136
+#: inc/customizer/configs/header/transparent.php:169
 msgid "Disable on singular"
 msgstr ""
 
-#: inc/customizer/configs/header/transparent.php:141
+#: inc/customizer/configs/header/transparent.php:174
 msgid "Disable on 404 page"
 msgstr ""
 
-#: inc/customizer/configs/header/transparent.php:149
+#: inc/customizer/configs/header/transparent.php:182
 msgid "Disable on product page"
 msgstr ""
 
-#: inc/customizer/configs/header/transparent.php:154
+#: inc/customizer/configs/header/transparent.php:187
 msgid "Disable on product category"
 msgstr ""
 
-#: inc/customizer/configs/header/transparent.php:159
+#: inc/customizer/configs/header/transparent.php:192
 msgid "Disable on product tag"
 msgstr ""
 
-#: inc/customizer/configs/header/transparent.php:174
+#: inc/customizer/configs/header/transparent.php:207
 msgid "Advanced Settings"
 msgstr ""
 
-#: inc/customizer/configs/header/transparent.php:219
+#: inc/customizer/configs/header/transparent.php:252
 msgid "Transparent Logo"
 msgstr ""
 
-#: inc/customizer/configs/header/transparent.php:230
+#: inc/customizer/configs/header/transparent.php:263
 msgid "Transparent Logo Retina"
 msgstr ""
 
-#: inc/customizer/configs/header/transparent.php:241
+#: inc/customizer/configs/header/transparent.php:274
 msgid "Transparent Logo Max Width"
 msgstr ""
 
@@ -3383,7 +3467,7 @@ msgid "Widget Title"
 msgstr ""
 
 #: inc/customizer/configs/typography.php:362
-msgid "Apply to all widget title in site content."
+msgid "Apply to widget titles in all widget areas."
 msgstr ""
 
 #: inc/customizer/configs/upsell.php:17
@@ -3784,7 +3868,7 @@ msgstr ""
 msgid "Content / Sidebar / Sidebar"
 msgstr ""
 
-#: inc/template-functions.php:853
+#: inc/template-functions.php:904
 msgid "Search &hellip;"
 msgstr ""
 
@@ -4004,7 +4088,7 @@ msgstr ""
 #: inc/customizer/configs/header/search-box.php:287
 #: inc/customizer/configs/header/search-icon.php:347
 #: inc/customizer/configs/header/search-icon.php:348
-#: inc/template-functions.php:852 inc/template-functions.php:853
+#: inc/template-functions.php:903 inc/template-functions.php:904
 msgctxt "label"
 msgid "Search for:"
 msgstr ""
@@ -4019,17 +4103,17 @@ msgctxt "customify-font-weight"
 msgid "Bold"
 msgstr ""
 
-#: inc/template-functions.php:831
+#: inc/template-functions.php:882
 msgctxt "yearly archives date format"
 msgid "Y"
 msgstr ""
 
-#: inc/template-functions.php:833
+#: inc/template-functions.php:884
 msgctxt "monthly archives date format"
 msgid "F Y"
 msgstr ""
 
-#: inc/template-functions.php:835
+#: inc/template-functions.php:886
 msgctxt "daily archives date format"
 msgid "F j, Y"
 msgstr ""

--- a/src/frontend/scss/compatibility/wc/_woocommerce-layout.scss
+++ b/src/frontend/scss/compatibility/wc/_woocommerce-layout.scss
@@ -307,6 +307,17 @@
     margin-inline-end: 0.5em;
 }
 
+.wc-block-product-gallery-thumbnails__scrollable,
+.wp-block-woocommerce-product-gallery {
+    gap: 1em;
+}
+
+// WooCommerce applies this through a zero-specificity `:where()` selector,
+// which lets the theme's list spacing win in block-based product galleries.
+.wc-block-product-gallery-large-image__container {
+    margin: 0;
+}
+
 // Un-trap the WooCommerce product-filters overlay from a Blocksify Section's
 // stacking context (.bsy-section__inner has position:relative; z-index:2 for its
 // shape/bg layering, which traps the overlay's position:fixed below the header).

--- a/src/frontend/scss/compatibility/wc/_woocommerce-main.scss
+++ b/src/frontend/scss/compatibility/wc/_woocommerce-main.scss
@@ -180,6 +180,16 @@ p.demo_store,
         padding-block: 0;
     }
 
+    // The standard WooCommerce Add to Cart Form stretches the quantity wrapper
+    // to the adjacent button, but its number input keeps a font-relative height.
+    // Fill the wrapper without changing the theme's field skin.
+    .wc-block-add-to-cart-form
+    .quantity:not(.wc-block-components-quantity-selector)
+    input[type="number"].input-text.qty.text {
+        box-sizing: border-box;
+        height: 100%;
+    }
+
     .blockUI.blockOverlay {
         position: relative;
         z-index: 35 !important;


### PR DESCRIPTION
## Summary
- apply Widget Title typography to all widget areas
- add Transparent Header row text color with sticky-header precedence
- preserve Header Top/Main/Bottom Advanced Styling when transparent values are empty
- fix WooCommerce block product gallery spacing and Add to Cart quantity height
- refresh the translation catalog

## Validation
- npm run build
- PHP lint for the three changed Customizer config files
- generated CSS/config checks for transparent inheritance and override precedence
- verified WooCommerce selectors against the installed plugin source
- git diff --check and LF line-ending audit