### PR TITLE
Palette-linked colour pickers + unified control scale

### DIFF
--- a/docs/SPEC-customizer-colors.md
+++ b/docs/SPEC-customizer-colors.md
@@ -564,6 +564,95 @@ This is a **strict improvement** over Phase 1, which had the
 Customizer-to-block-editor disconnect documented in the original
 §3.7 note. The Phase 2.11 filter resolved that limitation.
 
+### 3.8 Palette-linked pickers (component colors follow a token)
+
+Every eligible color picker in the Customizer offers the 12 palette
+tokens as swatches. Picking one stores the **token reference itself**:
+
+```
+footer_main_background_color = var(--customify-secondary, #c3512f)
+```
+
+so the field FOLLOWS the palette — editing the Secondary slot recolors
+it without touching the field. The baked fallback is what renders where
+the token is not emitted (the derived-token opt-in gate, §3.2).
+
+**Storage.** No new key, no shape change. The field keeps its existing
+`theme_mod` / composite-subfield slot and simply holds a different string
+form. Composite subfields work the same way (`customify_button_styling`
+→ `normal.bg_color`).
+
+**Sanitize.** `Customify_Sanitize_Input::sanitize_color()` gained an
+additive branch: a value matching `var(--customify-<token>[, <fallback>])`
+is accepted when the token name is in
+`Customify_Sanitize_Input::allowed_color_tokens()` (filter:
+`customify/color/allowed_tokens`) AND the fallback passes the ordinary
+hex/rgba validation. Everything else falls through to the original path
+unchanged, so no previously-valid value sanitizes differently. The
+fallback is re-validated, not trusted: `var(--customify-primary,
+javascript:alert(1))` normalizes to `var(--customify-primary)`.
+
+**Render.** `Customify_Customizer_Auto_CSS::setup_color()` runs the same
+sanitizer, so the token passes into `css_format` verbatim and the browser
+resolves it against the `:root` block.
+
+**Eligibility.** Everything registered in the `customify_colors` section
+is excluded (`customify_color_link_excluded_controls()`, derived from the
+live config, filter: `customify/color/palette_link_excluded`):
+
+| Excluded | Why |
+|---|---|
+| 6 palette slots | They DEFINE the tokens — `--customify-primary: var(--customify-primary)` is circular. |
+| 7 component overrides | The derived-token engine reads them through `customify_color_normalize_hex()`, which is hex-only; a `var()` there reads as "no override saved" and silently does nothing. The section's own "From palette" quick-pick is the right affordance for an override. |
+| 3 background composites | They already have a slot cascade keyed off whether `bg_color` was saved (§3.2). |
+
+**Where the code lives.** `initColor()` in
+`src/backend/customizer/js/control.js` — the single point every Customify
+color input passes through (standalone controls, `styling` composite
+subfields, `modal` subfields, repeater rows). `inc/color-palette-link.php`
+is data only: it resolves each token to a literal preview color by parsing
+back what `customify_color_palette_root_css()` actually emitted, and ships
+the list on the existing `Customify_Control_Args` payload.
+
+Two non-obvious constraints that the implementation exists to satisfy:
+
+1. **Iris cannot parse `var()`.** Left alone, `wpColorPicker()` reads the
+   token as empty and fires its `clear` callback, blanking the hidden
+   input the control reads — a later `getValue()` would then push `''`
+   over the saved token. `initColor()` seeds the VISIBLE input with the
+   resolved hex before init and restores the token on the hidden input
+   after.
+2. **`wpColorPicker()` fires `change` during init.** That callback pushes
+   the picker's hex to the setting whenever it differs from `current_val`,
+   which would rewrite a linked field to its fallback hex on every
+   re-render (e.g. `refreshFromSetting()`). `current_val` is therefore
+   seeded with the resolved hex so the init callback is a no-op. Net
+   effect: rendering a linked control writes nothing and never dirties the
+   Customizer.
+3. **The trigger chip is painted inline by `color-picker-alpha.js`.** The
+   sync pass may only UNDO an override it applied itself; clearing the
+   inline background unconditionally wipes the alpha script's paint and
+   leaves the chip transparent after an ordinary hex pick.
+4. **wp-color-picker slides `.iris-picker`, not `.wp-picker-holder`.** An
+   interrupted slideUp leaves an inline `display: none` on the picker while
+   the container still carries `.wp-picker-active` — the card then opens
+   showing the palette row with no picker above it. The SCSS ties
+   `.iris-picker` visibility to the container state instead
+   (`&.wp-picker-active .iris-picker { display: block !important }`).
+
+**Token matching is by NAME, never by whole string.** The stored value
+carries a fallback baked in at pick time, but the token list is rebuilt
+from live slot values on every page load — comparing whole strings would
+"unlink" every Accent-linked field the moment someone edits the Accent
+slot.
+
+**Known rough edge.** The baked fallback goes stale after a slot edit
+(the value box shows `var(--customify-accent, #ffd042)` while Accent is
+now `#7c3aed`). Harmless — the fallback only applies when the token is
+absent — but a follow-up could refresh it when the Customizer is already
+dirty, using the same "never write on a clean open" doctrine as the
+palette switcher (§8.13 D).
+
 ---
 
 ## 4. File inventory
@@ -1390,6 +1479,40 @@ LIVE background (matches Blocksify's current button hover):
 - 30K-safety: no storage/selector change. Only the transient hover *appearance*
   changes site-wide (darken → adaptive lift/deepen); resting + saved colors render
   identically.
+
+### 8.15 Phase 4 — palette-linked pickers (done)
+
+Component colors can follow a palette token instead of freezing a hex —
+full mechanism in §3.8. Rolled out to every color input outside the
+Colors section: 26 top-level `color` controls (13 eligible after the
+exclusions), 13 colors nested in `modal` composites, and the 8 color
+subfields of each of the 26 `styling` composites.
+
+**Files.** `inc/color-palette-link.php` (NEW — token list + preview
+resolution + eligibility + `Customify_Control_Args` payload);
+`inc/customizer/class-customizer-sanitize.php` (`sanitize_color()` split
+into `sanitize_color_token()` + `sanitize_color_literal()`, plus
+`allowed_color_tokens()`); `src/backend/customizer/js/control.js`
+(`initColor()` + the `customifyPaletteLink` helper);
+`src/backend/customizer/scss/_control.scss` (popover card + swatch row,
+scoped to the `.has-palette-link` class the JS adds).
+
+**30K-site verification** (see §5 for the method):
+
+| Check | Result |
+|---|---|
+| Scenario A — fresh install, zero saved mods | Generated CSS byte-identical to baseline |
+| Scenario B — 11 saved keys incl. legacy 9 + a per-row color | Byte-identical |
+| Scenario C — partial save (2 keys) | Byte-identical |
+| `sanitize_color()` equivalence, 48-input corpus (hex 3/6/8-char, rgba shapes, empty/null/array/bool, junk, injection attempts) | 0 regressions; 5 newly-accepted token shapes, all previously returning `null` or the malformed `rgba(,,,)` the old sscanf path produced |
+| Injection through the new branch | `var(--evil)`, `var(--customify-nope)`, `var(--customify-primary); background:url(x)` → rejected; bad fallback stripped |
+| Dirty-on-open (linked and unlinked fields) | Customizer stays clean |
+| Existing hex picking | Unchanged — stores hex, not linked |
+| Colors section | Untouched: no `.has-palette-link`, keeps its own quick-pick row |
+| Cost at scale | Swatch row is built on first popover open, not at mount — 0 rows in the DOM after a Customizer load |
+
+Baseline for the byte-diff was the same tree at `HEAD` installed as a
+second theme, so only the change under test differed.
 
 ### 8.12 Phase 2 — remaining (good follow-ups)
 

--- a/docs/SPEC-customizer.md
+++ b/docs/SPEC-customizer.md
@@ -789,6 +789,7 @@ These are enforced by [`../AGENTS.md`](../AGENTS.md) — restated here for compl
 - **English-only in source.** All docblocks, inline notes, and `.md` files in the codebase are English.
 - **Edit `src/`, not `build/`.** SCSS/JS sources live in `src/`; build outputs in `build/` are artifacts. See [`SPEC-asset-pipeline.md`](SPEC-asset-pipeline.md).
 - **CSS handle must match.** `wp_add_inline_style( 'customify-style', ... )` — never `'customify'` or any other typo.
+- **Control chrome resolves scale tokens, never literals.** `.customize-control` declares `--customify-control-h` / `--customify-control-radius` / `--customify-control-border` in `src/backend/customizer/scss/customizer.scss`; every field, select, select2 box and color-picker row resolves them. A panel that needs a different rhythm re-declares the tokens on its own root (the typography modal drops to `28px` / `2px` because it stacks ~12 fields) rather than hardcoding heights. Hardcoding is what produced the original mismatch: one styling modal carried a 32px rounded colour row, twelve 39px square number boxes and a 40px square select.
 
 ---
 

--- a/inc/class-customify.php
+++ b/inc/class-customify.php
@@ -499,6 +499,8 @@ class Customify
 			// Colors palette CSS var emitter for the new top-level Colors section.
 			'/inc/color-palette-switcher.php',
 			// Palettes UI (presets + custom palettes) at the top of the Colors section.
+			'/inc/color-palette-link.php',
+			// PROTOTYPE: palette swatch row inside a component color picker.
 			'/inc/style-guide.php',
 			// Customizer Style Guide: live specimen page in the preview + header toggle.
 			'/inc/extras.php',

--- a/inc/color-palette-link.php
+++ b/inc/color-palette-link.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Palette-linked color pickers.
+ *
+ * Lets any component color FOLLOW a palette token instead of freezing a hex.
+ * Picking a swatch in a color picker stores the token reference itself:
+ *
+ *     var(--customify-primary, #235787)
+ *
+ * so a later Primary change cascades to the field automatically, while the
+ * baked fallback keeps the field rendering on installs where the token is not
+ * emitted (see the derived-token opt-in gate in inc/colors-palette.php).
+ *
+ * This file is the DATA side only — the picker UI lives in
+ * `src/backend/customizer/js/control.js` (`initColor()` + the
+ * `customifyPaletteLink` helper) and `src/backend/customizer/scss/_control.scss`.
+ * That split matters: `initColor()` is the single point every Customify color
+ * input passes through — standalone controls, `styling` composite subfields,
+ * `modal` subfields and repeater rows alike — and it runs BEFORE
+ * wpColorPicker() so a token value can be handled without a write.
+ *
+ * 30K-site safety
+ * ---------------
+ * - No new storage key, no value-shape change. A field only ever holds a
+ *   `var()` string after the user picks a swatch; every existing hex / rgba /
+ *   empty value round-trips byte-identically.
+ * - `Customify_Sanitize_Input::sanitize_color()` gained an additive
+ *   `var(--customify-*)` branch restricted to an allowlist of emitted token
+ *   names; anything else still falls through to the original hex/rgba path.
+ * - The picker never writes on open: a linked field seeds the Iris input for
+ *   display only, so the Customizer is not dirtied by rendering a control.
+ *
+ * @package Customify
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'customify_color_link_root_map' ) ) {
+	/**
+	 * Parse the emitted `:root` block into a token => value map.
+	 *
+	 * Reading back what `customify_color_palette_root_css()` actually emitted
+	 * (instead of recomputing the derivation math here) keeps the swatch
+	 * previews in lockstep with the real pipeline — including the opt-in gate
+	 * that suppresses some tokens entirely.
+	 *
+	 * @return array<string,string> Raw declaration values, later-wins like CSS.
+	 */
+	function customify_color_link_root_map() {
+		static $map = null;
+		if ( null !== $map ) {
+			return $map;
+		}
+
+		$map = array();
+		if ( ! function_exists( 'customify_color_palette_root_css' ) ) {
+			return $map;
+		}
+
+		$css = customify_color_palette_root_css();
+		if ( ! preg_match( '/:root\{(.*?)\}/s', $css, $m ) ) {
+			return $map;
+		}
+
+		foreach ( explode( ';', $m[1] ) as $decl ) {
+			if ( false === strpos( $decl, '--customify-' ) ) {
+				continue;
+			}
+			$parts = explode( ':', $decl, 2 );
+			if ( count( $parts ) < 2 ) {
+				continue;
+			}
+			// Later declarations win — same as the browser resolving the block.
+			$map[ trim( $parts[0] ) ] = trim( $parts[1] );
+		}
+
+		return $map;
+	}
+}
+
+if ( ! function_exists( 'customify_color_link_resolve' ) ) {
+	/**
+	 * Resolve a CSS value to a concrete color for the controls-pane swatch.
+	 *
+	 * The `:root` block chains tokens (`--customify-heading: var(--customify-text, #2b2b2b)`),
+	 * and the Customizer CONTROLS document has no `--customify-*` vars at all,
+	 * so a swatch background has to be a literal. Walks the chain, falling back
+	 * to the inline fallback when a link in the chain isn't emitted.
+	 *
+	 * @param string $value CSS value: hex, rgba, or `var(--x, fallback)`.
+	 * @param int    $depth Recursion guard.
+	 *
+	 * @return string Literal color, or '' when unresolvable.
+	 */
+	function customify_color_link_resolve( $value, $depth = 0 ) {
+		$value = trim( (string) $value );
+		if ( '' === $value || $depth > 6 ) {
+			return '';
+		}
+
+		if ( ! preg_match( '/^var\(\s*(--customify-[a-z0-9-]+)\s*(?:,\s*(.+)\s*)?\)$/i', $value, $m ) ) {
+			// Not a var() — color-mix() and friends can't be resolved here, and
+			// the caller falls back to the token's own baked hex.
+			return preg_match( '/^(#|rgba?\()/i', $value ) ? $value : '';
+		}
+
+		$map      = customify_color_link_root_map();
+		$name     = strtolower( $m[1] );
+		$fallback = isset( $m[2] ) ? trim( $m[2] ) : '';
+
+		if ( isset( $map[ $name ] ) ) {
+			$resolved = customify_color_link_resolve( $map[ $name ], $depth + 1 );
+			if ( '' !== $resolved ) {
+				return $resolved;
+			}
+		}
+
+		return '' !== $fallback ? customify_color_link_resolve( $fallback, $depth + 1 ) : '';
+	}
+}
+
+if ( ! function_exists( 'customify_color_link_tokens' ) ) {
+	/**
+	 * Pickable tokens for the picker swatch row.
+	 *
+	 * Source list = the block-editor palette (`customify_color_palette_for_theme_json()`),
+	 * so a designer sees the same names and the same swatches in the Customizer
+	 * and in the block editor. `value` is what gets stored in the theme_mod.
+	 *
+	 * @return array[] Each: { value, label, preview }.
+	 */
+	function customify_color_link_tokens() {
+		if ( ! function_exists( 'customify_color_palette_for_theme_json' ) ) {
+			return array();
+		}
+
+		$tokens = array();
+		foreach ( customify_color_palette_for_theme_json() as $entry ) {
+			if ( empty( $entry['slug'] ) || empty( $entry['color'] ) ) {
+				continue;
+			}
+
+			// Skip tokens we can't show a truthful swatch for.
+			$preview = customify_color_link_resolve( $entry['color'] );
+			if ( '' === $preview ) {
+				continue;
+			}
+
+			$tokens[] = array(
+				'value'   => $entry['color'],
+				'label'   => isset( $entry['name'] ) ? $entry['name'] : $entry['slug'],
+				'preview' => $preview,
+			);
+		}
+
+		return $tokens;
+	}
+}
+
+if ( ! function_exists( 'customify_color_link_excluded_controls' ) ) {
+	/**
+	 * Control names that must NOT offer palette linking.
+	 *
+	 * Everything registered in the Colors section is excluded:
+	 *
+	 * - The 6 palette slots DEFINE the tokens. Linking a slot to a token would
+	 *   be circular (`--customify-primary: var(--customify-primary)`).
+	 * - The 7 component overrides feed the derived-token engine through
+	 *   `customify_color_normalize_hex()`, which only accepts hex — a `var()`
+	 *   there reads as "no override saved" and silently does nothing. The
+	 *   section already offers its own "From palette" quick-pick, which is the
+	 *   correct affordance for an override.
+	 * - The 3 background composites have their own slot cascade
+	 *   (see `customify_color_palette_root_css()`), which keys off whether a
+	 *   `bg_color` subfield was saved.
+	 *
+	 * Derived from the live config rather than hardcoded, so a config change
+	 * cannot silently expose a slot picker.
+	 *
+	 * @return string[]
+	 */
+	function customify_color_link_excluded_controls() {
+		$excluded = array();
+
+		if ( class_exists( 'Customify_Customizer' ) ) {
+			foreach ( Customify_Customizer::get_config() as $field ) {
+				if ( empty( $field['name'] ) || empty( $field['section'] ) ) {
+					continue;
+				}
+				if ( 'customify_colors' === $field['section'] ) {
+					$excluded[] = $field['name'];
+				}
+			}
+		}
+
+		return array_values( array_unique( apply_filters( 'customify/color/palette_link_excluded', $excluded ) ) );
+	}
+}
+
+if ( ! function_exists( 'customify_color_link_control_args' ) ) {
+	/**
+	 * Ship palette-link data to the controls JS.
+	 *
+	 * Rides the existing `Customify_Control_Args` payload (localized on the
+	 * `customify-customizer-control` handle) so no extra script or request is
+	 * added for the 30K install base.
+	 *
+	 * `enabled` is false when the palette produced no usable tokens, which
+	 * makes the whole feature a no-op rather than rendering an empty row.
+	 *
+	 * @param array $args Localized control args.
+	 *
+	 * @return array
+	 */
+	function customify_color_link_control_args( $args ) {
+		$tokens = customify_color_link_tokens();
+
+		$args['palette_link'] = array(
+			'enabled'  => ! empty( $tokens ),
+			'tokens'   => $tokens,
+			'excluded' => customify_color_link_excluded_controls(),
+			'l10n'     => array(
+				'linked' => __( 'Linked to', 'customify' ),
+				'unlink' => __( 'Unlink', 'customify' ),
+				'custom' => __( 'Custom color', 'customify' ),
+				'copy'   => __( 'Copy value', 'customify' ),
+			),
+		);
+
+		return $args;
+	}
+	add_filter( 'Customify_Control_Args', 'customify_color_link_control_args' );
+}

--- a/inc/customizer/class-customizer-sanitize.php
+++ b/inc/customizer/class-customizer-sanitize.php
@@ -101,19 +101,94 @@ class Customify_Sanitize_Input {
 	}
 
 	/**
-	 * Sanitize color
+	 * Palette token names accepted inside a `var()` color value.
 	 *
-	 * Output can be rgba or hex color code
+	 * Mirrors the tokens emitted by `customify_color_palette_root_css()`.
+	 * Hardcoded (not derived) so the sanitizer never depends on load order or
+	 * on the derived-token opt-in gate — an allowlisted token whose var is not
+	 * emitted still renders via its baked fallback.
+	 *
+	 * @return string[]
+	 */
+	static function allowed_color_tokens() {
+		$tokens = array(
+			'--customify-base',
+			'--customify-surface',
+			'--customify-text',
+			'--customify-primary',
+			'--customify-secondary',
+			'--customify-accent',
+			'--customify-primary-container',
+			'--customify-secondary-container',
+			'--customify-accent-container',
+			'--customify-body-text',
+			'--customify-text-muted',
+			'--customify-heading',
+			'--customify-widget-title',
+			'--customify-border',
+			'--customify-border-strong',
+			'--customify-link',
+			'--customify-link-hover',
+			'--customify-primary-hover',
+			'--customify-on-primary',
+			'--customify-on-secondary',
+			'--customify-on-accent',
+			'--customify-on-surface',
+			'--customify-on-primary-container',
+			'--customify-on-secondary-container',
+			'--customify-on-accent-container',
+			'--customify-btn-on-primary',
+			'--customify-btn-on-secondary',
+		);
+
+		return apply_filters( 'customify/color/allowed_tokens', $tokens );
+	}
+
+	/**
+	 * Sanitize a palette token reference — `var(--customify-<token>[, <fallback>])`.
+	 *
+	 * Written by the Customizer palette-link picker so a component color can
+	 * follow a palette token instead of freezing a hex. Both parts are
+	 * validated: the token name against the allowlist above, the fallback
+	 * through the same hex/rgba path as any other color. Anything else returns
+	 * '' so the caller falls through to the literal-color path — no CSS can be
+	 * smuggled into the stylesheet through this branch.
+	 *
+	 * @param string $value
+	 *
+	 * @return string Normalized `var(...)` string, or '' when not a valid token.
+	 */
+	static function sanitize_color_token( $value ) {
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
+
+		$value = trim( $value );
+		if ( ! preg_match( '/^var\(\s*(--customify-[a-z0-9-]+)\s*(?:,\s*(.+?)\s*)?\)$/i', $value, $matches ) ) {
+			return '';
+		}
+
+		$name = strtolower( $matches[1] );
+		if ( ! in_array( $name, self::allowed_color_tokens(), true ) ) {
+			return '';
+		}
+
+		$fallback = isset( $matches[2] ) ? self::sanitize_color_literal( $matches[2] ) : '';
+
+		return $fallback ? 'var(' . $name . ', ' . $fallback . ')' : 'var(' . $name . ')';
+	}
+
+	/**
+	 * Sanitize a literal color — hex or rgba.
+	 *
+	 * Extracted from sanitize_color() so the token fallback runs through the
+	 * exact same validation. Behavior for existing values is unchanged.
 	 *
 	 * @param string $color
 	 *
 	 * @return string
 	 */
-	static function sanitize_color( $color ) {
-		if ( empty( $color ) || is_array( $color ) ) {
-			return '';
-		}
-
+	static function sanitize_color_literal( $color ) {
 		// If string does not start with 'rgba', then treat as hex.
 		// sanitize the hex color and finally convert hex to rgba.
 		if ( false === strpos( $color, 'rgba' ) ) {
@@ -125,6 +200,31 @@ class Customify_Sanitize_Input {
 		sscanf( $color, 'rgba(%d,%d,%d,%f)', $red, $green, $blue, $alpha );
 
 		return 'rgba(' . $red . ',' . $green . ',' . $blue . ',' . $alpha . ')';
+	}
+
+	/**
+	 * Sanitize color
+	 *
+	 * Output can be rgba, hex color code, or an allowlisted palette token
+	 * reference (`var(--customify-primary, #235787)`).
+	 *
+	 * @param string $color
+	 *
+	 * @return string
+	 */
+	static function sanitize_color( $color ) {
+		if ( empty( $color ) || is_array( $color ) ) {
+			return '';
+		}
+
+		// Additive branch: no value that was valid before this check reaches
+		// it, since a leading `var(` never survived the hex/rgba path.
+		$token = self::sanitize_color_token( $color );
+		if ( '' !== $token ) {
+			return $token;
+		}
+
+		return self::sanitize_color_literal( $color );
 	}
 
 	private function sanitize_media( $value ) {

--- a/inc/customizer/configs/buttons-forms.php
+++ b/inc/customizer/configs/buttons-forms.php
@@ -62,9 +62,23 @@ if ( ! function_exists( 'customify_customizer_buttons_forms_config' ) ) {
 		//     its own dedicated nav-icon styling (transparent bg, no padding,
 		//     custom hover). Letting Button Styling reach it paints the
 		//     hamburger with the brand button background.
+		//   - `.input-pm-act` — the WooCommerce quantity stepper's +/- pair
+		//     (injected by `_wc_plus_minus()` in
+		//     src/frontend/js/compatibility/woocommerce.js, used on cart,
+		//     mini-cart and single product). They are plain <button>s sitting
+		//     directly against the qty input, so the brand button background
+		//     painted them as if they were CTAs.
+		//   - `.wc-block-components-quantity-selector__button` — the same
+		//     stepper in the Cart/Checkout blocks. Its class is `wc-block-…`,
+		//     NOT `wp-block-…`, so the carve-out above does not cover it. The
+		//     SCSS neutralizer in
+		//     src/frontend/scss/compatibility/wc/_woocommerce-main.scss only
+		//     handles the bundled :hover state layer — the Customizer's inline
+		//     CSS outranks any bundled rule, so the normal-state background has
+		//     to be excluded here at the source.
 		// Keep every :not() comma-free ($suffix_each below splits on commas).
 		$button_selector = '.button:not([class*="wp-block-"]):not(.menu-mobile-toggle), '
-			. 'button:not([class*="wp-block-"]):not(.customize-partial-edit-shortcut-button):not(.menu-mobile-toggle), '
+			. 'button:not([class*="wp-block-"]):not(.customize-partial-edit-shortcut-button):not(.menu-mobile-toggle):not(.input-pm-act):not(.wc-block-components-quantity-selector__button), '
 			. 'input[type="button"]:not([class*="wp-block-"]), '
 			. 'input[type="reset"]:not([class*="wp-block-"]), '
 			. 'input[type="submit"]:not([class*="wp-block-"]), '

--- a/src/backend/customizer/js/control.js
+++ b/src/backend/customizer/js/control.js
@@ -1993,16 +1993,39 @@ import { attachPopoverChrome } from './popover-chrome';
 			$(".customify-input-color", $el).each(function () {
 				var colorInput = $(this);
 				var df = colorInput.data("default") || "";
-				var current_val = $(
-					".customify-input--color",
-					colorInput
-				).val();
+				var hidden = $(".customify-input--color", colorInput);
+				var panel = $(".customify--color-panel", colorInput);
+
+				// Palette link — Iris cannot parse `var(--customify-x, #hex)`.
+				// Left alone, wpColorPicker() reads that string, treats the
+				// field as empty and fires its `clear` callback, which wipes
+				// the hidden input the control reads (a later getValue() would
+				// then push '' over the saved token) and shows the raw var() as
+				// an invalid entry. Seed the VISIBLE input with the resolved hex
+				// so Iris initialises on a real colour, then restore the token
+				// on the hidden input below. Nothing is written to the setting,
+				// so rendering a linked control never dirties the Customizer.
+				var linkedToken = customifyPaletteLink.tokenFor(hidden.val());
+				var linkedValue = linkedToken ? hidden.val() : null;
+				if (linkedToken && linkedToken.preview) {
+					panel.val(linkedToken.preview);
+				}
+
+				// wpColorPicker() fires its `change` callback during init. The
+				// callback writes the picker's hex into the hidden input and,
+				// when that hex differs from `current_val`, pushes it to the
+				// setting — which would silently rewrite a linked field to its
+				// fallback hex every time the control re-renders (e.g.
+				// refreshFromSetting after an external set). Seeding
+				// `current_val` with the resolved hex makes that init callback
+				// a no-op; the restore below then puts the token back.
+				var current_val =
+					linkedToken && linkedToken.preview
+						? linkedToken.preview
+						: hidden.val();
 				// data-alpha="true"
-				$(".customify--color-panel", colorInput).attr(
-					"data-alpha",
-					"true"
-				);
-				$(".customify--color-panel", colorInput).wpColorPicker({
+				panel.attr("data-alpha", "true");
+				panel.wpColorPicker({
 					defaultColor: df,
 					change: function (event, ui) {
 						var new_color = ui.color.toString();
@@ -2021,7 +2044,348 @@ import { attachPopoverChrome } from './popover-chrome';
 						);
 					}
 				});
+
+				if (linkedValue !== null) {
+					hidden.val(linkedValue);
+				}
+
+				customifyPaletteLink.attach(colorInput);
 			});
+		}
+	};
+
+	//-------------------------------------------------------------------------
+	// Palette link — pick a theme palette token from inside any color picker.
+	//
+	// The picked value is the token reference itself
+	// (`var(--customify-primary, #235787)`), so the field FOLLOWS the palette
+	// instead of freezing a hex; the baked fallback keeps it rendering where
+	// the token is not emitted (derived-token opt-in gate, see
+	// inc/colors-palette.php).
+	//
+	// Data comes from Customify_Control_Args.palette_link (see
+	// inc/color-palette-link.php). The row is built on first popover open, not
+	// at init: the Customizer mounts ~250 color inputs and eagerly building a
+	// 12-swatch row in each would cost thousands of nodes for nothing.
+	//
+	// Source of truth is the hidden `.customify-input--color` input — the same
+	// element the control reads in getValue(). initColor() above guarantees it
+	// still holds the token after wpColorPicker init.
+	//-------------------------------------------------------------------------
+
+	var customifyPaletteLink = {
+		config: function () {
+			var args =
+				typeof Customify_Control_Args !== "undefined"
+					? Customify_Control_Args
+					: null;
+			var cfg = args && args.palette_link ? args.palette_link : null;
+			return cfg && cfg.enabled && cfg.tokens && cfg.tokens.length
+				? cfg
+				: null;
+		},
+
+		// Customify round-trips setting values as URL-encoded JSON
+		// (getValue() -> encodeValue() -> setting.set()), so a value read back
+		// after a UI write looks like `%22var(--customify-accent,%20#ffd042)%22`
+		// while the same value is a plain string when PHP seeded it. Decode
+		// both shapes; a plain hex simply fails JSON.parse and passes through.
+		decode: function (value) {
+			if (typeof value !== "string") {
+				return "";
+			}
+			try {
+				var decoded = JSON.parse(decodeURI(value));
+				return typeof decoded === "string" ? decoded : value;
+			} catch (e) {
+				return value;
+			}
+		},
+
+		// Match on the TOKEN NAME, never the whole string: the stored value
+		// carries a fallback hex baked in at pick time, but the token list is
+		// rebuilt from live slot values on every page load — so editing the
+		// Accent slot would otherwise "unlink" every field linked to Accent.
+		nameOf: function (value) {
+			var match = /^var\(\s*(--customify-[a-z0-9-]+)/i.exec(
+				customifyPaletteLink.decode(value).trim()
+			);
+			return match ? match[1].toLowerCase() : "";
+		},
+
+		tokenFor: function (value) {
+			var cfg = customifyPaletteLink.config();
+			if (!cfg) {
+				return null;
+			}
+			var name = customifyPaletteLink.nameOf(value);
+			if (!name) {
+				return null;
+			}
+			for (var i = 0; i < cfg.tokens.length; i++) {
+				if (customifyPaletteLink.nameOf(cfg.tokens[i].value) === name) {
+					return cfg.tokens[i];
+				}
+			}
+			// Linked to a token this palette no longer offers — still report it
+			// as linked so the value is not presented as a custom hex.
+			return {
+				value: customifyPaletteLink.decode(value).trim(),
+				label: name,
+				preview: ""
+			};
+		},
+
+		// The Colors section owns the palette itself: its slot pickers define
+		// the tokens (linking one would be circular) and its override pickers
+		// feed a hex-only derivation path. They keep their own quick-pick row.
+		isEligible: function (colorInput) {
+			var cfg = customifyPaletteLink.config();
+			if (!cfg) {
+				return false;
+			}
+			var el = colorInput[0];
+			if (el.closest("#sub-accordion-section-customify_colors")) {
+				return false;
+			}
+			var li = el.closest(".customize-control");
+			if (li && li.id) {
+				var name = li.id.replace(/^customize-control-/, "");
+				if ((cfg.excluded || []).indexOf(name) > -1) {
+					return false;
+				}
+			}
+			return true;
+		},
+
+		hidden: function (colorInput) {
+			return $(".customify-input--color", colorInput);
+		},
+
+		attach: function (colorInput) {
+			if (!customifyPaletteLink.isEligible(colorInput)) {
+				return;
+			}
+
+			colorInput.addClass("has-palette-link");
+			$(".wp-picker-container", colorInput).addClass("has-palette-link");
+
+			// Build on first open — see the note above about node count.
+			$(".wp-color-result", colorInput).on("click", function () {
+				customifyPaletteLink.build(colorInput);
+			});
+
+			// wp-color-picker writes the hidden input on every Iris change;
+			// that is what flips a field back out of linked mode.
+			colorInput.on("change", ".customify-input--color", function () {
+				if (colorInput.data("cfy-palette-writing")) {
+					return;
+				}
+				customifyPaletteLink.sync(colorInput);
+			});
+
+			customifyPaletteLink.sync(colorInput);
+		},
+
+		// Write through the hidden input: control.js binds `change` on every
+		// input inside the control container and calls getValue() -> setting.set(),
+		// so this is the same path wp-color-picker's own change callback uses.
+		//
+		// `previewHex` also drives Iris so the popover matches the pick. Iris
+		// has to move FIRST: its change callback writes a hex into the hidden
+		// input, so writing the token afterwards leaves the field on the token.
+		write: function (colorInput, value, previewHex) {
+			var hidden = customifyPaletteLink.hidden(colorInput);
+			if (!hidden.length) {
+				return;
+			}
+
+			if (previewHex) {
+				colorInput.data("cfy-palette-writing", true);
+				$(".customify--color-panel", colorInput).wpColorPicker(
+					"color",
+					previewHex
+				);
+				colorInput.data("cfy-palette-writing", false);
+			}
+
+			hidden.val(value).trigger("change");
+			customifyPaletteLink.sync(colorInput);
+		},
+
+		build: function (colorInput) {
+			var cfg = customifyPaletteLink.config();
+			var holder = $(".wp-picker-holder", colorInput);
+			if (!cfg || !holder.length || $(".customify-palette-link", holder).length) {
+				return;
+			}
+
+			var root = $('<div class="customify-palette-link"></div>');
+
+			// Value row — the popover always shows the literal stored value, so
+			// a linked field reads `var(--customify-x, #hex)` and can be copied
+			// straight into custom CSS. Editable while it holds a hex,
+			// read-only while linked (swatches / Unlink drive it instead).
+			var valueRow = $('<div class="customify-palette-link__value"></div>');
+			var valueInput = $(
+				'<input type="text" class="customify-palette-link__value-input" spellcheck="false" autocomplete="off" />'
+			);
+			valueInput.on("click", function (e) {
+				e.stopPropagation();
+			});
+			valueInput.on("input", function () {
+				if (valueInput.prop("readonly")) {
+					return;
+				}
+				var v = ($.trim(valueInput.val()) || "").replace(/^(?!#)/, "#");
+				if (/^#[0-9a-fA-F]{6}$/.test(v) || /^#[0-9a-fA-F]{8}$/.test(v)) {
+					customifyPaletteLink.write(colorInput, v, v);
+				}
+			});
+
+			var copy = $(
+				'<button type="button" class="customify-palette-link__copy dashicons dashicons-admin-page"></button>'
+			).attr("title", cfg.l10n.copy);
+			copy.on("click", function (e) {
+				e.preventDefault();
+				e.stopPropagation();
+				valueInput.select();
+				try {
+					document.execCommand("copy");
+				} catch (err) {}
+			});
+
+			valueRow.append(valueInput).append(copy);
+			root.append(valueRow);
+
+			// One flat grid — brand pairs first, then the neutral axis.
+			var row = $('<div class="customify-palette-link__row"></div>');
+			$.each(cfg.tokens, function (i, token) {
+				var swatch = $(
+					'<button type="button" class="customify-palette-link__swatch"></button>'
+				)
+					.css("background-color", token.preview)
+					.attr("data-value", token.value)
+					.attr("data-label", token.label)
+					.attr("title", token.label);
+				swatch.on("click", function (e) {
+					e.preventDefault();
+					e.stopPropagation();
+					customifyPaletteLink.write(
+						colorInput,
+						token.value,
+						token.preview
+					);
+				});
+				row.append(swatch);
+			});
+			root.append(row);
+			root.append('<div class="customify-palette-link__status"></div>');
+
+			holder.append(root);
+			customifyPaletteLink.sync(colorInput);
+		},
+
+		// Repaint trigger swatch, active swatch, value input and status from
+		// the current stored value. Cheap enough to run on every change.
+		sync: function (colorInput) {
+			var cfg = customifyPaletteLink.config();
+			if (!cfg) {
+				return;
+			}
+
+			var value = customifyPaletteLink.decode(
+				customifyPaletteLink.hidden(colorInput).val() || ""
+			).trim();
+			var token = customifyPaletteLink.tokenFor(value);
+
+			colorInput.toggleClass("is-palette-linked", !!token);
+
+			// The trigger chip is painted inline by color-picker-alpha.js on its
+			// own change events. Override it only while linked (the picker's
+			// own colour is the resolved hex, which is right, but Iris does not
+			// know about tokens) and only UNDO an override we actually applied
+			// — clearing unconditionally would wipe the alpha script's paint
+			// and leave the chip transparent on every ordinary hex pick.
+			var chip = $(".wp-color-result .color-alpha", colorInput);
+			if (!chip.length) {
+				chip = $(".wp-color-result", colorInput);
+			}
+			if (chip.length) {
+				if (token && token.preview) {
+					chip[0].style.setProperty(
+						"background-color",
+						token.preview,
+						"important"
+					);
+					colorInput.data("cfy-chip-override", true);
+				} else if (colorInput.data("cfy-chip-override")) {
+					chip[0].style.removeProperty("background-color");
+					colorInput.data("cfy-chip-override", false);
+					// Repaint from the picker's own value: the alpha script
+					// only paints on its own events, so dropping the override
+					// mid-flight would otherwise leave the chip blank.
+					var ownColor = $(".customify--color-panel", colorInput).val();
+					if (ownColor) {
+						chip[0].style.backgroundColor = ownColor;
+					}
+				}
+			}
+
+			var row = $(".customify-palette-link", colorInput);
+			if (!row.length) {
+				return;
+			}
+
+			var activeName = customifyPaletteLink.nameOf(value);
+			$(".customify-palette-link__swatch", row).each(function () {
+				var swatch = $(this);
+				swatch.toggleClass(
+					"is-active",
+					!!activeName &&
+						customifyPaletteLink.nameOf(swatch.attr("data-value")) ===
+							activeName
+				);
+			});
+
+			var valueInput = $(".customify-palette-link__value-input", row);
+			if (valueInput.length && !valueInput.is(":focus")) {
+				valueInput.val(value).prop("readonly", !!token);
+			}
+
+			var status = $(".customify-palette-link__status", row);
+			if (!status.length) {
+				return;
+			}
+			status.empty();
+			if (token) {
+				var dot = $('<span class="customify-palette-link__dot"></span>');
+				if (token.preview) {
+					dot.css("background-color", token.preview);
+				}
+				var unlink = $(
+					'<button type="button" class="customify-palette-link__unlink"></button>'
+				).text(cfg.l10n.unlink);
+				unlink.on("click", function (e) {
+					e.preventDefault();
+					e.stopPropagation();
+					// Hand the field back to Iris: keep the colour identical,
+					// drop the link.
+					customifyPaletteLink.write(
+						colorInput,
+						token.preview || "",
+						token.preview
+					);
+				});
+				status
+					.addClass("is-linked")
+					.append($("<span></span>").text(cfg.l10n.linked + " "))
+					.append(dot)
+					.append($("<strong></strong>").text(token.label))
+					.append(unlink);
+			} else {
+				status.removeClass("is-linked").text(cfg.l10n.custom);
+			}
 		}
 	};
 

--- a/src/backend/customizer/scss/_control.scss
+++ b/src/backend/customizer/scss/_control.scss
@@ -560,12 +560,27 @@ $text_color: #555d66;
         display: block;
         text-transform: uppercase;
     }
+    // Each column is `span.input` (the control) above `.customify--small-label`
+    // (the X / Y / BLUR / SPREAD / INSET caption). The height used to be a
+    // hardcoded 28px, so once the number inputs moved to the control-height
+    // token the 16px INSET checkbox — which centres inside this box, not
+    // inside the input — sat above the row and dragged its caption up with
+    // it. Track the token and centre, so every column shares one baseline
+    // whatever the control inside it is.
     span.input {
-        height: 28px;
-        display: block;
-        vertical-align: middle;
-        line-height: 28px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: var(--customify-control-h, 28px);
+        line-height: normal;
         text-align: center;
+
+        // WP admin ships checkboxes with `margin: -4px 4px 0 0`, meant for
+        // inline text baselines. Inside a centred flex column that offset is
+        // pure misalignment.
+        input[type="checkbox"] {
+            margin: 0;
+        }
     }
     label {
         cursor: pointer;
@@ -823,6 +838,17 @@ $text_color: #555d66;
 // value-cluster column width (136px) and the same box style, so the
 // whole popover reads as one aligned two-column form.
 .customize-control-customify-typography .customify-modal-settings {
+    // This popover deliberately runs a more compact scale than the styling
+    // composite: it stacks ~11 fields (family, size, weight, line-height,
+    // letter-spacing, style, decoration, transform, …) and the roomier
+    // 36px rhythm would push it past the sidebar. Re-declaring the tokens
+    // here keeps every control in this panel — including the Select2 font
+    // picker, which resolves them through the shared rule in
+    // customizer.scss — on ONE scale instead of leaving the font box
+    // taller than the fields beneath it.
+    --customify-control-h: 28px;
+    --customify-control-radius: 2px;
+
     // Quieter field labels — the values are the stars here.
     .customize-control-title {
         font-weight: 500;
@@ -1590,6 +1616,50 @@ $text_color: #555d66;
         }
     }
 }
+// ──────────────────────────────────────────────────────────────────
+// Composite-modal form controls.
+//
+// A styling modal used to mix three scales in one panel: the colour row
+// (32px, rounded), the css_ruler number boxes for padding / border
+// radius / box-shadow offsets (39px, square), and the Border Style
+// select (40px, square) — twelve fields, three heights, two corner
+// styles, stacked vertically.
+//
+// The scale tokens (--customify-control-h / -radius / -border) are
+// declared once on `.customize-control` in customizer.scss; everything
+// here just resolves them, so there is one number to change.
+// ──────────────────────────────────────────────────────────────────
+.customify-modal-settings {
+    input[type="text"],
+    input[type="number"],
+    input[type="search"],
+    input[type="email"],
+    input[type="url"],
+    input[type="button"],
+    select,
+    .wp-color-result {
+        height: var(--customify-control-h);
+        min-height: var(--customify-control-h);
+        border-radius: var(--customify-control-radius);
+        border-color: var(--customify-control-border);
+        box-shadow: none;
+        font-size: 13px;
+    }
+
+    // Number boxes sit under their own TOP/RIGHT/BOTTOM/LEFT captions, so
+    // centring reads better than WP's default left alignment at this width.
+    input[type="number"] {
+        padding: 0 6px;
+        text-align: center;
+    }
+
+    select {
+        padding-top: 0;
+        padding-bottom: 0;
+        line-height: calc(var(--customify-control-h) - 2px);
+    }
+}
+
 .customify-modal-settings {
     box-shadow: 0 2px 15px rgba(0,0,0,.3);
     background: #fff;
@@ -2644,4 +2714,385 @@ $text_color: #555d66;
 @keyframes customify-color-popover-in {
     from { opacity: 0; }
     to   { opacity: 1; }
+}
+
+
+// ──────────────────────────────────────────────────────────────────
+// Palette link — token swatch row inside any eligible color picker.
+//
+// Behaviour lives in src/backend/customizer/js/control.js
+// (initColor() + the customifyPaletteLink helper); data comes from
+// Customify_Control_Args.palette_link (inc/color-palette-link.php).
+//
+// Everything here is scoped to `.has-palette-link`, a class the JS adds
+// only to pickers it decorates — pickers in the Colors section and any
+// excluded control keep their existing appearance untouched.
+// ──────────────────────────────────────────────────────────────────
+
+// The Colors section renders `.wp-picker-holder` as a floating card, but
+// that rule is scoped to #sub-accordion-section-customify_colors. Elsewhere
+// the holder is an unstyled block sitting in the section body, so anything
+// appended to it reads as "outside the picker". Same card, scoped to us.
+.customify-input-color.has-palette-link {
+    position: relative;
+}
+
+.wp-picker-container.has-palette-link {
+    // Trigger row — WP lays the swatch button, the hex input and Clear out as
+    // three independently-sized inline-blocks, so they sit at different heights
+    // and baselines. One flex row with a shared control height lines them up.
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+
+    // One shared control height for all three parts, taken from the same
+    // custom property the composite modal uses so a colour row matches the
+    // number inputs it sits between. `min-height` has to be reset
+    // explicitly: Customify's global Customizer field styling puts
+    // `min-height: 39px` on text inputs, which otherwise wins over `height`
+    // and leaves the hex box taller than the swatch button and Clear.
+    .wp-color-result,
+    input[type="text"].wp-color-picker,
+    .wp-picker-clear {
+        height: var(--customify-control-h, 36px);
+        min-height: var(--customify-control-h, 36px);
+        border-radius: var(--customify-control-radius, 4px);
+    }
+
+    // Swatch-only trigger. WP's "Select Color" label needs ~90px on top of the
+    // colour chip, which does not fit next to the hex field + Clear in a
+    // narrow panel (the styling-composite modal is ~260px) — the label ends up
+    // truncated mid-word. The chip alone already reads as "pick a colour", so
+    // the text is hidden VISUALLY ONLY, the accessible name is kept.
+    .wp-color-result {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex: 0 0 auto;
+        // Square chip — same edge as the control height so it reads as one
+        // token in the row rather than a differently-proportioned box.
+        width: var(--customify-control-h, 36px);
+        margin: 0;
+        padding: 0;
+        border-radius: var(--customify-control-radius, 4px);
+        overflow: hidden;
+
+        // wp-color-picker's own stylesheet pins the chip to a fixed 30px,
+        // which leaves a transparent sliver of the button showing down the
+        // right-hand edge of a 36px swatch. Same `!important` treatment the
+        // height already needs in customizer.scss.
+        .color-alpha {
+            width: 100% !important;
+            height: 100% !important;
+            border-radius: 0;
+        }
+
+        .wp-color-result-text {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            border: 0;
+            overflow: hidden;
+            white-space: nowrap;
+            clip-path: inset(50%);
+        }
+    }
+
+    .wp-picker-input-wrap {
+        display: flex;
+        align-items: center;
+        flex: 1 1 auto;
+        gap: 6px;
+        min-width: 0;
+        margin: 0;
+
+        label {
+            display: block;
+            flex: 1 1 auto;
+            min-width: 0;
+            margin: 0;
+        }
+    }
+
+    // wp-color-picker's JS writes an inline `width` on the hex field during
+    // init, so this needs `!important` to fill the row instead of leaving dead
+    // space between the field and Clear — no stylesheet rule can outrank an
+    // inline style.
+    input[type="text"].wp-color-picker {
+        width: 100% !important;
+        min-width: 0;
+        margin: 0;
+        border-radius: var(--customify-control-radius, 4px);
+        font-family: Menlo, Consolas, monospace;
+        font-size: 11px;
+        text-align: center;
+    }
+
+    .wp-picker-clear {
+        flex: 0 0 auto;
+        margin: 0;
+        padding: 0 10px;
+        border-radius: var(--customify-control-radius, 4px);
+        line-height: calc(var(--customify-control-h, 36px) - 2px);
+    }
+
+    .wp-picker-holder {
+        display: none;
+        // Reset any leftover height jQuery's slideUp may have inlined.
+        height: auto !important;
+    }
+
+    // Iris ships 8 default swatches inside the picker — redundant next to
+    // the theme palette row.
+    .iris-palette-container {
+        display: none !important;
+    }
+
+    &.wp-picker-active .wp-picker-holder {
+        display: block !important; // beat Iris's inline display:none mid-slide
+        position: absolute;
+        top: calc(100% + 8px);
+        left: 0;
+        right: 0;
+        width: auto;
+        padding: 16px;
+        background: #fff;
+        border: 1px solid rgba(0, 0, 0, 0.08);
+        border-radius: 6px;
+        box-shadow:
+            0 0 0 1px rgba(0, 0, 0, 0.04),
+            0 12px 28px rgba(0, 0, 0, 0.16);
+        z-index: 100;
+        animation: customify-color-popover-in 0.08s ease-out;
+    }
+
+    // wp-color-picker slides `.iris-picker` itself (not the holder), so it can
+    // be left with an inline `display: none` from an interrupted slideUp while
+    // the container is still `.wp-picker-active` — the card then opens showing
+    // only the palette row, with no picker above it. Tie the picker's
+    // visibility to the container state instead of to the animation.
+    &.wp-picker-active .iris-picker {
+        display: block !important;
+    }
+
+    // Iris chrome cleanup — the card provides the surface now, so Iris must
+    // not draw its own bordered box inside it. Its internals (.iris-square /
+    // .iris-strip) keep their native layout: the drag math reads
+    // offsetWidth/offsetTop, so resizing them breaks hue + alpha drag.
+    //
+    // Iris renders at a FIXED 255px regardless of its container, and a picker
+    // row is narrower than that in most panels (~251px in a composite modal),
+    // so it always overhangs by a few px. Centre it with the width baked into
+    // the offset — `(100% - 255px) / 2` resolves against the content box, so
+    // the overhang splits evenly (~2px a side) whatever the container width.
+    // A fixed negative margin cannot do this: the -10px value this rule
+    // carried was copied from the Colors section, whose rows are ~283px wide,
+    // and in a narrower panel it dragged the whole picker left and pushed the
+    // alpha strip hard against the card's right edge.
+    &.wp-picker-active .iris-picker.iris-border {
+        background: transparent !important;
+        border: 0 !important;
+        box-shadow: none !important;
+        padding: 0 !important;
+        margin: 0 calc((100% - 255px) / 2) !important;
+    }
+
+    &.wp-picker-active .iris-picker-inner .iris-strip {
+        top: 0 !important;
+        margin-top: 0 !important;
+        margin-bottom: 0 !important;
+        height: 100% !important;
+    }
+
+    // Drag handles — appearance only. Iris positions these by writing
+    // `top`/`left` in px, and its own CSS pairs each size with a matching
+    // negative margin, so the BOX SIZE must not change: restyling borders,
+    // radius and shadow is safe, resizing would offset the handle from the
+    // colour it points at.
+    //
+    // Stock look is a 5px solid ring on the square handle and a flat
+    // grey jQuery-UI pill on the strips. Both read as unfinished next to
+    // the rest of the panel.
+    .iris-square-handle {
+        border-width: 2px;
+        border-color: #fff;
+        background: transparent;
+        box-shadow:
+            0 0 0 1px rgba(0, 0, 0, 0.3),
+            0 1px 3px rgba(0, 0, 0, 0.35);
+    }
+
+    .iris-slider-offset .ui-slider-handle {
+        background: #fff;
+        border: 1px solid rgba(0, 0, 0, 0.25);
+        border-radius: 3px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+    }
+}
+
+.customify-palette-link {
+    margin-top: 14px;
+}
+
+.customify-palette-link__value {
+    position: relative;
+    margin-bottom: 14px;
+}
+
+.customify-palette-link__value-input {
+    width: 100%;
+    padding-right: 30px !important;
+    font-family: Menlo, Consolas, monospace;
+    font-size: 11px;
+
+    &[readonly] {
+        background: #f6f7f7;
+    }
+}
+
+.customify-palette-link__copy {
+    position: absolute;
+    top: 50%;
+    right: 4px;
+    transform: translateY(-50%);
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: 0;
+    background: none;
+    color: #787c82;
+    font-size: 16px;
+    line-height: 24px;
+    cursor: pointer;
+
+    &:hover {
+        color: var(--wp-admin-theme-color, #3858e9);
+    }
+}
+
+// Every token in one compact block — 12 tokens at 6 per line = two rows.
+.customify-palette-link__row {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    justify-items: center;
+    gap: 9px;
+    margin-bottom: 12px;
+}
+
+.customify-palette-link__swatch {
+    position: relative;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: 0;
+    border-radius: 50%;
+    cursor: pointer;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.12);
+
+    &:focus {
+        outline: none;
+        box-shadow:
+            inset 0 0 0 1px rgba(0, 0, 0, 0.12),
+            0 0 0 2px var(--wp-admin-theme-color, #3858e9);
+    }
+
+    // Selected state: white ring lifts the swatch off the card, and the
+    // dashicon check still reads at 24px where a border alone would not.
+    &.is-active {
+        box-shadow:
+            inset 0 0 0 1px rgba(0, 0, 0, 0.12),
+            0 0 0 2px #fff,
+            0 0 0 4px var(--wp-admin-theme-color, #3858e9);
+
+        &::after {
+            content: '\f147';
+            position: absolute;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-family: dashicons;
+            font-size: 16px;
+            line-height: 1;
+            color: #fff;
+            text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+        }
+    }
+
+    // Token-name tooltip — same interaction as the Colors section quick-pick
+    // swatches (SPEC-customizer-colors §6.7).
+    &::before {
+        content: attr(data-label);
+        position: absolute;
+        bottom: calc(100% + 7px);
+        left: 50%;
+        transform: translateX(-50%);
+        padding: 3px 7px;
+        border-radius: 3px;
+        background: #1d2327;
+        color: #fff;
+        font-size: 10px;
+        line-height: 1.4;
+        white-space: nowrap;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.12s ease-out;
+        z-index: 5;
+    }
+
+    &:hover::before {
+        opacity: 1;
+    }
+}
+
+.customify-palette-link__status {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 11px;
+    color: #787c82;
+
+    &.is-linked {
+        color: #1d2327;
+    }
+}
+
+.customify-palette-link__dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.15);
+}
+
+.customify-palette-link__unlink {
+    margin-left: auto;
+    padding: 0;
+    border: 0;
+    background: none;
+    color: var(--wp-admin-theme-color, #3858e9);
+    font-size: 11px;
+    cursor: pointer;
+    text-decoration: underline;
+}
+
+// Linked fields read differently at a glance from custom-hex ones: the
+// trigger swatch carries the same accent marker used by the active swatch.
+// The dot sits INSIDE the button so the trigger row can keep `overflow:
+// hidden` (which is what clips the colour chip to the rounded corners).
+.customify-input-color.is-palette-linked .wp-color-result {
+    position: relative;
+
+    &::after {
+        content: '';
+        position: absolute;
+        right: 3px;
+        bottom: 3px;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--wp-admin-theme-color, #3858e9);
+        box-shadow: 0 0 0 2px #fff;
+    }
 }

--- a/src/backend/customizer/scss/customizer.scss
+++ b/src/backend/customizer/scss/customizer.scss
@@ -130,12 +130,25 @@ $builder_active_color: #0073aa;
 		}
 	}
 
+	// Single source of truth for the Customizer form-control scale. Composite
+	// modals used to mix three of them in one panel — colour rows at 32px with
+	// rounded corners, css_ruler number boxes at 39px square, the select at
+	// 40px square — so a styling modal read as three different form kits
+	// stacked on top of each other. Every control rule below (and the
+	// palette-link picker chrome in _control.scss) resolves these tokens.
+	--customify-control-h: 36px;
+	--customify-control-radius: 4px;
+	--customify-control-border: #dcdcde;
+
 	select.customify-modal-input,
 	input[type="number"].customify-modal-input,
 	input[type="text"].customify-modal-input,
 	.customify--field-select select,
 	.customify--field-select .select2-selection {
-		min-height: 39px;
+		min-height: var(--customify-control-h);
+		height: var(--customify-control-h);
+		border-radius: var(--customify-control-radius);
+		border-color: var(--customify-control-border);
 		display: flex;
 		align-items: center;
 	}
@@ -154,10 +167,19 @@ $builder_active_color: #0073aa;
 		}
 	}
 	
+	// select2 paints its own corner radius on the single-select box; without
+	// this the font pickers keep a 2px corner while every field beside them
+	// is on the 4px token.
+	.select2-container--default .select2-selection--single {
+		border-radius: var(--customify-control-radius);
+	}
+
 	.select2-container--default
 		.select2-selection--single
 		.select2-selection__arrow {
-		height: 37px;
+		// Fills the select minus its 1px border on each side — keep in step
+		// with --customify-control-h or the arrow detaches from the field.
+		height: calc(var(--customify-control-h) - 2px);
 		background: #fff url(data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%231e1e1e%22%2F%3E%3C%2Fsvg%3E) no-repeat right 8px top 55%;
     background-size: 16px 16px;
 		width: 28px;	
@@ -165,8 +187,11 @@ $builder_active_color: #0073aa;
 }
 
 .wp-customizer {
+	// Rendered in a body-level select2 dropdown, outside `.customize-control`,
+	// so the token is not inherited here — keep the literal in step with
+	// --customify-control-h.
 	.select2-search__field {
-		min-height: 39px;
+		min-height: 36px;
 	}
 	ul.select2-results__options {
 		.select2-results__option {


### PR DESCRIPTION
## What

Customify derives 6 palette slots and ~19 tokens, but **no colour picker outside the Colors section could reach them** — every field froze a hex, so changing a palette slot left the rest of the site behind.

Picking a swatch now stores the token reference itself:

```
footer_main_background_color = var(--customify-secondary, #c3512f)
```

The field **follows** the palette; the baked fallback keeps it rendering where the token is not emitted (the derived-token opt-in gate).

Applied to every colour input outside the Colors section — 13 eligible top-level controls, 13 nested in `modal` composites, and the 8 colour subfields of each of the 26 `styling` composites (~224 inputs).

## Where it lives

All of it hangs off `initColor()` in `src/backend/customizer/js/control.js` — the single point every Customify colour input passes through, so standalone controls, `styling` subfields, `modal` subfields and repeater rows are covered by one implementation. `inc/color-palette-link.php` is data only and rides the existing `Customify_Control_Args` payload (no extra request).

The Colors section is **excluded** and keeps its own quick-pick: its slot pickers DEFINE the tokens (linking one would be circular) and its overrides feed a hex-only derivation path. The exclusion list is derived from the live config, so a new field added to that section cannot silently expose a slot picker.

## 30K-site safety

No new storage key, no value-shape change. `sanitize_color()` gained an **additive** `var(--customify-*)` branch restricted to an allowlist of emitted token names, with the fallback re-validated through the ordinary hex/rgba path.

Verified against **the same tree at `HEAD` installed as a second theme**, so only the change under test differed:

| Check | Result |
|---|---|
| Scenario A — fresh install, zero saved mods | Generated CSS **byte-identical** |
| Scenario B — 11 saved keys incl. the legacy 9 | **byte-identical** |
| Scenario C — partial save | **byte-identical** |
| `sanitize_color()` corpus — 48 inputs (hex 3/6/8-char, rgba shapes, empty/null/array/bool, junk, injection) | **0 regressions** |
| Injection via the new branch | `var(--evil)`, `var(--customify-nope)`, `var(--customify-primary); background:url(x)` rejected; hostile fallback stripped |
| Dirty-on-open, linked and unlinked | Customizer stays clean |
| Existing hex picking | unchanged |
| Cost at scale | swatch row built on first popover open — 0 rows in the DOM after a Customizer load |

Also exercised with **Customify Pro 0.4.17** active: 240 colour inputs, 224 decorated, the only 16 undecorated are the Colors section. Zero Pro pickers missed, zero decorated that shouldn't be. Pro's mega-menu — the one Pro file that touches `wpColorPicker` — targets `.color` inside its own panel and does not intersect `.customify-input-color`; no contamination, no console errors.

## Non-obvious constraints (documented in SPEC-customizer-colors.md §3.8)

Four things bit during implementation and will bite again if the code is refactored:

1. **Iris cannot parse `var()`.** `wpColorPicker()` init treats a token as empty and fires its `clear` callback, blanking the hidden input the control reads — a later `getValue()` would push `''` over the saved token.
2. **`wpColorPicker()` fires `change` during init**, which pushes the picker's hex to the setting — that would rewrite a linked field to its fallback hex on every re-render.
3. **The trigger chip is painted inline by `color-picker-alpha.js`**, so the sync pass may only undo an override it applied itself; clearing unconditionally leaves the chip transparent after an ordinary hex pick.
4. **wp-color-picker slides `.iris-picker`, not the holder** — an interrupted slideUp leaves the card open with the palette row and no picker above it.

## Also in this PR

**Unified form-control scale** (`refactor` commit). A composite modal mixed three scales in one panel — 32px rounded colour row, 39px square number boxes, 40px square select. The scale is now declared once on `.customize-control` as custom properties; a panel that needs a different rhythm re-declares them on its own root (the typography modal drops to 28px/2px because it stacks ~12 fields) instead of hardcoding heights. Visual only.

**Quantity steppers no longer take the button skin** (`fix` commit). The +/- controls are plain `<button>`s and were being painted with the brand button background on cart, mini-cart and single product. Both the classic (`.input-pm-act`) and Cart-block (`.wc-block-components-quantity-selector__button`) variants are excluded. **Render change for existing sites**: a site that saved a button background no longer has it applied to quantity steppers.

## Known follow-ups

- The baked fallback in a stored token goes stale after a slot edit (harmless — it only applies when the token is absent). A follow-up could refresh it when the Customizer is already dirty, using the same "never write on a clean open" doctrine as the palette switcher.
- `build/` is gitignored here, so reviewers need `npm run build` to see the compiled assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)