### PR TITLE
Align and balance the My Account login/register columns

### DIFF
--- a/src/frontend/scss/compatibility/wc/_wc-forms.scss
+++ b/src/frontend/scss/compatibility/wc/_wc-forms.scss
@@ -307,3 +307,76 @@ ul#shipping_method {
         }
     }
 }
+
+/**
+* My Account — login / register columns.
+*
+* `myaccount/form-login.php` renders `#customer_login.u-columns.col2-set` with a
+* `.col-1` (Login) and `.col-2` (Register). Two inherited quirks made that read
+* as misaligned:
+*
+* 1. `form.login / form.register` above carry `padding: 20px`, ported from
+*    WooCommerce's stock rule — where the form is a BORDERED card and the
+*    padding clears that border. Customify drops the border but kept the
+*    padding, so every field sat indented ~20px from its own <h2> with nothing
+*    to justify the inset.
+* 2. `.col2-set .col-1 / .col-2` are `float` + `width: 48%`, a shared checkout
+*    rule. Floats give no control over the gutter and let the two columns end
+*    at different heights.
+*
+* The padding reset is scoped to `.woocommerce-account` rather than to
+* `#customer_login`: that wrapper only exists when registration is enabled
+* (see the `woocommerce_enable_myaccount_registration` guard in the template),
+* so scoping the reset to it would leave the far more common registration-off
+* layout still indented. Checkout keeps its own boxed treatment either way —
+* `form.checkout_coupon` genuinely has a border, and the checkout login toggle
+* is outside this scope.
+*/
+.woocommerce-account {
+    form.login,
+    form.register {
+        margin: 0;
+        padding: 0;
+    }
+
+    // `form .form-row` adds 3px on every side; drop the horizontal part so the
+    // inputs line up flush with the heading, and keep the vertical rhythm.
+    form.login .form-row,
+    form.register .form-row {
+        padding-left: 0;
+        padding-right: 0;
+    }
+}
+
+#customer_login {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0 clamp(24px, 4vw, 56px);
+    align-items: start;
+
+    // `.col2-set` carries a clearfix, whose ::before/::after become GRID ITEMS
+    // here — they take the first and last cells, pushing Login into column 2
+    // and wrapping Register onto a second row. The grid needs no clearing.
+    &::before,
+    &::after {
+        content: none;
+    }
+
+    // Neutralize the shared float layout — the grid owns placement now.
+    > .col-1,
+    > .col-2 {
+        float: none;
+        width: auto;
+    }
+
+    // Headings align with the fields below them, not with a phantom inset.
+    > .col-1 > h2,
+    > .col-2 > h2 {
+        margin-top: 0;
+    }
+
+    @include mq(max-sm) {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 40px 0;
+    }
+}


### PR DESCRIPTION
## The bug

On My Account, the Login and Register forms were indented from their own headings, and the two columns were uneven.

## Cause — two inherited quirks

**1. Phantom padding.** `form.login / form.register` carry `padding: 20px`, ported from WooCommerce's stock rule:

```css
/* WooCommerce woocommerce.css */
.woocommerce form.login, .woocommerce form.register {
  border: 1px solid #cfc8d8; padding: 20px; border-radius: 5px;
}
```

There the form is a **bordered card** and the padding clears that border. Customify drops the border but kept the padding, so every field sat inset ~20px from its `<h2>` with nothing to justify it — plus another 3px from the shared `.form-row` padding.

**2. Float columns.** `.col2-set .col-1 / .col-2` are `float` + `width: 48%`, a rule shared with checkout. Floats give no control over the gutter and let the two columns end at different heights.

## The fix

`#customer_login` becomes a two-column grid with a fluid gutter (`clamp(24px, 4vw, 56px)`), collapsing to one column under 768px via the theme's `mq(max-sm)` mixin.

**Its clearfix `::before`/`::after` are cancelled.** This one is easy to miss: in a grid container those pseudo-elements become **grid items**, so they took the first and last cells — pushing Login into column 2 and wrapping Register onto a second row. Caught on the first visual check.

**The padding reset is scoped to `.woocommerce-account`, not `#customer_login`.** That wrapper only exists when registration is enabled:

```php
<?php if ( 'yes' === get_option( 'woocommerce_enable_myaccount_registration' ) ) : ?>
<div class="u-columns col2-set" id="customer_login">
```

Registration is off by default, so scoping the reset to the wrapper would have left the far more common single-column layout still indented.

## Not touched

Checkout keeps its boxed treatment. Verified in the built CSS — the original rule is intact and the new resets are all under `.woocommerce-account`:

```css
form.checkout_coupon,form.login,form.register{border-radius:1px;margin:2em 0;padding:20px;text-align:left}
.woocommerce-account form.login,.woocommerce-account form.register{margin:0;padding:0}
```

`form.checkout_coupon` genuinely has a border, so its padding stays earned.

## Verified

Screenshots on a live site, all four states:

- **Registration on, desktop** — headings flush with their fields, equal columns, even gutter, both starting at the same top edge.
- **Registration on, mobile** — single column, forms stacked, spacing preserved.
- **Registration off, desktop** — single-column login, no indent (the case most installs are in).
- **Checkout** — unaffected by scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)