### PR TITLE
Add per-page Transparent Header override

### DIFF
--- a/docs/SPEC-header-transparent.md
+++ b/docs/SPEC-header-transparent.md
@@ -176,75 +176,66 @@ if ( $hide ) $is_tran = false;
 
 ### 4.3 Tier 3 — Per-page metabox override
 
-Runs **inside** the tier-1 `if ( $is_tran ) { … }` block ([`transparent.php:338-348`](../inc/customizer/configs/header/transparent.php#L338-L348)):
+The value is read from `_customify_header_transparent_display` and applied
+after the inherited Customizer result and the compatibility filter. This makes
+an explicit metabox choice the final display decision for that page:
 
 ```php
-if ( Customify()->is_using_post() ) {
-    $id = Customify()->get_current_post_id();
-    if ( $id ) {
-        $meta = get_post_meta( $id, '_customify_header_transparent_display', true );
-        if ( $meta === 'hide' )       $is_tran = false;
-        elseif ( $meta === 'show' )   $is_tran = true;
-    }
+if ( 'hide' === $override ) {
+    $is_tran = false;
+} elseif ( 'show' === $override && $has_transparent_row ) {
+    $is_tran = true;
 }
 ```
 
-The metabox UI field is `header_transparent_display` on tab `page_header` ([`class-metabox.php:125-137`](../inc/class-metabox.php#L125-L137)) with three choices:
+The metabox UI field is `header_transparent_display`. It is rendered in both
+the classic-editor Page Header tab and the block editor's **Customify Page
+Settings** panel, but only while a Transparent Header
+implementation is enabled. The free theme port is always enabled when Pro
+does not own the feature; when Pro is present, its module toggle is
+authoritative.
 
 | Choice | Stored value | Effect |
 |---|---|---|
-| Inherit from Customizer settings | `'default'` (or empty) | Use tier 1 + 2 result |
-| Force transparent | `'show'` | Override tier 2 only — **does not bypass tier 1** |
-| Force opaque | `'hide'` | Override tier 2 — force opaque header |
+| Default | `'default'` (or empty) | Use the filtered tier 1 + 2 result |
+| Enable | `'show'` | Final display override when at least one row is configured transparent; adds `is-header-transparent-forced` so the header overlays pages without a page cover |
+| Disable | `'hide'` | Final display override — force opaque header |
 
-### 4.4 Final filter
+### 4.4 Compatibility filter
 
 ```php
-self::$is_transparent = apply_filters( 'customify/render_header/is-transparent', $is_tran );
+$is_tran = apply_filters( 'customify/render_header/is-transparent', $is_tran );
 ```
 
-Last word goes to the filter. **The result is cached** — any callback added after the first `is_transparent()` call of the request is ignored. See §7 issue #6.
+The filter can change the inherited result, but an explicit per-page `show` or
+`hide` value is applied afterward. **The final result is cached** — any callback
+added after the first `is_transparent()` call of the request is ignored. See §7
+issue #6.
 
 ### 4.5 Resolution flowchart
 
 ```
-                ┌─────────────────────────────┐
-                │ Any row toggle ON?          │
-                │ header_{top|main|bottom}_   │
-                │ transparent                 │
-                └──────────────┬──────────────┘
-                  No           │  Yes
-                  ▼            ▼
-              return ◀──────────────────────┐
-              false                          │
-                                             ▼
-                      ┌──────────────────────────────┐
-                      │ Resolve page-type key (§4.2) │
-                      │ Check display['<key>']        │
-                      └──────────────┬───────────────┘
-                        Excluded     │  Allowed
-                        ▼            ▼
-                  $is_tran = false   │
-                        │            │
-                        └────►──────┐│
-                                    ▼▼
-                          ┌──────────────────────┐
-                          │ Per-page meta?       │
-                          │ '_customify_header_  │
-                          │ transparent_display' │
-                          └──────────┬───────────┘
-                'hide' │ ''/default │ 'show'
-                   ▼   ▼            ▼
-              false  keep          true
-                          │
-                          ▼
-                ┌─────────────────────────────┐
-                │ apply_filters(              │
-                │ 'customify/render_header/   │
-                │  is-transparent', …)         │
-                └──────────────┬──────────────┘
-                               ▼
-                          cached result
+┌─────────────────────────────┐
+│ Any row toggle ON?          │
+│ Establish inherited result  │
+└──────────────┬──────────────┘
+               ▼
+┌─────────────────────────────┐
+│ Apply page-type exclusions  │
+└──────────────┬──────────────┘
+               ▼
+┌─────────────────────────────┐
+│ Apply compatibility filter  │
+└──────────────┬──────────────┘
+               ▼
+┌─────────────────────────────┐
+│ Apply per-page meta last    │
+│ hide → false                │
+│ show + configured row → true│
+│ default → keep result       │
+└──────────────┬──────────────┘
+               ▼
+          cached result
 ```
 
 ---
@@ -300,7 +291,7 @@ The `--transparent-header-height` CSS variable and `.has-transparent-offset` bod
 
 | Hook | Type | Arguments | Use case |
 |---|---|---|---|
-| `customify/render_header/is-transparent` | filter | `(bool $is_tran)` | Final override; runs once per request before caching |
+| `customify/render_header/is-transparent` | filter | `(bool $is_tran)` | Filter the inherited display result before the final per-page override |
 | `customify/builder/row-classes` | filter | `(array $classes, string $row_id, $builder)` | Where this feature itself injects `.header--transparent` |
 | `customify/logo-classes` | filter | `(array $classes)` | Where this feature injects `.has-tran-logo` / `.no-tran-logo` |
 | `customizer/after-logo-img` | action | none | Where this feature outputs `<img class="site-img-logo-tran">` |
@@ -330,11 +321,15 @@ Workaround: document this in support, or add a dedicated `front` key on the next
 
 `is_shop()` is checked in the WC branch and maps to `display['page']`. There is no dedicated `shop` key. Users have to disable "Single page" to also disable shop — which then also disables all static pages. No workaround without adding a new key.
 
-### Issue #3 — Per-page metabox `show` cannot bypass tier 1
+### Issue #3 — Per-page metabox `show` requires a configured row
 
-The metabox override runs **inside** the `if ( $is_tran )` block ([`transparent.php:280`](../inc/customizer/configs/header/transparent.php#L280)). If every row toggle is off, `is_transparent()` returns `false` before reaching the metabox check, so a "Force transparent" choice on a specific page is ignored.
+The metabox is the final display override, but it does not choose which header
+rows use the transparent skin. If every row toggle is off, a page-level
+`show` value cannot enable the feature because there is no configured
+transparent row.
 
-For "Force transparent" to be respected, **at least one** row toggle must be enabled in the Customizer.
+For `Enable` to take effect, **at least one** row toggle must be enabled in the
+Customizer.
 
 ### Issue #4 — Per-page metabox `show` does not choose which row is transparent
 
@@ -382,8 +377,8 @@ Pro typically extends with: sticky transparent behaviour, scroll-triggered anima
 | I want to… | Code |
 |---|---|
 | Check programmatically whether transparent is active on the current request | `Customify_Header_Transparent::get_instance()->is_transparent()` |
-| Force-disable transparent header in a specific scenario | `add_filter( 'customify/render_header/is-transparent', '__return_false' );` (register early) |
-| Force-enable transparent header in a specific scenario | `add_filter( 'customify/render_header/is-transparent', '__return_true' );` (register early; also requires at least one row toggle ON) |
+| Filter-disable transparent header when the page uses `Default` | `add_filter( 'customify/render_header/is-transparent', '__return_false' );` (register early) |
+| Filter-enable transparent header when the page uses `Default` | `add_filter( 'customify/render_header/is-transparent', '__return_true' );` (register early; rows still control which skins are transparent) |
 | Read whether a specific row is currently transparent | `Customify()->get_setting( "header_{$row}_transparent" )` + `is_transparent()` |
 | Read the per-page override | `get_post_meta( $post_id, '_customify_header_transparent_display', true )` returns `''`, `'show'`, or `'hide'` |
 | Find which display keys are excluded | `Customify()->get_setting_tab( 'header_transparent_display_pages', 'display' )` |

--- a/docs/SPEC-pro-integration.md
+++ b/docs/SPEC-pro-integration.md
@@ -368,7 +368,7 @@ Filters that exist primarily for Pro consumption — changing signatures require
 | `customify/customizer/config` | filter | Append config items (Pro's primary extension point) |
 | `customify/builder/<builder>/items` | filter | Register builder items (Pro extends header + footer) |
 | `customify/builder/<builder>/rows` | filter | Override builder rows (Pro can add new rows) |
-| `customify/render_header/is-transparent` | filter | Final transparent-header override |
+| `customify/render_header/is-transparent` | filter | Filter the inherited transparent-header result before the final per-page override |
 | `customify/breadcrumb/is-showing` | filter | Conditional breadcrumb rendering |
 | `customify_dashboard_pro_active` | filter | Pro flips to `true` |
 | `customify_dashboard_localize` | filter | Pro injects boot payload extras |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -135,7 +135,7 @@ add_filter( 'customify/styling/primary-color', function ( $css ) {
 
 | Hook | Type | Payload | File |
 |---|---|---|---|
-| `customify/render_header/is-transparent` | filter | `bool $is_tran` — final override before result is cached | [`inc/customizer/configs/header/transparent.php`](../inc/customizer/configs/header/transparent.php) |
+| `customify/render_header/is-transparent` | filter | `bool $is_tran` — filters the inherited result before the final per-page metabox override and caching | [`inc/customizer/configs/header/transparent.php`](../inc/customizer/configs/header/transparent.php) |
 
 Note: the result is cached on first call. Register the filter as early as possible (`after_setup_theme`, `init`) — late hooks won't run.
 
@@ -204,6 +204,7 @@ Template tags are PHP functions you call from theme template files. Most live in
 | `customify_get_layout()` | Resolves to one of the 4 layout values |
 | `Customify()->get_setting( $key, $device = null )` | Read a Customizer setting (device-aware) |
 | `Customify()->customizer->get_field_setting( $name )` | Read the config definition for a field |
+| `customify_is_header_transparent_module_enabled()` | Whether the native or Pro Transparent Header implementation is enabled |
 | `Customify()->is_woocommerce_active()` | Boolean — WC plugin active |
 | `Customify()->is_using_post()` | Boolean — current request is a singular post-like context |
 | `Customify()->get_current_post_id()` | Best-guess current post ID across is_singular / blog page / etc. |

--- a/inc/admin/page-settings.php
+++ b/inc/admin/page-settings.php
@@ -138,6 +138,8 @@ class Customify_Page_Settings {
 
 		$has_breadcrumb = class_exists( 'Customify_Breadcrumb' ) &&
 		                  Customify_Breadcrumb::get_instance()->support_plugins_active();
+		$has_header_transparent = function_exists( 'customify_is_header_transparent_module_enabled' )
+			&& customify_is_header_transparent_module_enabled();
 
 		// Resolve the layout to use when the per-post sidebar meta is empty
 		// (i.e. "Inherit from Customizer"). Computed server-side because the
@@ -206,6 +208,7 @@ class Customify_Page_Settings {
 				'sidebarLayouts'  => customify_get_config_sidebar_layouts(),
 				'hasProFeatures'  => (bool) class_exists( 'Customify_Pro' ),
 				'hasBreadcrumb'   => (bool) $has_breadcrumb,
+				'hasHeaderTransparent' => (bool) $has_header_transparent,
 				'fallbackLayout'  => $fallback_layout,
 				'contentSizeMap'  => customify_get_layout_content_sizes(),
 				'postType'        => $post_type,

--- a/inc/class-metabox.php
+++ b/inc/class-metabox.php
@@ -146,19 +146,28 @@ class Customify_MetaBox {
 		// `_customify_page_header_display` is unchanged — saved values on
 		// existing sites still load correctly.
 
-		$this->field_builder->add_field(
-			array(
-				'title'   => __( 'Transparent Header', 'customify' ),
-				'name'    => 'header_transparent_display',
-				'tab'     => 'page_header',
-				'type'    => 'select',
-				'choices' => array(
-					'default' => __( 'Inherit from Customizer settings', 'customify' ),
-					'show'    => __( 'Force transparent', 'customify' ),
-					'hide'    => __( 'Force opaque', 'customify' ),
-				),
-			)
-		);
+		// Pro registers the classic-editor field itself when its module is
+		// enabled. The theme supplies the field only for the native fallback,
+		// avoiding a duplicate control when Pro owns the feature.
+		if (
+			function_exists( 'customify_is_header_transparent_module_enabled' )
+			&& customify_is_header_transparent_module_enabled()
+			&& ! class_exists( 'Customify_Pro_Module_Header_Transparent' )
+		) {
+			$this->field_builder->add_field(
+				array(
+					'title'   => __( 'Transparent Header', 'customify' ),
+					'name'    => 'header_transparent_display',
+					'tab'     => 'page_header',
+					'type'    => 'select',
+					'choices' => array(
+						'default' => __( 'Default', 'customify' ),
+						'show'    => __( 'Enable', 'customify' ),
+						'hide'    => __( 'Disable', 'customify' ),
+					),
+				)
+			);
+		}
 
 		if ( Customify_Breadcrumb::get_instance()->support_plugins_active() ) {
 			$this->field_builder->add_tab(

--- a/inc/customizer/configs/header/transparent.php
+++ b/inc/customizer/configs/header/transparent.php
@@ -292,23 +292,47 @@ class Customify_Header_Transparent {
 	}
 
 	/**
+	 * Get the current post's explicit Transparent Header override.
+	 *
+	 * Empty and legacy unknown values continue to inherit the Customizer result.
+	 *
+	 * @return string Either default, show, or hide.
+	 */
+	private function get_current_post_override() {
+		if ( ! Customify()->is_using_post() ) {
+			return 'default';
+		}
+
+		$id = Customify()->get_current_post_id();
+		if ( ! $id ) {
+			return 'default';
+		}
+
+		$meta = get_post_meta( $id, '_customify_header_transparent_display', true );
+		return in_array( $meta, array( 'show', 'hide' ), true ) ? $meta : 'default';
+	}
+
+	/**
 	 * Determine whether the transparent header should be active on the current page.
 	 *
 	 * Checks:
 	 *   1. At least one header row has its transparent setting enabled.
 	 *   2. The page type is not in the "disable on" list.
-	 *   3. The per-page post meta does not force it off (or forces it on).
+	 *   3. Extensions can filter the inherited result.
+	 *   4. The per-page post meta is applied last.
 	 */
 	public function is_transparent( $force = false ) {
 		if ( self::$is_transparent === null || $force ) {
-			$is_tran = false;
+			$has_transparent_row = false;
 
 			foreach ( array( 'top', 'main', 'bottom' ) as $row_id ) {
 				if ( Customify()->get_setting( "header_{$row_id}_transparent" ) ) {
-					$is_tran = true;
+					$has_transparent_row = true;
 					break;
 				}
 			}
+
+			$is_tran = $has_transparent_row;
 
 			if ( $is_tran ) {
 				$display = Customify()->get_setting_tab( 'header_transparent_display_pages', 'display' );
@@ -366,22 +390,18 @@ class Customify_Header_Transparent {
 				if ( $hide ) {
 					$is_tran = false;
 				}
-
-				// Per-page post meta override.
-				if ( Customify()->is_using_post() ) {
-					$id = Customify()->get_current_post_id();
-					if ( $id ) {
-						$meta = get_post_meta( $id, '_customify_header_transparent_display', true );
-						if ( $meta === 'hide' ) {
-							$is_tran = false;
-						} elseif ( $meta === 'show' ) {
-							$is_tran = true;
-						}
-					}
-				}
 			}
 
-			self::$is_transparent = apply_filters( 'customify/render_header/is-transparent', $is_tran );
+			$is_tran = apply_filters( 'customify/render_header/is-transparent', $is_tran );
+			$override = $this->get_current_post_override();
+
+			if ( 'hide' === $override ) {
+				$is_tran = false;
+			} elseif ( 'show' === $override && $has_transparent_row ) {
+				$is_tran = true;
+			}
+
+			self::$is_transparent = $is_tran;
 		}
 
 		return self::$is_transparent;
@@ -393,6 +413,10 @@ class Customify_Header_Transparent {
 	public function body_classes( $classes ) {
 		if ( $this->is_transparent() ) {
 			$classes['header_transparent'] = 'is-header-transparent';
+
+			if ( 'show' === $this->get_current_post_override() ) {
+				$classes['header_transparent_forced'] = 'is-header-transparent-forced';
+			}
 		}
 		return $classes;
 	}
@@ -427,6 +451,32 @@ class Customify_Header_Transparent {
 		$classes[] = $logo_image ? 'has-tran-logo' : 'no-tran-logo';
 
 		return $classes;
+	}
+}
+
+if ( ! function_exists( 'customify_is_header_transparent_module_enabled' ) ) {
+	/**
+	 * Check whether a Transparent Header implementation is active.
+	 *
+	 * The free theme port is always available when Customify Pro does not own the
+	 * feature. When Pro is present, honour its module toggle instead of treating
+	 * the loaded module class as enabled.
+	 *
+	 * @return bool
+	 */
+	function customify_is_header_transparent_module_enabled() {
+		if ( class_exists( 'Customify_Pro_Module_Header_Transparent' ) ) {
+			if ( ! function_exists( 'Customify_Pro' ) ) {
+				return false;
+			}
+
+			$pro = Customify_Pro();
+			return is_object( $pro )
+				&& method_exists( $pro, 'is_enabled_module' )
+				&& $pro->is_enabled_module( 'Customify_Pro_Module_Header_Transparent' );
+		}
+
+		return class_exists( 'Customify_Header_Transparent' );
 	}
 }
 

--- a/src/backend/page-settings/index.js
+++ b/src/backend/page-settings/index.js
@@ -2,8 +2,8 @@
  * Customify Page Settings — block editor plugin.
  *
  * Renders a PluginDocumentSettingPanel with a flat stack of controls in the
- * Document sidebar. Sections (Layout, Disable Elements, Page Header) are
- * introduced by uppercase section labels rather than tabs.
+ * Document sidebar. Related toggle controls are introduced by a field-style
+ * label rather than a separate tab.
  */
 
 import './style.scss';
@@ -295,6 +295,12 @@ const PAGE_HEADER_OPTIONS = [
 	{ label: __( 'Hide', 'customify' ),                    value: 'none' },
 ];
 
+const TRANSPARENT_HEADER_OPTIONS = [
+	{ label: __( 'Default', 'customify' ), value: 'default' },
+	{ label: __( 'Enable', 'customify' ), value: 'show' },
+	{ label: __( 'Disable', 'customify' ), value: 'hide' },
+];
+
 const BREADCRUMB_OPTIONS = [
 	{ label: __( 'Inherit from Customizer', 'customify' ), value: 'default' },
 	{ label: __( 'Hide', 'customify' ),                    value: 'hide' },
@@ -390,23 +396,32 @@ function CustomifyPageSettings() {
 			<MetaToggle label={ __( 'Footer Bottom', 'customify' ) } metaKey="disable_footer_bottom" meta={ meta } setMeta={ setMeta } />
 
 			{ /*
-			 * "Page Header" section heading is conditional now — Page Title
-			 * Layout moved up next to Content Layout, so only Breadcrumb
-			 * lives down here. When the user has no breadcrumb plugin
-			 * active, the section would be empty and the heading would
-			 * dangle.
+			 * Both controls depend on optional features. Transparent Header
+			 * follows the native/Pro module gate localized by PHP; Breadcrumb
+			 * follows its plugin compatibility gate.
 			 */ }
-			{ config.hasBreadcrumb && (
+			{ ( config.hasHeaderTransparent || config.hasBreadcrumb ) && (
 				<>
-					<p className="customify-ps-section-label">
-						{ __( 'Page Header', 'customify' ) }
-					</p>
-					<SelectControl
-						label={ __( 'Breadcrumb', 'customify' ) }
-						value={ get( 'breadcrumb_display' ) || 'default' }
-						options={ BREADCRUMB_OPTIONS }
-						onChange={ ( v ) => set( 'breadcrumb_display', v ) }
-					/>
+					{ config.hasHeaderTransparent && (
+						<SelectControl
+							label={ __( 'Transparent Header', 'customify' ) }
+							value={
+								get( 'header_transparent_display' ) || 'default'
+							}
+							options={ TRANSPARENT_HEADER_OPTIONS }
+							onChange={ ( v ) =>
+								set( 'header_transparent_display', v )
+							}
+						/>
+					) }
+					{ config.hasBreadcrumb && (
+						<SelectControl
+							label={ __( 'Breadcrumb', 'customify' ) }
+							value={ get( 'breadcrumb_display' ) || 'default' }
+							options={ BREADCRUMB_OPTIONS }
+							onChange={ ( v ) => set( 'breadcrumb_display', v ) }
+						/>
+					) }
 				</>
 			) }
 		</div>

--- a/src/backend/page-settings/style.scss
+++ b/src/backend/page-settings/style.scss
@@ -5,22 +5,23 @@
 		padding-top: 4px;
 
 		.components-base-control {
-			margin-bottom: 10px;
+			margin-bottom: 16px;
 		}
 
-		// Section group heading (Disable Elements, Page Header, …).
+		// Match the labels used by SelectControl fields in this panel.
 		.customify-ps-section-label {
 			font-size: 11px;
-			font-weight: 600;
+			font-weight: 500;
+			line-height: 1.4;
 			text-transform: uppercase;
-			letter-spacing: 0.5px;
-			color: #757575;
-			margin: 16px 0 6px;
+			letter-spacing: normal;
+			color: #1e1e1e;
+			margin: 0 0 8px;
 		}
 
-		// ToggleControl rows — compact, no excess vertical space.
+		// Keep related toggles compact while separating them from other fields.
 		.components-toggle-control {
-			margin-bottom: 4px;
+			margin-bottom: 8px;
 
 			.components-flex {
 				gap: 8px;
@@ -29,6 +30,10 @@
 			.components-toggle-control__label {
 				font-size: 13px;
 			}
+		}
+
+		.components-toggle-control + .components-select-control {
+			margin-top: 16px;
 		}
 	}
 }

--- a/src/frontend/scss/header/_header_transparent.scss
+++ b/src/frontend/scss/header/_header_transparent.scss
@@ -2,7 +2,9 @@
 
 // Position the header absolutely so page content flows beneath it.
 .is-header-transparent {
-	&.has-page-cover, &.home {
+	&.has-page-cover,
+	&.home,
+	&.is-header-transparent-forced {
 		#masthead {
 			position: absolute;
 			top: 0;


### PR DESCRIPTION
## Summary

- add a Default/Enable/Disable Transparent Header control to Customify Page Settings
- show the control only while the native or Pro module is enabled
- make explicit per-page values the final display decision
- allow forced transparent headers to overlay pages without a page cover
- align page-settings labels and spacing
- update the Transparent Header and Pro integration documentation

## Test plan

- PHP syntax check for the Transparent Header implementation
- production npm build
- priority cases for show/hide/default against page exclusions and filters
- block-editor and frontend verification on Home v2