### PR TITLE
fix(woocommerce): guard cart during widget REST rendering

### DIFF
--- a/inc/compatibility/woocommerce/config/header/cart.php
+++ b/inc/compatibility/woocommerce/config/header/cart.php
@@ -674,13 +674,14 @@ class Customify_Builder_Item_WC_Cart {
 
 	/**
 	 * Print the off-canvas drawer panel + overlay once, near </body>, when the
-	 * Cart Behavior is Drawer. Skipped on Cart/Checkout (nothing to preview
-	 * there — the cart link just follows its href). The body reuses WooCommerce
-	 * core's own `.widget_shopping_cart_content` + woocommerce_mini_cart() so
-	 * the AJAX fragments keep it in live sync on add/remove.
+	 * Cart Behavior is Drawer. Skipped when the cart is unavailable and on
+	 * Cart/Checkout (nothing to preview there — the cart link just follows its
+	 * href). The body reuses WooCommerce core's own
+	 * `.widget_shopping_cart_content` + woocommerce_mini_cart() so the AJAX
+	 * fragments keep it in live sync on add/remove.
 	 */
 	public function render_cart_drawer() {
-		if ( ! function_exists( 'WC' ) || is_cart() || is_checkout() ) {
+		if ( ! function_exists( 'WC' ) || ! WC()->cart || is_cart() || is_checkout() ) {
 			return;
 		}
 

--- a/woocommerce/cart/mini-cart.php
+++ b/woocommerce/cart/mini-cart.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 do_action( 'woocommerce_before_mini_cart' ); ?>
 
-<?php if ( ! WC()->cart->is_empty() ) : ?>
+<?php if ( WC()->cart && ! WC()->cart->is_empty() ) : ?>
 
 	<ul class="woocommerce-mini-cart cart_list <?php echo esc_attr( $args['list_class'] ); ?>">
 		<?php


### PR DESCRIPTION
## Summary

- Skip the off-canvas cart drawer when the WooCommerce cart is unavailable.
- Guard the theme mini-cart override against a null `WC()->cart`, matching WooCommerce core behavior.

## Root cause

The WordPress legacy widget REST renderer calls `wp_footer()` while processing `/wp/v2/widget-types/<type>/render`. In this REST context, `WC()->cart` can be null. The Customify cart drawer called `woocommerce_mini_cart()` from `wp_footer()`, and the theme mini-cart template dereferenced the missing cart, causing a PHP fatal and an invalid JSON response.

## Testing

- [x] Reproduced the `nav_menu/render` 500 response on the local Fallow site before the fix.
- [x] Confirmed the REST dispatcher returns status 200 with a JSON `preview` after the fix.
- [x] Reloaded Customizer and opened the footer widget without a new WooCommerce fatal log entry.
- [x] Verified the mini-cart template handles a null cart without a fatal error.
- [x] Verified the frontend cart drawer still renders with the current cart contents.
- [x] Ran PHP syntax checks for both changed files.
- [x] Ran `git diff --check`.
- [x] Ran `npm run build` successfully.