### PR TITLE
Merge Customizer and WooCommerce styling fixes into DEV

### DIFF
--- a/docs/SPEC-data-migration-policy.md
+++ b/docs/SPEC-data-migration-policy.md
@@ -392,7 +392,7 @@ Customify's `image` control stores `{ id, mime, url }` object — NOT a plain at
 
 ### Issue #4 — Composite control sub-key drift
 
-The `styling` composite control's enabled sub-fields change between feature contexts (e.g. `header_transparent_styling` disables `padding`, `margin`, `text_color`, etc.). Saved values from a context that had sub-fields A+B+C should not break when re-read in a context that only allows A+B. Sanitize accepts wider shape than emits.
+The `styling` composite control's enabled sub-fields change between feature contexts (e.g. `header_transparent_styling` disables `padding`, `margin`, `link_color`, etc.). Saved values from a context that had sub-fields A+B+C should not break when re-read in a context that only allows A+B. Sanitize accepts wider shape than emits.
 
 ### Issue #5 — Customizer `get_setting()` returns registered default, not `null`
 

--- a/docs/SPEC-header-transparent.md
+++ b/docs/SPEC-header-transparent.md
@@ -64,7 +64,11 @@ All settings live under panel `header_settings`, section `header_transparent` ("
 | `header_{row}_transparent` | checkbox | **Enable transparent on this row** |
 | `header_{row}_transparent_styling` | styling | Background + border + colors; targets `.header--row.header-{row}.header--transparent .customify-container, …` |
 
-The styling control disables `padding`, `margin`, `text_color`, `link_color`, `bg_heading`, `bg_cover`, `bg_image`, `bg_repeat`, `border_radius`, `box_shadow`, and hover state — it is a deliberately minimal styling form because the row layout fields are owned by the builder's per-row settings.
+The styling control enables `text_color` and disables `padding`, `margin`, `link_color`, `bg_heading`, `bg_cover`, `bg_image`, `bg_repeat`, `border_radius`, `box_shadow`, and hover state — it is a deliberately minimal styling form because the row layout fields are owned by the builder's per-row settings.
+
+`text_color` uses a dedicated `#masthead:not(.sticky-active) .header--row.header-{row}.header--transparent …` selector list. It targets the row text plus each builder item's primary link/button, site title, top-level menu links, social/search/nav/cart icons, HTML/contact/icon-box links, CTA buttons, and search-box text. The ID-scoped selector deliberately outranks skin-mode and per-item normal/hover/active colors. It stops matching during `.sticky-active`, so sticky-header colors remain the only higher-priority color context. Dropdown/submenu links are intentionally not included.
+
+The regular `Header Top/Main/Bottom → Advanced Styling` rule also targets the transparent row's layout surface. When a Transparent Styling sub-field is empty, it emits no CSS and the regular row value remains visible and live-previewable. An explicit Transparent Styling value uses the ID-scoped, non-sticky selector above and overrides the inherited row value. During `.sticky-active`, the explicit Transparent rule stops matching and the regular row styling becomes the fallback.
 
 ### 3.2 Global settings
 
@@ -436,7 +440,7 @@ $logo_url   = Customify()->get_media( $logo_value, 'full' );       // string URL
 The styling control stores either:
 
 - `""` (empty string) when no fields have been set, or
-- an array with sub-keys for each enabled field (background, border, …). Per-row config in this feature disables most fields ([§3.1](#31-per-row-settings-repeated-for-top-main-bottom)), so only the active subset is ever populated.
+- an array with sub-keys for each enabled field (text color, background, border, …). The text color is stored at `normal.text_color`. Per-row config in this feature disables most fields ([§3.1](#31-per-row-settings-repeated-for-top-main-bottom)), so only the active subset is ever populated.
 
 Auto-CSS generation reads this shape via `Customify_Customizer_Auto_CSS` — no need to parse it manually in feature code.
 

--- a/docs/SPEC-typography.md
+++ b/docs/SPEC-typography.md
@@ -97,7 +97,7 @@ These live in the `typography_panel` section and start with `global_typography_`
 |---|---|---|
 | `global_typography_site_tt_title` | `.site-branding .site-title, .site-branding .site-title a` | reuses `var(--customify-typo-heading-font-family, inherit)` |
 | `global_typography_site_tt_desc` (tagline) | `.site-branding .site-description` | none — `.site-description` has no typography var consumer; inherits the body font |
-| `global_typography_base_widget_title` | `.site-content .widget-title` | reuses `var(--customify-typo-heading-font-family, inherit)` |
+| `global_typography_base_widget_title` | `.widget-area .widget-title` | reuses `var(--customify-typo-heading-font-family, inherit)` |
 
 All 11 panel settings (8 foundation + 3 leaf) live in the flattened `typography_panel` section (the former Base / Site Title & Tagline / Content sub-sections are now `heading` separators inside it).
 
@@ -216,7 +216,7 @@ For the 8 foundation settings, **SCSS owns the selector** — tokens at `:root` 
 
 **Leaf reuse note.** Leaf selectors don't mint their own tokens but two of them *reuse* the foundation heading token as their default font-family:
 
-- `.site-branding .site-title` (and `.widget-title` / `.site-content .widget-title`) default to `font-family: var(--customify-typo-heading-font-family, inherit)` — see [`header/builder_items/_logo_site_identity.scss`](../src/frontend/scss/header/builder_items/_logo_site_identity.scss) and [`widgets/_widgets.scss`](../src/frontend/scss/widgets/_widgets.scss). When the user sets Site Title / Widget Title typography, PHP emits selector-scoped literal CSS that overrides these defaults.
+- `.site-branding .site-title` and `.widget-title` default to `font-family: var(--customify-typo-heading-font-family, inherit)` — see [`header/builder_items/_logo_site_identity.scss`](../src/frontend/scss/header/builder_items/_logo_site_identity.scss) and [`widgets/_widgets.scss`](../src/frontend/scss/widgets/_widgets.scss). When the user sets Site Title / Widget Title typography, PHP emits selector-scoped literal CSS (`.widget-area .widget-title` for Widget Title) that overrides these defaults.
 - The tagline `.site-description` carries **no** typography var consumer (only `margin`); it inherits the body font and is overridden by the literal CSS that the Tagline field emits when set.
 
 **Consumer pattern — direct 2-arg `var(...)`.** Preferred for selectors that already had typography literals. Preserves breakpoint-specific fallbacks (e.g. h1 `font-size` differs per `@include for_device`):

--- a/inc/customizer/configs/header/panel.php
+++ b/inc/customizer/configs/header/panel.php
@@ -98,10 +98,18 @@ class Customify_Builder_Header extends Customify_Customize_Builder_Panel {
 			$color_mode = 'dark-mode';
 		}
 
-		$selector           = '.header--row.' . str_replace( '_', '-', $section );
-		$skin_selector      = '.header--row.' . str_replace( '_', '-', $section );
-		$skin_selector      = '.header--row:not(.header--transparent).' . str_replace( '_', '-', $section );
-		$skin_mode_selector = '.header--row-inner.' . str_replace( '_', '-', $section ) . '-inner';
+		$selector             = '.header--row.' . str_replace( '_', '-', $section );
+		$transparent_selector = "{$selector}.header--transparent";
+		$styling_selector     = implode(
+			', ',
+			array(
+				"{$selector}:not(.header--transparent) .header--row-inner",
+				"{$transparent_selector} .customify-container",
+				"{$transparent_selector}.layout-full-contained",
+				"{$transparent_selector}.layout-fullwidth",
+			)
+		);
+		$skin_mode_selector   = '.header--row-inner.' . str_replace( '_', '-', $section ) . '-inner';
 
 		$fn           = 'customify_customize_render_header';
 		$selector_all = '#masthead';
@@ -201,7 +209,7 @@ class Customify_Builder_Header extends Customify_Customize_Builder_Panel {
 				'description'      => sprintf( __( 'Advanced styling for %s', 'customify' ), $section_name ),
 				'live_title_field' => 'title',
 				'selector'         => array(
-					'normal' => "{$skin_selector} .header--row-inner",
+					'normal' => $styling_selector,
 				),
 				'css_format'       => 'styling',
 				'fields'           => array(

--- a/inc/customizer/configs/header/transparent.php
+++ b/inc/customizer/configs/header/transparent.php
@@ -49,6 +49,38 @@ class Customify_Header_Transparent {
 		$section      = 'header_transparent';
 		$row_selector = ".header--row.header-{$args['id']}.header--transparent";
 
+		// Explicit Transparent styling sits above inherited row/item styling.
+		// Excluding `.sticky-active` leaves the sticky header as the only
+		// higher-priority styling context.
+		$transparent_style_root = "#masthead:not(.sticky-active) {$row_selector}";
+		$text_color_selector    = implode(
+			', ',
+			array(
+				$transparent_style_root,
+				"{$transparent_style_root} .header--row-inner",
+				"{$transparent_style_root} .item--inner > a",
+				"{$transparent_style_root} .item--inner > button",
+				"{$transparent_style_root} .customify-builder-btn",
+				"{$transparent_style_root} .builder-contact--item",
+				"{$transparent_style_root} .builder-contact--item a",
+				"{$transparent_style_root} .site-title",
+				"{$transparent_style_root} .site-title a",
+				"{$transparent_style_root} .customify-builder-social-icons li a",
+				"{$transparent_style_root} .search-icon",
+				"{$transparent_style_root} .menu-mobile-toggle",
+				"{$transparent_style_root} .nav-menu > li > a",
+				"{$transparent_style_root} .icon-box a",
+				"{$transparent_style_root} .item--html a",
+				"{$transparent_style_root} .cart-item-link",
+				"{$transparent_style_root} .cart-item-link .cart-icon",
+				"{$transparent_style_root} .cart-item-link .cart-icon i",
+				"{$transparent_style_root} .cart-item-link .cart-icon svg",
+				"{$transparent_style_root} .header-search_box-item .search-field",
+				"{$transparent_style_root} .header-search_box-item .search-field::placeholder",
+				"{$transparent_style_root} .header-search_box-item .search-submit",
+			)
+		);
+
 		return array(
 			array(
 				'name'    => 'header_' . $args['id'] . '_transparent_h',
@@ -70,14 +102,15 @@ class Customify_Header_Transparent {
 				'description'      => sprintf( __( 'Transparent styling for %s', 'customify' ), $args['name'] ),
 				'live_title_field' => 'title',
 				'selector'         => array(
-					'normal' => "{$row_selector} .customify-container, {$row_selector}.layout-full-contained, {$row_selector}.layout-fullwidth",
+					'normal'            => "{$transparent_style_root} .customify-container, {$transparent_style_root}.layout-full-contained, {$transparent_style_root}.layout-fullwidth",
+					'normal_text_color' => $text_color_selector,
 				),
 				'css_format'       => 'styling',
 				'fields'           => array(
 					'normal_fields' => array(
 						'padding'       => false,
 						'margin'        => false,
-						'text_color'    => false,
+						'text_color'    => true,
 						'link_color'    => false,
 						'bg_heading'    => false,
 						'bg_cover'      => false,

--- a/inc/customizer/configs/typography.php
+++ b/inc/customizer/configs/typography.php
@@ -359,9 +359,9 @@ if ( ! function_exists( 'customify_customizer_typography_config' ) ) {
 			'type'             => 'typography',
 			'section'          => 'typography_panel',
 			'title'            => __( 'Widget Title', 'customify' ),
-			'description'      => __( 'Apply to all widget title in site content.', 'customify' ),
+			'description'      => __( 'Apply to widget titles in all widget areas.', 'customify' ),
 			'css_format'       => 'typography',
-			'selector'         => '.site-content .widget-title',
+			'selector'         => '.widget-area .widget-title',
 			// Mirrors widgets/_widgets.scss `.widget-title` literals.
 			'display_defaults' => array(
 				'font_size'   => '16px',

--- a/languages/customify.pot
+++ b/languages/customify.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Customify 0.4.21\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/customify\n"
-"POT-Creation-Date: 2026-06-19 16:51:42+00:00\n"
+"POT-Creation-Date: 2026-07-28 11:19:25+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -22,7 +22,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: .\n"
 "X-Poedit-Bookmarks: \n"
 "X-Textdomain-Support: yes\n"
-"X-Generator: grunt-wp-i18n 1.0.3\n"
+"X-Generator: grunt-wp-i18n 1.0.4\n"
+
+#: inc/customizer/configs/layouts.php:243
+msgid "404"
+msgstr ""
 
 #: 404.php:19
 msgid "Oops! That page can&rsquo;t be found."
@@ -228,8 +232,8 @@ msgstr ""
 
 #: inc/admin/dashboard.php:332 inc/compatibility/breadcrumb.php:213
 #: inc/compatibility/woocommerce/config/catalog-designer.php:408
-#: inc/compatibility/woocommerce/config/header/cart.php:179
-#: inc/compatibility/woocommerce/config/header/cart.php:235
+#: inc/compatibility/woocommerce/config/header/cart.php:194
+#: inc/compatibility/woocommerce/config/header/cart.php:250
 #: inc/customizer/configs/blogs.php:371
 #: inc/customizer/configs/header/button.php:107
 #: inc/customizer/configs/header/panel.php:300
@@ -238,7 +242,7 @@ msgid "Styling"
 msgstr ""
 
 #: inc/admin/dashboard.php:338 inc/compatibility/breadcrumb.php:203
-#: inc/compatibility/woocommerce/config/header/cart.php:206
+#: inc/compatibility/woocommerce/config/header/cart.php:221
 #: inc/customizer/configs/blogs.php:357
 #: inc/customizer/configs/header/button.php:96
 #: inc/customizer/configs/typography.php:164 inc/style-guide-template.php:554
@@ -254,6 +258,7 @@ msgid "Titlebar Settings"
 msgstr ""
 
 #: inc/admin/dashboard.php:352 inc/customizer/configs/blogs.php:8
+#: inc/customizer/configs/layouts.php:219
 msgid "Blog Posts"
 msgstr ""
 
@@ -644,8 +649,8 @@ msgstr ""
 
 #: inc/class-customify.php:305 inc/class-customify.php:316
 #: inc/class-customify.php:330
-#: inc/compatibility/woocommerce/woocommerce.php:583
-#: inc/compatibility/woocommerce/woocommerce.php:594
+#: inc/compatibility/woocommerce/woocommerce.php:587
+#: inc/compatibility/woocommerce/woocommerce.php:598
 msgid "Add widgets here."
 msgstr ""
 
@@ -670,8 +675,8 @@ msgstr ""
 #: inc/customizer/class-customizer.php:814
 #: inc/customizer/class-customizer.php:909
 #: inc/customizer/configs/header/social-icons.php:273
-#: inc/customizer/configs/layouts.php:309
-#: inc/customizer/configs/layouts.php:332
+#: inc/customizer/configs/layouts.php:398
+#: inc/customizer/configs/layouts.php:421
 #: inc/customizer/configs/page-header.php:236
 #: inc/customizer/configs/page-header.php:277
 #: inc/customizer/configs/page-header.php:288
@@ -721,7 +726,7 @@ msgstr ""
 
 #: inc/class-metabox.php:67 inc/customizer/configs/footer/panel.php:158
 #: inc/customizer/configs/header/panel.php:129
-#: inc/customizer/configs/layouts.php:42
+#: inc/customizer/configs/layouts.php:51
 #: inc/customizer/configs/page-header.php:238
 msgid "Full Width"
 msgstr ""
@@ -922,6 +927,7 @@ msgid "Download"
 msgstr ""
 
 #: inc/color-palette-switcher.php:223
+#: inc/compatibility/woocommerce/config/header/cart.php:699
 #: inc/customizer/controls/class-control-repeater.php:33
 #: inc/panel-builder/class-abstract-layout-frontend.php:122
 #: inc/panel-builder/class-layout-builder.php:565
@@ -960,6 +966,20 @@ msgstr ""
 
 #: inc/color-palette-switcher.php:231
 msgid "Linked to palette"
+msgstr ""
+
+#: inc/color-palette-switcher.php:232
+msgid "Save current colors?"
+msgstr ""
+
+#: inc/color-palette-switcher.php:233
+msgid ""
+"These colors are not saved as a palette. Save them before switching so you "
+"can recover them later."
+msgstr ""
+
+#: inc/color-palette-switcher.php:234
+msgid "Save & switch"
 msgstr ""
 
 #: inc/colors-palette.php:1914
@@ -1097,7 +1117,7 @@ msgid "Styling for breadcrumb"
 msgstr ""
 
 #: inc/compatibility/woocommerce/config/cart.php:46
-#: inc/compatibility/woocommerce/config/header/cart.php:76
+#: inc/compatibility/woocommerce/config/header/cart.php:91
 msgid "Cart"
 msgstr ""
 
@@ -1286,88 +1306,89 @@ msgid "On Sale"
 msgstr ""
 
 #: inc/compatibility/woocommerce/config/header/cart.php:35
+#: inc/compatibility/woocommerce/config/header/cart.php:697
 msgid "Shopping Cart"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:75
+#: inc/compatibility/woocommerce/config/header/cart.php:90
 #: inc/customizer/configs/header/nav-icon.php:36
 msgid "Label"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:89
+#: inc/compatibility/woocommerce/config/header/cart.php:104
 #: inc/customizer/configs/header/button.php:57
 #: inc/customizer/configs/header/social-icons.php:104
 msgid "Icon"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:100
+#: inc/compatibility/woocommerce/config/header/cart.php:115
 #: inc/customizer/configs/header/button.php:69
 msgid "Before"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:101
+#: inc/compatibility/woocommerce/config/header/cart.php:116
 #: inc/customizer/configs/header/button.php:70
 msgid "After"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:103
+#: inc/compatibility/woocommerce/config/header/cart.php:118
 #: inc/customizer/configs/header/button.php:67
 #: inc/customizer/configs/header/search-box.php:131
 #: inc/customizer/configs/header/search-icon.php:245
 msgid "Icon Position"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:114
+#: inc/compatibility/woocommerce/config/header/cart.php:129
 msgid "Cart Page"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:115
+#: inc/compatibility/woocommerce/config/header/cart.php:130
 msgid "Checkout"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:117
+#: inc/compatibility/woocommerce/config/header/cart.php:132
 msgid "Link To"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:132
-#: inc/compatibility/woocommerce/config/header/cart.php:133
+#: inc/compatibility/woocommerce/config/header/cart.php:147
+#: inc/compatibility/woocommerce/config/header/cart.php:148
 #: inc/customizer/configs/header/nav-icon.php:52
 msgid "Show Label"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:144
+#: inc/compatibility/woocommerce/config/header/cart.php:159
 msgid "Sub Total"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:145
+#: inc/compatibility/woocommerce/config/header/cart.php:160
 msgid "Show Sub Total"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:161
-#: inc/compatibility/woocommerce/config/header/cart.php:262
+#: inc/compatibility/woocommerce/config/header/cart.php:176
+#: inc/compatibility/woocommerce/config/header/cart.php:277
 #: woocommerce/cart/cart.php:32 woocommerce/cart/cart.php:140
 msgid "Quantity"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:162
+#: inc/compatibility/woocommerce/config/header/cart.php:177
 msgid "Show Quantity"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:171
+#: inc/compatibility/woocommerce/config/header/cart.php:186
 #: inc/customizer/configs/blogs.php:245
 #: inc/customizer/configs/single-blog-post.php:150
 msgid "Separator"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:172
+#: inc/compatibility/woocommerce/config/header/cart.php:187
 msgid "/"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:216
+#: inc/compatibility/woocommerce/config/header/cart.php:231
 msgid "Icon Settings"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:225
+#: inc/compatibility/woocommerce/config/header/cart.php:240
 #: inc/customizer/configs/header/nav-icon.php:61
 #: inc/customizer/configs/header/search-box.php:103
 #: inc/customizer/configs/header/search-icon.php:65
@@ -1375,38 +1396,106 @@ msgstr ""
 msgid "Icon Size"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:236
+#: inc/compatibility/woocommerce/config/header/cart.php:251
 msgid "Advanced styling for cart icon"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:263
+#: inc/compatibility/woocommerce/config/header/cart.php:278
 msgid "Advanced styling for cart quantity"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:289
+#: inc/compatibility/woocommerce/config/header/cart.php:307
+msgid "Cart Behavior"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:314
+msgid "Behavior"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:317
+msgid "Dropdown"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:318
+msgid "Off-Canvas Drawer"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:327
 msgid "Dropdown Settings"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:296
+#: inc/compatibility/woocommerce/config/header/cart.php:335
 msgid "Dropdown Alignment"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:301
+#: inc/compatibility/woocommerce/config/header/cart.php:341
+#: inc/compatibility/woocommerce/config/header/cart.php:381
 #: inc/customizer/configs/header/logo.php:84
 #: inc/customizer/configs/related-posts.php:93
 #: inc/customizer/controls/class-control-css-ruler.php:70
 msgid "Left"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:302
+#: inc/compatibility/woocommerce/config/header/cart.php:342
+#: inc/compatibility/woocommerce/config/header/cart.php:380
 #: inc/customizer/configs/header/logo.php:85
 #: inc/customizer/configs/related-posts.php:94
 #: inc/customizer/controls/class-control-css-ruler.php:62
 msgid "Right"
 msgstr ""
 
-#: inc/compatibility/woocommerce/config/header/cart.php:313
+#: inc/compatibility/woocommerce/config/header/cart.php:353
 msgid "Dropdown Width"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:368
+msgid "Drawer Settings"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:376
+msgid "Drawer Position"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:389
+msgid "Drawer Width"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:408
+msgid "Auto-open on Add to Cart"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:417
+msgid "Drawer Offset"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:418
+msgid ""
+"Gap from the screen edges. Set values to float the drawer away from the "
+"edge."
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:439
+msgid "Corner Radius"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:453
+msgid "Backdrop Color"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:464
+msgid "Panel Background"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:475
+msgid "Heading Color"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:695
+msgid "Shopping cart"
+msgstr ""
+
+#: inc/compatibility/woocommerce/config/header/cart.php:713
+msgid "Continue Shopping"
 msgstr ""
 
 #: inc/compatibility/woocommerce/config/single-product.php:156
@@ -1517,20 +1606,41 @@ msgstr ""
 msgid "Your order"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:535
+#: inc/compatibility/woocommerce/woocommerce.php:539
 msgid "Display on product taxonomies (categories/tags,..)"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:543
+#: inc/compatibility/woocommerce/woocommerce.php:547
 msgid "Display on single product"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:581
+#: inc/compatibility/woocommerce/woocommerce.php:585
 msgid "WooCommerce Primary Sidebar"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:592
+#: inc/compatibility/woocommerce/woocommerce.php:596
 msgid "WooCommerce Secondary Sidebar"
+msgstr ""
+
+#: inc/content-area-spacing.php:16
+#: inc/customizer/controls/class-control-base.php:310
+msgid "Inherit"
+msgstr ""
+
+#: inc/content-area-spacing.php:17
+msgid "Top & Bottom"
+msgstr ""
+
+#: inc/content-area-spacing.php:18
+msgid "Top Only"
+msgstr ""
+
+#: inc/content-area-spacing.php:19
+msgid "Bottom Only"
+msgstr ""
+
+#: inc/content-area-spacing.php:20
+msgid "Disabled"
 msgstr ""
 
 #: inc/customizer/class-customify-panel.php:31
@@ -2387,14 +2497,14 @@ msgstr ""
 
 #: inc/customizer/configs/header/logo.php:55
 #: inc/customizer/configs/header/logo.php:69
-#: inc/customizer/configs/layouts.php:54 inc/customizer/configs/layouts.php:227
+#: inc/customizer/configs/layouts.php:63 inc/customizer/configs/layouts.php:284
 msgid "Yes"
 msgstr ""
 
 #: inc/customizer/configs/header/logo.php:56
 #: inc/customizer/configs/header/logo.php:70
 #: inc/customizer/configs/header/panel.php:469
-#: inc/customizer/configs/layouts.php:55 inc/customizer/configs/layouts.php:228
+#: inc/customizer/configs/layouts.php:64 inc/customizer/configs/layouts.php:285
 msgid "No"
 msgstr ""
 
@@ -2842,117 +2952,136 @@ msgstr ""
 msgid "Global"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:36
+#: inc/customizer/configs/layouts.php:39
+msgid "Content Area Spacing"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:45
 msgid "Site layout"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:37
+#: inc/customizer/configs/layouts.php:46
 msgid "Select global site layout."
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:43 inc/customizer/configs/layouts.php:166
+#: inc/customizer/configs/layouts.php:52 inc/customizer/configs/layouts.php:175
 msgid "Boxed"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:44
+#: inc/customizer/configs/layouts.php:53
 msgid "Framed"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:52
+#: inc/customizer/configs/layouts.php:61
 msgid "Site boxed/framed shadow"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:69
+#: inc/customizer/configs/layouts.php:78
 msgid "Site framed margin"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:88
+#: inc/customizer/configs/layouts.php:97
 msgid "Width"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:111
+#: inc/customizer/configs/layouts.php:120
 msgid "Container Width"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:112
+#: inc/customizer/configs/layouts.php:121
 msgid "Max width of the site container."
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:145
+#: inc/customizer/configs/layouts.php:154
 msgid "Narrow Content Width"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:146
+#: inc/customizer/configs/layouts.php:155
 msgid ""
 "Max width when a post uses the \"Narrow\" Content Layout option in the Page "
 "Settings panel."
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:155
+#: inc/customizer/configs/layouts.php:164
 msgid "Content Area"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:163
+#: inc/customizer/configs/layouts.php:172
 msgid "Site content layout"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:165
+#: inc/customizer/configs/layouts.php:174
 msgid "Full width"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:177
-msgid "Site content padding"
-msgstr ""
-
-#: inc/customizer/configs/layouts.php:196
-msgid "Sidebars"
-msgstr ""
-
-#: inc/customizer/configs/layouts.php:203
+#: inc/customizer/configs/layouts.php:186
+#: inc/customizer/configs/layouts.php:260
 msgid "General"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:217
-msgid "Default Sidebar Layout"
+#: inc/customizer/configs/layouts.php:193
+msgid "Site content padding"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:225
-msgid "Sidebar with vertical border"
-msgstr ""
-
-#: inc/customizer/configs/layouts.php:239
-msgid "Page Types"
-msgstr ""
-
-#: inc/customizer/configs/layouts.php:250
+#: inc/customizer/configs/layouts.php:211
+#: inc/customizer/configs/layouts.php:307
 msgid "Pages"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:259
+#: inc/customizer/configs/layouts.php:227
+msgid "Blog Archives"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:235
+msgid "Search"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:253
+msgid "Sidebars"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:274
+msgid "Default Sidebar Layout"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:282
+msgid "Sidebar with vertical border"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:296
+msgid "Page Types"
+msgstr ""
+
+#: inc/customizer/configs/layouts.php:316
 msgid "Blog posts"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:268
+#: inc/customizer/configs/layouts.php:325
 msgid "Blog Archive Page"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:277
+#: inc/customizer/configs/layouts.php:334
 msgid "Search Page"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:286
+#: inc/customizer/configs/layouts.php:343
 msgid "404 Page"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:298
+#: inc/customizer/configs/layouts.php:356
+#: inc/customizer/configs/layouts.php:387
 msgid "Post Type Settings"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:307
+#: inc/customizer/configs/layouts.php:366
+#: inc/customizer/configs/layouts.php:396
+#. translators: %s: singular post type label.
 msgid "Single %s"
 msgstr ""
 
-#: inc/customizer/configs/layouts.php:330
+#: inc/customizer/configs/layouts.php:377
+#: inc/customizer/configs/layouts.php:419
+#. translators: %s: singular post type label.
 msgid "%s Archive"
 msgstr ""
 
@@ -3383,7 +3512,7 @@ msgid "Widget Title"
 msgstr ""
 
 #: inc/customizer/configs/typography.php:362
-msgid "Apply to all widget title in site content."
+msgid "Apply to widget titles in all widget areas."
 msgstr ""
 
 #: inc/customizer/configs/upsell.php:17
@@ -3445,10 +3574,6 @@ msgstr ""
 
 #: inc/customizer/controls/class-control-base.php:309
 msgid "Theme Default"
-msgstr ""
-
-#: inc/customizer/controls/class-control-base.php:310
-msgid "Inherit"
 msgstr ""
 
 #: inc/customizer/controls/class-control-base.php:314
@@ -3784,7 +3909,7 @@ msgstr ""
 msgid "Content / Sidebar / Sidebar"
 msgstr ""
 
-#: inc/template-functions.php:853
+#: inc/template-functions.php:904
 msgid "Search &hellip;"
 msgstr ""
 
@@ -4004,7 +4129,7 @@ msgstr ""
 #: inc/customizer/configs/header/search-box.php:287
 #: inc/customizer/configs/header/search-icon.php:347
 #: inc/customizer/configs/header/search-icon.php:348
-#: inc/template-functions.php:852 inc/template-functions.php:853
+#: inc/template-functions.php:903 inc/template-functions.php:904
 msgctxt "label"
 msgid "Search for:"
 msgstr ""
@@ -4019,17 +4144,17 @@ msgctxt "customify-font-weight"
 msgid "Bold"
 msgstr ""
 
-#: inc/template-functions.php:831
+#: inc/template-functions.php:882
 msgctxt "yearly archives date format"
 msgid "Y"
 msgstr ""
 
-#: inc/template-functions.php:833
+#: inc/template-functions.php:884
 msgctxt "monthly archives date format"
 msgid "F Y"
 msgstr ""
 
-#: inc/template-functions.php:835
+#: inc/template-functions.php:886
 msgctxt "daily archives date format"
 msgid "F j, Y"
 msgstr ""
@@ -4169,32 +4294,4 @@ msgstr[1] ""
 #: woocommerce/product-searchform.php:26
 msgctxt "submit button"
 msgid "Search"
-msgstr ""
-
-#: inc/customizer/configs/layouts.php:243
-msgid "404"
-msgstr ""
-
-#: inc/customizer/configs/layouts.php:39
-msgid "Content Area Spacing"
-msgstr ""
-
-#: inc/content-area-spacing.php:17
-msgid "Top & Bottom"
-msgstr ""
-
-#: inc/content-area-spacing.php:18
-msgid "Top Only"
-msgstr ""
-
-#: inc/content-area-spacing.php:19
-msgid "Bottom Only"
-msgstr ""
-
-#: inc/content-area-spacing.php:20
-msgid "Disabled"
-msgstr ""
-
-#: inc/customizer/configs/layouts.php:227
-msgid "Blog Archives"
 msgstr ""

--- a/src/frontend/scss/compatibility/wc/_woocommerce-layout.scss
+++ b/src/frontend/scss/compatibility/wc/_woocommerce-layout.scss
@@ -307,6 +307,17 @@
     margin-inline-end: 0.5em;
 }
 
+.wc-block-product-gallery-thumbnails__scrollable,
+.wp-block-woocommerce-product-gallery {
+    gap: 1em;
+}
+
+// WooCommerce applies this through a zero-specificity `:where()` selector,
+// which lets the theme's list spacing win in block-based product galleries.
+.wc-block-product-gallery-large-image__container {
+    margin: 0;
+}
+
 // Un-trap the WooCommerce product-filters overlay from a Blocksify Section's
 // stacking context (.bsy-section__inner has position:relative; z-index:2 for its
 // shape/bg layering, which traps the overlay's position:fixed below the header).

--- a/src/frontend/scss/compatibility/wc/_woocommerce-main.scss
+++ b/src/frontend/scss/compatibility/wc/_woocommerce-main.scss
@@ -180,6 +180,16 @@ p.demo_store,
         padding-block: 0;
     }
 
+    // The standard WooCommerce Add to Cart Form stretches the quantity wrapper
+    // to the adjacent button, but its number input keeps a font-relative height.
+    // Fill the wrapper without changing the theme's field skin.
+    .wc-block-add-to-cart-form
+    .quantity:not(.wc-block-components-quantity-selector)
+    input[type="number"].input-text.qty.text {
+        box-sizing: border-box;
+        height: 100%;
+    }
+
     .blockUI.blockOverlay {
         position: relative;
         z-index: 35 !important;


### PR DESCRIPTION
## Summary
- port the five commits from #459 to the uppercase DEV branch
- apply Widget Title typography across widget areas
- add Transparent Header text color with sticky precedence
- preserve header row Advanced Styling in transparent state
- include the reviewed WooCommerce block layout fixes
- refresh the translation catalog

## Validation
- npm run build
- PHP lint for changed Customizer configuration files
- git diff --check and LF line-ending audit

Original PR into lowercase dev: #459