### PR TITLE
Add Shop Archive content-area spacing control

### DIFF
--- a/docs/SPEC-content-area-spacing.md
+++ b/docs/SPEC-content-area-spacing.md
@@ -21,6 +21,7 @@ Context controls store one of `inherit`, `both`, `top`, `bottom`, or `disabled`:
 | Pages | `page_content_area_spacing` |
 | Blog posts | `posts_content_area_spacing` |
 | Blog archives | `posts_archives_content_area_spacing` |
+| Shop archive and product taxonomies | `shop_content_area_spacing` |
 | Search | `search_content_area_spacing` |
 | 404 | `404_content_area_spacing` |
 | CPT single | `{post_type}_content_area_spacing` |
@@ -32,7 +33,9 @@ before this feature.
 
 The existing singular post meta
 `_customify_disable_content_vertical_padding=1` remains supported and has
-absolute precedence over the context setting.
+absolute precedence over the context setting. On Shop and product taxonomy
+archives, the same meta on the assigned Shop Page takes precedence over
+`shop_content_area_spacing`.
 
 ---
 
@@ -40,17 +43,16 @@ absolute precedence over the context setting.
 
 The `Content Area Spacing` section lives under the existing `Layouts` panel.
 The `General` group contains the unchanged global spacing magnitude followed by
-Pages, Blog Posts, Blog Archives, Search and 404 modes.
+Pages, Blog Posts, Blog Archives, Shop Archive when WooCommerce is active,
+Search and 404 modes.
 
 `Post Type Settings` is a heading control above dynamically generated CPT
 controls. The CPT source is `customify_get_content_post_types()`, so internal
 utility types and plugin-specific exclusions remain centralized. A CPT archive
 control is added only when the type has a real archive and Customify owns that
 archive. WooCommerce's Product archive and product-only taxonomies keep their
-established ownership, receive no context setting, and leave the global spacing
-unchanged. Their assigned Shop Page's legacy
-`_customify_disable_content_vertical_padding` override is still honored through
-the WooCommerce integration.
+established ownership and resolve through the dedicated `Shop Archive` control
+registered by the WooCommerce integration.
 
 ---
 
@@ -63,7 +65,7 @@ the WooCommerce integration.
 3. Page or blog-post single.
 4. Supported CPT archive.
 5. Custom taxonomy owned by exactly one supported archive CPT.
-6. Archive/taxonomy owned by an excluded integration → no context setting.
+6. Archive/taxonomy owned by an excluded integration → no core context setting.
 7. Built-in/shared/unresolved archive → Blog Archives.
 8. Supported CPT single.
 
@@ -72,6 +74,16 @@ the WooCommerce integration.
 1. Existing singular disable meta → `disabled`.
 2. Context theme mod.
 3. Invalid/empty value → `inherit`.
+
+For Shop and WooCommerce product taxonomy archives, the integration resolves
+its owned context after the core resolver:
+
+1. Assigned Shop Page legacy disable meta → `disabled`.
+2. `shop_content_area_spacing`.
+3. `inherit` → unchanged global `site_content_padding`.
+
+Single Product requests do not enter this archive path. They continue to use
+`product_content_area_spacing` and the individual product's legacy meta.
 
 Taxonomies shared by multiple post types intentionally fall back to Blog
 Archives. This avoids guessing ownership and matches the sidebar resolver.
@@ -115,7 +127,8 @@ its existing precedence cannot be weakened accidentally.
 
 Focused resolver coverage lives in `tests/content-area-spacing-test.php` and
 includes page, blog post, CPT single, CPT archive, owning taxonomy, shared
-taxonomy, search, 404 and legacy meta precedence. Run:
+taxonomy, Shop, WooCommerce product taxonomies, search, 404 and legacy meta
+precedence. Run:
 
 ```bash
 php tests/content-area-spacing-test.php

--- a/docs/SPEC-data-migration-policy.md
+++ b/docs/SPEC-data-migration-policy.md
@@ -53,6 +53,7 @@ Three things matter most:
 | `page_content_area_spacing` | string | `inherit` | Pages: `inherit` / `both` / `top` / `bottom` / `disabled` |
 | `posts_content_area_spacing` | string | `inherit` | Blog-post singles |
 | `posts_archives_content_area_spacing` | string | `inherit` | Blog home, built-in archives, and shared/unresolved taxonomies |
+| `shop_content_area_spacing` | string | `inherit` | WooCommerce Shop and product taxonomy archives; assigned Shop Page legacy disable meta wins |
 | `search_content_area_spacing` | string | `inherit` | Search results |
 | `404_content_area_spacing` | string | `inherit` | 404 requests |
 | `{post_type}_content_area_spacing` | string | `inherit` | Per-CPT single; generated from `customify_get_content_post_types()` |

--- a/inc/compatibility/woocommerce/woocommerce.php
+++ b/inc/compatibility/woocommerce/woocommerce.php
@@ -31,7 +31,7 @@ class Customify_WC {
 			add_filter( 'get_post_metadata', array( $this, 'get_post_metadata' ), 999, 4 );
 
 			add_action( 'widgets_init', array( $this, 'register_sidebars' ) );
-			add_filter( 'customify/customizer/config', array( $this, 'customize_shop_sidebars' ) );
+			add_filter( 'customify/customizer/config', array( $this, 'customize_shop_sidebars' ), 15 );
 			add_filter( 'customify/sidebar-id', array( $this, 'shop_sidebar_id' ), 15, 2 );
 
 			add_filter( 'customify_is_header_display', array( $this, 'show_shop_header' ), 15 );
@@ -426,12 +426,13 @@ class Customify_WC {
 	}
 
 	/**
-	 * Apply the Shop Page's legacy vertical-padding override to Woo archives.
+	 * Resolve content area spacing for WooCommerce archives.
 	 *
 	 * Product archives are intentionally excluded from the generic contextual
 	 * spacing settings because WooCommerce already owns their layout through
-	 * the assigned Shop Page. Product singles keep their own contextual setting
-	 * and per-product legacy override.
+	 * the assigned Shop Page. The Shop Page's legacy disable flag takes
+	 * precedence over the Shop Archive Customizer setting. Product singles keep
+	 * their own contextual setting and per-product legacy override.
 	 *
 	 * @param string $mode    Resolved content area spacing mode.
 	 * @param array  $context Resolved request context.
@@ -439,13 +440,20 @@ class Customify_WC {
 	 * @return string
 	 */
 	function shop_content_area_spacing_mode( $mode, $context = array(), $setting = '' ) {
-		if ( ! $this->is_shop_pages() || is_product() ) {
+		if ( ! is_shop() && ! is_product_taxonomy() ) {
 			return $mode;
 		}
 
 		$disable_padding = $this->get_shop_page_meta( '_customify_disable_content_vertical_padding' );
+		if ( '1' === (string) $disable_padding ) {
+			return 'disabled';
+		}
 
-		return '1' === (string) $disable_padding ? 'disabled' : $mode;
+		$shop_mode = customify_sanitize_content_area_spacing_mode(
+			Customify()->get_setting( 'shop_content_area_spacing' )
+		);
+
+		return 'inherit' === $shop_mode ? $mode : $shop_mode;
 	}
 
 	function show_shop_header( $show = true ) {
@@ -600,6 +608,32 @@ class Customify_WC {
 	}
 
 	function customize_shop_sidebars( $configs = array() ) {
+		$shop_spacing_config = array(
+			'name'    => 'shop_content_area_spacing',
+			'type'    => 'select',
+			'default' => 'inherit',
+			'section' => 'content_area_spacing_section',
+			'title'   => __( 'Shop Archive', 'customify' ),
+			'choices' => customify_get_content_area_spacing_choices(),
+		);
+		$insert_at           = null;
+
+		foreach ( $configs as $index => $config ) {
+			$name = isset( $config['name'] ) ? $config['name'] : '';
+			if ( 'shop_content_area_spacing' === $name ) {
+				return $configs;
+			}
+			if ( 'posts_archives_content_area_spacing' === $name ) {
+				$insert_at = $index + 1;
+			}
+		}
+
+		if ( is_null( $insert_at ) ) {
+			$configs[] = $shop_spacing_config;
+		} else {
+			array_splice( $configs, $insert_at, 0, array( $shop_spacing_config ) );
+		}
+
 		return $configs;
 	}
 

--- a/languages/customify.pot
+++ b/languages/customify.pot
@@ -649,8 +649,8 @@ msgstr ""
 
 #: inc/class-customify.php:305 inc/class-customify.php:316
 #: inc/class-customify.php:330
-#: inc/compatibility/woocommerce/woocommerce.php:587
-#: inc/compatibility/woocommerce/woocommerce.php:598
+#: inc/compatibility/woocommerce/woocommerce.php:645
+#: inc/compatibility/woocommerce/woocommerce.php:656
 msgid "Add widgets here."
 msgstr ""
 
@@ -1606,19 +1606,23 @@ msgstr ""
 msgid "Your order"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:539
+#: inc/compatibility/woocommerce/woocommerce.php:571
 msgid "Display on product taxonomies (categories/tags,..)"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:547
+#: inc/compatibility/woocommerce/woocommerce.php:579
 msgid "Display on single product"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:585
+#: inc/compatibility/woocommerce/woocommerce.php:616
+msgid "Shop Archive"
+msgstr ""
+
+#: inc/compatibility/woocommerce/woocommerce.php:643
 msgid "WooCommerce Primary Sidebar"
 msgstr ""
 
-#: inc/compatibility/woocommerce/woocommerce.php:596
+#: inc/compatibility/woocommerce/woocommerce.php:654
 msgid "WooCommerce Secondary Sidebar"
 msgstr ""
 

--- a/tests/content-area-spacing-test.php
+++ b/tests/content-area-spacing-test.php
@@ -33,9 +33,10 @@ $GLOBALS['customify_test_types']   = array(
 	'product' => new WP_Post_Type( 'product', true ),
 );
 $GLOBALS['customify_test_taxonomies'] = array(
-	'book_genre'  => array( 'book' ),
-	'product_cat' => array( 'product' ),
-	'shared'      => array( 'book', 'post' ),
+	'book_genre'    => array( 'book' ),
+	'product_cat'   => array( 'product' ),
+	'product_brand' => array( 'product' ),
+	'shared'        => array( 'book', 'post' ),
 );
 
 function __( $text ) {
@@ -143,6 +144,10 @@ function is_product_category() {
 
 function is_product_tag() {
 	return customify_test_flag( 'product_tag' );
+}
+
+function is_product_taxonomy() {
+	return customify_test_flag( 'product_taxonomy' ) || is_product_category() || is_product_tag();
 }
 
 function is_product() {
@@ -265,6 +270,15 @@ function customify_test_assert_same( $expected, $actual, $message ) {
 	}
 }
 
+$customify_test_configs = $customify_test_woo->customize_shop_sidebars(
+	array(
+		array( 'name' => 'posts_archives_content_area_spacing' ),
+		array( 'name' => 'search_content_area_spacing' ),
+	)
+);
+customify_test_assert_same( 'shop_content_area_spacing', $customify_test_configs[1]['name'], 'Shop Archive is registered after Blog Archives.' );
+customify_test_assert_same( 'inherit', $customify_test_configs[1]['default'], 'Shop Archive defaults to inherit.' );
+
 customify_test_reset(
 	array(
 		'page'      => true,
@@ -338,7 +352,19 @@ customify_test_reset(
 		'shop'              => true,
 		'shop_page_id'      => 16,
 	),
-	array(),
+	array( 'shop_content_area_spacing' => 'top' )
+);
+$context = customify_get_content_area_spacing_context();
+customify_test_assert_same( array( 'content-area-spacing-top-only' ), customify_get_content_area_spacing_body_classes( $context ), 'Shop Archive controls the product archive.' );
+
+customify_test_reset(
+	array(
+		'post_type_archive' => true,
+		'post_type'         => 'product',
+		'shop'              => true,
+		'shop_page_id'      => 16,
+	),
+	array( 'shop_content_area_spacing' => 'bottom' ),
 	array(
 		16 => array( '_customify_disable_content_vertical_padding' => '1' ),
 	)
@@ -367,7 +393,19 @@ customify_test_reset(
 		'product_category' => true,
 		'shop_page_id'     => 16,
 	),
-	array(),
+	array( 'shop_content_area_spacing' => 'bottom' )
+);
+$context = customify_get_content_area_spacing_context();
+customify_test_assert_same( array( 'content-area-spacing-bottom-only' ), customify_get_content_area_spacing_body_classes( $context ), 'Shop Archive controls product categories.' );
+
+customify_test_reset(
+	array(
+		'tax'              => true,
+		'queried_object'   => new WP_Term( 'product_cat' ),
+		'product_category' => true,
+		'shop_page_id'     => 16,
+	),
+	array( 'shop_content_area_spacing' => 'top' ),
 	array(
 		16 => array( '_customify_disable_content_vertical_padding' => '1' ),
 	)
@@ -377,13 +415,29 @@ customify_test_assert_same( array( 'disable-content-vertical-padding' ), customi
 
 customify_test_reset(
 	array(
+		'tax'              => true,
+		'queried_object'   => new WP_Term( 'product_brand' ),
+		'product_taxonomy' => true,
+		'shop_page_id'     => 16,
+	),
+	array( 'shop_content_area_spacing' => 'disabled' )
+);
+$context = customify_get_content_area_spacing_context();
+customify_test_assert_same( 'none', $context['key'], 'A WooCommerce product taxonomy remains owned by the integration.' );
+customify_test_assert_same( array( 'disable-content-vertical-padding' ), customify_get_content_area_spacing_body_classes( $context ), 'Shop Archive controls all WooCommerce product taxonomies.' );
+
+customify_test_reset(
+	array(
 		'singular'     => true,
 		'product'      => true,
 		'post_type'    => 'product',
 		'post_id'      => 17,
 		'shop_page_id' => 16,
 	),
-	array( 'product_content_area_spacing' => 'top' ),
+	array(
+		'product_content_area_spacing' => 'top',
+		'shop_content_area_spacing'    => 'disabled',
+	),
 	array(
 		16 => array( '_customify_disable_content_vertical_padding' => '1' ),
 	)


### PR DESCRIPTION
## Summary

- add a WooCommerce-only Shop Archive control to Layouts → Content Area Spacing, directly after Blog Archives
- resolve Shop and all product taxonomy archives with this precedence: assigned Shop Page legacy disable override, Shop Archive Customizer mode, then inherited global spacing
- keep Single Product spacing independent and document the new theme mod
- add focused coverage for control registration, Shop, product category, custom product taxonomy, legacy precedence, and Single Product isolation

## Testing

- php tests/content-area-spacing-test.php
- php -l inc/compatibility/woocommerce/woocommerce.php
- php -l tests/content-area-spacing-test.php
- npm run build
- npm run makepot
- git diff --check