### PR TITLE
fix(blocks): style Core Comments and repair blockGap-broken core blocks

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -101,11 +101,20 @@ if ( ! function_exists( 'customify_comment' ) ) :
 					<div class="comment-wrap">
 						<header class="comment-header">
 							<?php
+							// If current post author is also comment author, make it known visually.
+							// Guest comments carry `user_id` 0, and a post whose author was
+							// deleted (or that was inserted programmatically) carries
+							// `post_author` 0 — the old strict comparison matched 0 === 0 and
+							// badged EVERY guest comment as "Post author". Require a real
+							// account, and compare as integers because the two values do not
+							// reliably arrive with the same type.
+							$customify_is_post_author = $post instanceof WP_Post
+								&& (int) $comment->user_id > 0
+								&& (int) $comment->user_id === (int) $post->post_author;
 							printf(
 								'<cite class="comment-author fn vcard">%1$s %2$s</cite>',
 								get_comment_author_link(),
-								// If current post author is also comment author, make it known visually.
-								( $comment->user_id === $post->post_author ) ? '<span class="comment-post-author text-uppercase text-xsmall">' . __( 'Post author', 'customify' ) . '</span>' : ''
+								$customify_is_post_author ? '<span class="comment-post-author text-uppercase text-xsmall">' . __( 'Post author', 'customify' ) . '</span>' : ''
 							);
 							?>
 							<div class="comment-meta text-uppercase text-xsmall link-meta">

--- a/src/backend/admin/scss/editor.scss
+++ b/src/backend/admin/scss/editor.scss
@@ -14,6 +14,13 @@ $editor_context: true;
 @import "../../../frontend/scss/base/base";
 @import "../../../frontend/scss/base/blocks";
 
+// Core Comments blocks. The editor canvas renders `core/comment-template` and
+// friends with the SAME class names as the frontend, so importing the one
+// partial keeps the two in step. `base/_comments.scss` is deliberately NOT
+// imported here — it targets the classic `comments.php` walker markup, which
+// never exists inside the editor.
+@import "../../../frontend/scss/base/comment-blocks";
+
 // Block-widget styles (.wp-block-archives-list, .wp-block-categories-list,
 // .wp-block-tag-cloud, .wp-block-latest-posts, .wp-block-latest-comments,
 // .wp-block-rss, .wp-block-calendar, .wp-block-search) so the editor

--- a/src/frontend/scss/base/_blocks.scss
+++ b/src/frontend/scss/base/_blocks.scss
@@ -56,8 +56,14 @@
 	width: 100vw;
 	max-width: 100vw;
 	// Vertical rhythm driven by theme.json → styles.spacing.blockGap.
-	// Variable is emitted only when blockGap has a value; when blockGap is
-	// false the variable is absent and the fallback 0 applies — i.e. no spacing.
+	//
+	// NOTE on the mechanism, which is not what it looks like: with
+	// `blockGap: false` WordPress still EMITS `--wp--style--block-gap`, with an
+	// empty value. An empty-but-declared custom property makes the declaration
+	// invalid at computed-value time rather than falling back, so the `0` here
+	// is never actually used — the property just resolves to its initial value,
+	// which is also 0. Same result, different route. Do not rely on the
+	// fallback slot to carry a NON-zero value: it will silently never apply.
 	margin-top: var(--wp--style--block-gap, 0);
 	margin-bottom: var(--wp--style--block-gap, 0);
 	margin-left: calc(50% - 50vw);
@@ -81,11 +87,31 @@
 	}
 }
 
-.entry-content ul:not(:is(ul, ol) ul),
-.entry-content ol:not(:is(ul, ol) ol) {
+// Top-level content lists get their own vertical rhythm, distinct from the
+// generic `ul, ol` rule in `base/_base.scss`.
+//
+// `.entry-content` only exists on the frontend, so in editor context the same
+// declarations are emitted unscoped — WordPress rewrites every selector in an
+// injected theme editor stylesheet to sit under `.editor-styles-wrapper`, which
+// supplies the boundary. Without this split the canvas gave lists the base
+// `ms(2)` margin while the frontend gave them 1.5em, so list spacing visibly
+// changed between writing and publishing.
+@mixin customify-content-list-rhythm {
 	margin-top: 1.5em;
 	margin-bottom: 1.5em;
 	list-style-position: outside;
+}
+
+@if $editor_context {
+	ul:not(:is(ul, ol) ul):not(.wp-block-comment-template):not(.wp-block-post-template),
+	ol:not(:is(ul, ol) ol):not(.wp-block-comment-template):not(.wp-block-post-template) {
+		@include customify-content-list-rhythm;
+	}
+} @else {
+	.entry-content ul:not(:is(ul, ol) ul),
+	.entry-content ol:not(:is(ul, ol) ol) {
+		@include customify-content-list-rhythm;
+	}
 }
 
 // Top-level block divs (wp-block-columns, group, buttons, cover, gallery,
@@ -95,8 +121,11 @@
 // uses .editor-styles-wrapper / .is-root-container scope instead.
 //
 // Acts as a flag off theme.json → styles.spacing.blockGap:
-//   - blockGap: <value> → WP emits `--wp--style--block-gap` → margin auto-uses it
-//   - blockGap: false   → variable absent → fallback 0 applies → no block spacing
+//   - blockGap: <value> → WP emits `--wp--style--block-gap` → margin uses it
+//   - blockGap: false   → WP emits the property EMPTY (not absent), so the
+//     declaration is invalid at computed-value time and the margin resolves to
+//     its initial 0. The written fallback is never reached — see the longer
+//     note on `.alignfull` above before changing that `0` to anything else.
 .entry-content > div[class*="wp-block-"] {
 	margin-bottom: var(--wp--style--block-gap, 0);
 }
@@ -285,50 +314,82 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 	width: 100%;
 }
 
+// Cells. Core draws a 1px border on ALL FOUR sides of every cell with no
+// color, so the browser falls back to `currentcolor` — on a dark Palette base
+// that is the white text color, producing bright white grid lines.
+//
+// The color was only half the problem. This file used to also tint every cell
+// (header 10%, odd rows 4%, even rows 6%, footer 10%), and a boxed grid plus a
+// fill on every cell reads as one grey slab — the ink competes with the data
+// instead of organising it.
+//
+// Horizontal rules only, no fills. The row is the unit of meaning in almost
+// every table an editor writes, so the row division is the only one worth
+// drawing; vertical rules and per-cell tints add weight without adding
+// structure. Dropping the blanket fills also un-breaks Core's own cell colour
+// classes (`.has-subtle-pale-blue-background-color` and friends), which the
+// old `.wp-block-table tbody td` rule silently outranked.
 .wp-block-table td,
 .wp-block-table th {
-	padding: 0.5em;
-	// WP / bundled SCSS leave `border: 1px solid` with no color, so the
-	// browser falls back to `currentcolor` — which on dark Palette bases
-	// is the white text color, producing bright white grid lines.
-	// Explicit border-color via the $color_border token gives the
-	// adaptive currentcolor-tint border (10%) we use elsewhere.
-	border-color: $color_border;
-}
-// WP core block-library also adds `border-bottom: 3px solid` on
-// `.wp-block-table thead` and `border-top: 3px solid` on `tfoot` with
-// no color — same currentcolor-fallback problem produces a bright
-// 3px white bar between header/footer and body on dark bases. Set
-// border-color so those separators use the adaptive token.
-.wp-block-table thead,
-.wp-block-table tfoot {
-	border-color: $color_border;
+	padding: 0.75em 0.85em;
+	border: 0;
+	border-bottom: 1px solid $color_border;
+	background-color: transparent;
 }
 
-// WP block defaults paint table cells/headers with hard-coded #f0f0f0 /
-// #f9f9f9 light greys AND force dark `#40464d` text via a `:where()`
-// reset (selector specificity 0). On dark Palette bases the greys wash
-// out into the canvas and the dark text becomes unreadable. Override:
-//   1. `color: $color_text` on `.wp-block-table table` cascades through
-//      the body-text token so cells inherit the theme palette text
-//      color and beat WP's 0-specificity `:where()` reset.
-//   2. Surface adaptive tints on cells/headers stay readable on any
-//      background — saved Palette Surface wins, unsaved → currentcolor
-//      mix.
+// Header and footer keep a heavier rule so they read as the frame around the
+// data rather than as another row of it. Core's own 3px is brought down to 2px:
+// with no cell fills left to balance it, a 3px bar dominates the table.
+.wp-block-table thead {
+	border-bottom: 2px solid $color_border_medium;
+}
+
+.wp-block-table tfoot {
+	border-top: 1px solid $color_border_medium;
+}
+
+.wp-block-table thead th {
+	color: $color_heading;
+	font-weight: 600;
+	text-align: left;
+}
+
+.wp-block-table tfoot td {
+	font-weight: 600;
+	border-bottom: 0;
+}
+
+// The last body row's rule is redundant against the table's own closing edge.
+.wp-block-table tbody tr:last-child td {
+	border-bottom: 0;
+}
+
+// WP forces a dark `#40464d` onto cells through a `:where()` reset (specificity
+// 0), which is unreadable on dark Palette bases. One token'd declaration on the
+// table beats it and cascades to every cell.
 .wp-block-table table {
 	color: $color_text;
 }
-.wp-block-table thead th {
-	background-color: $surface_strong;
-}
-.wp-block-table tbody td {
-	background-color: $surface_subtle;
-}
-.wp-block-table tbody tr:nth-child(2n) td {
-	background-color: $surface_medium;
-}
-.wp-block-table tfoot td {
-	background-color: $surface_strong;
+
+// Zebra striping belongs to the block style that asks for it, and only there.
+// Core hard-codes `#f0f0f0`, which washes out on a dark base; the Surface token
+// tints from the current text color instead so it stays visible either way.
+// Core already makes the cell borders transparent in this style, so the stripes
+// carry the structure on their own — the row rules would double up with them.
+//
+// Same specificity as Core's rule; the theme stylesheet is enqueued after the
+// block-library styles, so it wins the tie.
+.wp-block-table.is-style-stripes {
+	border-bottom-color: $color_border;
+
+	tbody tr:nth-child(odd) {
+		background-color: $surface_subtle;
+	}
+
+	td,
+	th {
+		border-bottom: 0;
+	}
 }
 
 // Code / preformatted / verse blocks — same WP-default-gray problem as
@@ -637,4 +698,157 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 
 .has-very-dark-gray-background-color {
 	background-color: #444;
+}
+
+/*--------------------------------------------------------------
+  # Layout gaps for Core blocks (blockGap is disabled in theme.json)
+  --------------------------------------------------------------*/
+//
+// `theme.json` does not opt into `settings.spacing.blockGap`, so WordPress
+// emits no layout `gap` for ANY flex or grid block on the site. Worse, it still
+// emits the custom property — with an EMPTY value:
+//
+//     :root { --wp--style--block-gap: ; }
+//
+// An empty-but-declared custom property makes a declaration invalid at
+// computed-value time instead of falling back, so every `var( --wp--style--
+// block-gap, <default> )` that Core writes as a safety net silently resolves to
+// nothing. The blocks below are the ones where that visibly breaks the block:
+// their items end up touching, and in the Gallery's case the block stops
+// laying out altogether.
+//
+// The values restated here are CORE'S OWN defaults, not a Customify opinion —
+// `2em` is `core/columns`' `spacing.blockGap.__experimentalDefault`, and `0.5em`
+// is the fallback Core writes into its own `calc()` expressions for buttons,
+// social links and the gallery.
+//
+// Every rule is wrapped in `:where()` (specificity 0) so that:
+//   • a site that DOES enable blockGap keeps Core's `.wp-container-*{gap:…}`,
+//   • a per-block gap set in the editor still wins,
+//   • and any custom CSS an existing site already wrote to work around this
+//     keeps winning too — which is what makes the change safe on installs that
+//     have been living with the broken rendering.
+
+// Gallery. Core sizes each tile with
+//   width: calc( 33.33% - var( --wp--style--unstable-gallery-gap, 16px ) * .667 )
+// and resolves that variable through a chain ending at `--wp--style--block-gap`.
+// With the empty value the calc() is invalid, `width` falls back to `auto`, and
+// because Core also sets `flex-grow: 1` on the tiles EVERY image takes a full
+// row — a three-image gallery renders as three stacked full-width images.
+// Re-declaring the variable on the gallery itself skips the empty link in the
+// chain. A gallery-specific gap from theme.json (`--wp--style--gallery-gap-
+// default`) is still honoured first, and a gap set on one gallery in the editor
+// serialises as an inline custom property on this same element.
+// WordPress emits the chain itself, per gallery instance, as
+//   .wp-block-gallery.wp-block-gallery-N {
+//     --wp--style--unstable-gallery-gap:
+//        var( --wp--style--gallery-gap-default,
+//        var( --gallery-block--gutter-size,
+//        var( --wp--style--block-gap, 0.5em ) ) );
+//     gap: var( --wp--style--unstable-gallery-gap );
+//   }
+// so overriding the RESULT would mean out-specifying a two-class rule and would
+// also clobber a gap the user set on an individual gallery. Instead, fill in the
+// first link of Core's own chain — `--wp--style--gallery-gap-default` is exactly
+// the extension point for "what a gallery's gap should be by default", and
+// WordPress leaves it undefined here. Core's rule then resolves cleanly, the
+// calc() becomes valid, and the tiles get their widths back.
+//
+// Declared on the block rather than `:root` because the editor stylesheet is
+// injected with every selector prefixed by `.editor-styles-wrapper`, which would
+// turn a `:root` rule into one that matches nothing in the canvas.
+//
+// A gap set on one gallery in the editor serialises as a literal value in that
+// same Core rule, so it still wins.
+.wp-block-gallery {
+	--wp--style--gallery-gap-default: 0.5em;
+}
+
+// Columns sit flush against each other without this.
+:where(.wp-block-columns) {
+	gap: 2em;
+}
+
+// Buttons and social icons run together into one blob.
+:where(.wp-block-buttons),
+:where(.wp-block-social-links) {
+	gap: 0.5em;
+}
+
+// Query Loop results. Two problems at once: no grid gap, and — because the
+// block renders as a `<ul>` — the `ul, ol { margin: 0 0 ms(2) ms(4) }` content-
+// list rule in `base/_base.scss` pushes the whole result grid ~42px to the
+// right of the column it belongs to. Same defect the comment thread had.
+.wp-block-post-template {
+	margin-left: 0;
+	margin-right: 0;
+}
+
+:where(.wp-block-post-template) {
+	gap: 1.5em;
+}
+
+// Remaining flex/grid layout containers in the main content column — most
+// often a Group the author set to a row. Flow layouts are deliberately left
+// alone: there the block's own element margins still provide vertical rhythm,
+// so adding a gap would double it. Flex and grid have no such fallback, so
+// without this every horizontal Group renders as touching items.
+//
+// Scoped to `.content-area` rather than `.entry-content` so it reaches BOTH
+// frontend paths: the classic post body and a block template's own groups (a
+// dynamic template's meta row is a sibling of `.entry-content`, not inside it).
+// The header and footer builders keep their own class names and are untouched.
+//
+// The editor canvas has no `.content-area` — WordPress injects theme editor
+// styles with EVERY selector rewritten to sit under `.editor-styles-wrapper`,
+// so a `.content-area`-scoped rule would match nothing there and the canvas
+// would show touching items while the frontend showed spaced ones. In editor
+// context the rule is therefore written unscoped and WordPress's own prefixing
+// supplies the boundary.
+@if $editor_context {
+	:where(.is-layout-flex, .is-layout-grid) {
+		gap: 1em;
+	}
+} @else {
+	:where(.content-area .is-layout-flex, .content-area .is-layout-grid) {
+		gap: 1em;
+	}
+}
+
+// Accordion (WordPress 7.0). Core ships the toggle button's typography, the
+// +/× icon and the open/close transition, but nothing that separates one item
+// from the next — a two-question FAQ renders as two bare lines of text with no
+// indication that they are separate, clickable rows. A hairline per item, in
+// the same Border token the rest of the theme's dividers use, is enough.
+.wp-block-accordion-item {
+	border-bottom: 1px solid var(--customify-border, rgba(0, 0, 0, 0.09));
+
+	&:first-child {
+		border-top: 1px solid var(--customify-border, rgba(0, 0, 0, 0.09));
+	}
+}
+
+// `wp_link_pages()` — the front-end counterpart of `core/nextpage`. Rendered by
+// the theme's own singular templates, never in the editor. Without this it is a
+// bare run of text ("Pages: 1 2") in body copy size, with the current page
+// indistinguishable from the links.
+.post-nav-links {
+	margin-top: 2em;
+	font-size: 0.875em;
+
+	.post-page-numbers {
+		display: inline-block;
+		padding: 0 0.5em;
+		text-decoration: none;
+
+		&:hover,
+		&:focus-visible {
+			text-decoration: underline;
+		}
+	}
+
+	.current {
+		font-weight: 600;
+		color: var(--customify-heading, #2b2b2b);
+	}
 }

--- a/src/frontend/scss/base/_comment-blocks.scss
+++ b/src/frontend/scss/base/_comment-blocks.scss
@@ -1,0 +1,456 @@
+/*--------------------------------------------------------------
+## Comments — Core Comments blocks
+--------------------------------------------------------------*/
+//
+// `base/_comments.scss` styles the CLASSIC comment markup that
+// `comments.php` + the `customify_comment()` walker emit. That markup
+// (`.comment-list`, `article.comment`, `.comment-wrap`) never appears when a
+// page renders comments through blocks — a block template, a Full Site
+// Editing template, or a page-builder template that drops `core/comments`
+// into the layout. Those paths emit an entirely different DOM
+// (`.wp-block-comment-template`, `.wp-block-comment-author-name`, …), which
+// until now the theme did not style at all.
+//
+// What Core actually ships for these blocks is close to nothing: `box-sizing`,
+// a `list-style: none` reset, and `padding-left: 2rem` on the nested reply
+// list. Everything else — hierarchy, rhythm, meta contrast, the reply
+// affordance, the form — is the theme's job.
+//
+// Two constraints shape every rule below:
+//
+//   1. `theme.json` does NOT opt into `settings.spacing.blockGap`, so WordPress
+//      emits no `gap` for flex layouts and no `margin-block-start` for flow
+//      layouts anywhere on the site. A Core Comments composition therefore
+//      collapses to zero spacing: the author name touches the date, the
+//      avatar touches the text. The theme has to supply that rhythm. Enabling
+//      blockGap globally instead would re-flow every existing layout on every
+//      site running this theme, which is not a trade this file makes.
+//
+//   2. The user's Global Styles and per-block attributes must keep winning.
+//      Anything a block support can set (gap, spacing, color, typography) is
+//      declared through `:where()` (specificity 0) or reads the corresponding
+//      `--wp--style--*` variable first, so a saved value always takes over.
+//      Colors resolve through the `--customify-*` palette tokens, never a
+//      literal hex, so the Customizer palette drives them like the rest of
+//      the theme.
+//
+// This partial is imported by BOTH `frontend/scss/style.scss` and
+// `backend/admin/scss/editor.scss` — the blocks render with the same class
+// names in the editor canvas, so a single source keeps editor/frontend parity.
+
+.wp-block-comments,
+.wp-block-post-comments-form {
+	// Gutter between an avatar and the comment body, and between the items of
+	// any flex row inside a comment (author / date / edit link).
+	--customify-comment-gap: 1rem;
+	// Vertical rhythm inside one comment: meta row → content → reply link.
+	--customify-comment-rhythm: 0.5rem;
+	// Space between sibling threads at the top level.
+	--customify-comment-thread-gap: 2.25rem;
+	// Space between sibling replies inside one thread.
+	--customify-comment-reply-gap: 1.5rem;
+	// Indent of each nesting level, and the hairline that traces it.
+	--customify-comment-indent: 2.5rem;
+	--customify-comment-guide: #{$color_border};
+	// Rendered size of the Avatar block. The thread line is drawn down the
+	// avatar's centre line, so this is what positions it — KEEP IN LOCKSTEP
+	// with the `size` attribute used by `core/avatar` in the template (48).
+	// A composition with no avatar still reads fine: the line simply runs down
+	// a 24px-wide gutter to the left of the reply.
+	//
+	// `--customify-comment-indent` must stay comfortably LARGER than half this
+	// value, or the line lands on top of the reply's own avatar instead of
+	// beside it.
+	--customify-comment-avatar-size: 48px;
+}
+
+/* Heading -------------------------------------------------------------- */
+
+.wp-block-comments-title {
+	margin-bottom: var(--customify-comment-thread-gap);
+}
+
+/* The thread ----------------------------------------------------------- */
+
+.wp-block-comment-template {
+	// `base/_base.scss` styles content lists with `ul, ol { margin: 0 0 ms(2)
+	// ms(4) }` and adds another `ms(4)` for `li > ol`. Those are the right
+	// rules for prose, but the comment thread IS a list of lists, so they
+	// stack ~42px of margin onto every nesting level on top of the indent set
+	// below — by depth 3 on a 390px screen the reply column collapses to about
+	// 136px, roughly twenty characters per line. The classic markup never hit
+	// this because `base/_comments.scss` zeroes `.comment-list` and
+	// `.comment-list ul`; this is the block-markup equivalent.
+	margin: 0;
+
+	// Only the rhythm between top-level threads is missing from Core.
+	> li + li {
+		margin-top: var(--customify-comment-thread-gap);
+		padding-top: var(--customify-comment-thread-gap);
+		// A single hairline between top-level threads is enough to separate
+		// them. Deliberately NOT a card: no background, border box or shadow
+		// per comment, which would turn a long discussion into a stack of
+		// heavy panels and fight the reading column.
+		border-top: 1px solid var(--customify-comment-guide);
+	}
+
+	// Replies. Core nests them in a bare `<ol>` that is a direct child of the
+	// comment's own `<li>`. `li.comment >` (rather than plain `li >`) keeps
+	// this off a list a COMMENTER wrote inside their comment: `comment_class()`
+	// puts `comment` on every comment item, and nothing inside
+	// `.wp-block-comment-content` carries it. Pingback/trackback items get
+	// `pingback`/`trackback` instead and are not threaded, so they are
+	// unaffected either way.
+	li.comment > ol {
+		margin-top: var(--customify-comment-reply-gap);
+		// `base/_base.scss` `li > ul, li > ol { margin-left: ms(4) }` adds ~42px
+		// here on top of the indent below, at EVERY level. Zeroed so the indent
+		// is exactly what this file declares and nothing else.
+		margin-left: 0;
+		margin-bottom: 0;
+		padding-left: var(--customify-comment-indent);
+
+		> li + li {
+			margin-top: var(--customify-comment-reply-gap);
+		}
+
+		// Thread line. Drawn down the CENTRE of the parent's avatar, so it reads
+		// as descending from that person rather than as a rule floating in the
+		// margin — a `border-left` on this list would sit on the parent
+		// avatar's left EDGE, alongside it, touching nothing.
+		//
+		// Deliberately no horizontal elbow into each reply: the indent leaves
+		// only ~16px between the line and the reply's own avatar, so a
+		// connector drawn across it collides with the avatar instead of
+		// pointing at it. The reply's avatar sitting just to the right of the
+		// line is enough to read as attached, which is how threaded comment
+		// UIs generally handle it.
+		//
+		// The line is indentation's PARTNER, not its replacement: it is what
+		// lets the indent stay modest on narrow viewports (see the max-sm
+		// block) without the thread losing its structure.
+		> li {
+			position: relative;
+
+			// Every reply paints from one reply-gap ABOVE itself down to its
+			// own bottom, so the segments chain into one unbroken line with no
+			// special case for `:first-child`.
+			&::after {
+				content: "";
+				position: absolute;
+				top: calc(var(--customify-comment-reply-gap) * -1);
+				bottom: 0;
+				left: calc(
+					var(--customify-comment-avatar-size) / 2 -
+						var(--customify-comment-indent)
+				);
+				width: 1px;
+				background: var(--customify-comment-guide);
+			}
+
+			// The last reply ends the branch: the line stops level with the
+			// centre of that reply's avatar instead of trailing off past it.
+			&:last-child::after {
+				bottom: auto;
+				height: calc(
+					var(--customify-comment-reply-gap) +
+						var(--customify-comment-avatar-size) / 2
+				);
+			}
+		}
+	}
+
+	// Bridge the parent's own comment body, so the line is continuous from the
+	// bottom of the parent's avatar all the way down to the last reply rather
+	// than restarting below the parent's text.
+	//
+	// The reply list's top margin is what separates it from the comment body,
+	// so a segment spanning the body element covers exactly the missing run.
+	// `:first-child` is "whatever the comment renders before its reply list",
+	// which holds for any composition. Browsers without `:has()` just skip this
+	// segment — the thread still reads, it simply starts at the reply list.
+	li.comment:has(> ol) > :first-child {
+		position: relative;
+
+		&::after {
+			content: "";
+			position: absolute;
+			top: calc(var(--customify-comment-avatar-size) + 0.375rem);
+			bottom: 0;
+			left: calc(var(--customify-comment-avatar-size) / 2);
+			width: 1px;
+			background: var(--customify-comment-guide);
+		}
+	}
+}
+
+// Flex rows inside the comments area (the avatar row, the author/date meta
+// row, the pagination row). With blockGap off these render at `gap: normal`,
+// i.e. the author name touches the date and the text touches the avatar.
+//
+// Note this canNOT be written as `var(--wp--style--block-gap, <fallback>)`:
+// when a theme.json sets `styles.spacing.blockGap: false`, WordPress still
+// emits the custom property — with an EMPTY value. An empty-but-declared
+// custom property makes the whole declaration invalid at computed-value time
+// rather than falling back, so the fallback would never be reached and the
+// gap would silently stay 0.
+//
+// The whole selector sits inside `:where()` (specificity 0) instead, so on a
+// site that does enable blockGap — globally or on one of these blocks —
+// Core's own `.wp-container-*{gap:…}` rule outranks this default regardless
+// of stylesheet order, and the user's value wins.
+:where(.wp-block-comments .is-layout-flex) {
+	column-gap: var(--customify-comment-gap);
+	row-gap: 0.25rem;
+}
+
+/* Avatar --------------------------------------------------------------- */
+
+.wp-block-comments .wp-block-avatar {
+	// Never let the avatar shrink out of shape when the body column is long;
+	// Core's `.is-layout-flex > :is(*, div){margin:0}` is more specific than a
+	// bare class, hence the two-class selector.
+	flex: 0 0 auto;
+	line-height: 0;
+
+	img {
+		// A user-set radius on the Avatar block serializes inline and wins.
+		border-radius: 50%;
+		display: block;
+		height: auto;
+		max-width: 100%;
+	}
+}
+
+/* Meta: author, date, edit link ---------------------------------------- */
+
+.wp-block-comment-author-name {
+	font-weight: 600;
+	line-height: 1.3;
+	color: $color_heading;
+
+	a {
+		color: inherit;
+		text-decoration: none;
+
+		&:hover,
+		&:focus-visible {
+			text-decoration: underline;
+		}
+	}
+}
+
+.wp-block-comment-date,
+.wp-block-comment-edit-link {
+	// The date renders as a permalink, so without this it picks up the site
+	// link color and competes with the author name for the eye. Muted meta
+	// keeps the name first in the hierarchy while the timestamp stays
+	// available; `--customify-text-muted` is the same token the classic
+	// comment meta uses, so both markups read alike.
+	font-size: 0.8125em;
+	line-height: 1.4;
+	color: $color_meta;
+
+	a {
+		color: inherit;
+		text-decoration: none;
+
+		&:hover,
+		&:focus-visible {
+			color: $color_link_hover;
+			text-decoration: underline;
+		}
+	}
+}
+
+/* Content -------------------------------------------------------------- */
+
+.wp-block-comment-content {
+	margin-top: var(--customify-comment-rhythm);
+	// A pasted URL or a long unbroken token is the usual cause of horizontal
+	// overflow in a narrow nested reply.
+	overflow-wrap: break-word;
+
+	> :first-child {
+		margin-top: 0;
+	}
+
+	> :last-child {
+		margin-bottom: 0;
+	}
+
+	// Core's `.wp-block-comment-template ol{list-style:none;padding-left:2rem}`
+	// is written for the reply list but also matches a list a commenter wrote
+	// inside their comment, stripping its markers. Restore them.
+	ul,
+	ol {
+		margin: 1em 0;
+		padding-left: 1.5em;
+	}
+
+	ul {
+		list-style: disc;
+	}
+
+	ol {
+		list-style: decimal;
+	}
+
+	li + li {
+		margin-top: 0.35em;
+	}
+
+	// Embedded media should never push the reading column wider than the
+	// thread that contains it.
+	img,
+	video,
+	iframe,
+	embed,
+	object {
+		max-width: 100%;
+		height: auto;
+	}
+
+	blockquote {
+		margin: 1em 0;
+		padding-left: 1em;
+		border-left: 2px solid var(--customify-comment-guide);
+	}
+}
+
+.comment-awaiting-moderation {
+	color: $color_meta;
+	font-style: italic;
+}
+
+/* Reply link ----------------------------------------------------------- */
+
+.wp-block-comment-reply-link {
+	margin-top: var(--customify-comment-rhythm);
+	font-size: 0.8125em;
+
+	a {
+		display: inline-block;
+		font-weight: 600;
+		letter-spacing: 0.02em;
+		text-decoration: none;
+		color: $color_link;
+		// An underline that only appears on hover/focus keeps the resting
+		// thread quiet while still marking Reply as the one action in a
+		// comment. `currentColor` means the mark follows the link token.
+		border-bottom: 1px solid transparent;
+		transition: color 0.15s ease, border-color 0.15s ease;
+
+		&:hover {
+			color: $color_link_hover;
+			border-bottom-color: currentColor;
+		}
+
+		&:focus-visible {
+			color: $color_link_hover;
+			outline: 2px solid currentColor;
+			outline-offset: 3px;
+			border-radius: 1px;
+		}
+	}
+}
+
+/* Pagination ----------------------------------------------------------- */
+
+.wp-block-comments-pagination {
+	margin-top: var(--customify-comment-thread-gap);
+	font-size: 0.9375em;
+
+	.page-numbers {
+		text-decoration: none;
+
+		&:hover,
+		&:focus-visible {
+			text-decoration: underline;
+		}
+	}
+
+	.current {
+		font-weight: 600;
+		color: $color_heading;
+	}
+}
+
+/* Comment form --------------------------------------------------------- */
+
+.wp-block-post-comments-form {
+	margin-top: var(--customify-comment-thread-gap);
+
+	.comment-reply-title {
+		margin-bottom: 0.5rem;
+	}
+
+	.comment-notes,
+	.logged-in-as {
+		font-size: 0.875em;
+		color: $color_meta;
+	}
+
+	// Mirrors the label treatment `base/_comments.scss` gives the classic
+	// form, so a site that switches a template from classic to blocks does not
+	// see its comment form change character.
+	.comment-form-comment,
+	.comment-form-author,
+	.comment-form-email,
+	.comment-form-url {
+		label {
+			text-transform: uppercase;
+			letter-spacing: 0.5px;
+			font-size: 0.85em;
+		}
+	}
+
+	.required {
+		color: $color_secondary;
+	}
+
+	// Core sets `display:flex; gap:.25em` here. The checkbox needs to align to
+	// the first line of a label that wraps onto two or three lines at 390px
+	// rather than to the middle of the wrapped block, and it must not shrink
+	// away when the label is long.
+	.comment-form-cookies-consent {
+		align-items: flex-start;
+		gap: 0.5em;
+
+		input[type="checkbox"] {
+			flex: 0 0 auto;
+			margin-top: 0.25em;
+		}
+
+		label {
+			font-size: 0.875em;
+			line-height: 1.5;
+		}
+	}
+
+	.form-submit {
+		margin-bottom: 0;
+	}
+}
+
+/* Narrow viewports ----------------------------------------------------- */
+
+@include mq(max-sm) {
+	.wp-block-comments {
+		// Core's flat 2rem per level costs 6rem by depth 3, which on a 390px
+		// screen leaves a reply column too narrow to read. The thread line
+		// carries the hierarchy instead, so the indent can come down — but only
+		// to the point where the line still clears the reply's avatar
+		// (avatar/2 = 24px + breathing room), not below it.
+		--customify-comment-indent: 2.25rem;
+		--customify-comment-gap: 0.875rem;
+		--customify-comment-thread-gap: 1.75rem;
+		--customify-comment-reply-gap: 1.25rem;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.wp-block-comment-reply-link a {
+		transition: none;
+	}
+}

--- a/src/frontend/scss/base/_comments.scss
+++ b/src/frontend/scss/base/_comments.scss
@@ -26,6 +26,25 @@
 		list-style: none;
 		margin: 0;
 	}
+	// The reset above is aimed at the nested REPLY lists, but it also matches a
+	// list a commenter wrote inside their own comment, leaving it with no
+	// markers and no indent — three bullet points read as one run-on
+	// paragraph. Restore normal list rendering inside the comment body only.
+	// (`base/_comment-blocks.scss` fixes the same defect on the block markup,
+	// where it comes from Core's own `.wp-block-comment-template ol` rule.)
+	.comment-content {
+		ul,
+		ol {
+			margin: 1em 0;
+			padding-left: 1.5em;
+		}
+		ul {
+			list-style: disc;
+		}
+		ol {
+			list-style: decimal;
+		}
+	}
 	.children li.comment {
 		padding-left: 30px;
 		@include mq(min-md) {
@@ -110,6 +129,20 @@ article.comment {
 	}
 	.comment-form-url {
 		margin-right: 0px;
+	}
+	// The three fields above are the form's only floats, and nothing after them
+	// clears. Everything that follows — the cookie-consent row and the submit
+	// button — therefore wraps into the sliver of space left beside the last
+	// float instead of starting a new row: the consent checkbox and its label
+	// end up stacked one word per line in a ~40px column.
+	//
+	// This affects the classic `comments.php` markup and the `core/comments`
+	// block form equally, because WordPress gives both `id="respond"`. `clear`
+	// is inert when the floats are off (below the min-md breakpoint), so the
+	// rule is safe to declare unconditionally.
+	.comment-form-cookies-consent,
+	.form-submit {
+		clear: both;
 	}
 	.comment-form-cookies-consent {
 		#wp-comment-cookies-consent {

--- a/src/frontend/scss/style.scss
+++ b/src/frontend/scss/style.scss
@@ -6,6 +6,7 @@
 // == Site base ==
 @import "base/base";
 @import "base/comments";
+@import "base/comment-blocks";
 @import "base/skins";
 @import "base/blocks";
 // == Site header ==


### PR DESCRIPTION
## What

Customify styled the classic `comments.php` walker markup but contributed **nothing** to the Core Comments blocks. Auditing that turned up a root cause with a much wider blast radius, so this PR covers both.

## Root cause

`theme.json` does not opt into `settings.spacing.blockGap`, and WordPress **still emits the custom property — with an empty value**:

```css
:root { --wp--style--block-gap: ; }
```

An empty-but-declared custom property makes a declaration invalid at computed-value time instead of falling back, so every `var( --wp--style--block-gap, <default> )` Core writes as a safety net silently resolves to nothing.

| Block | Before |
|---|---|
| **Gallery** | `calc( 33.33% - var(…) * .667 )` invalid → `width: auto` + Core's `flex-grow: 1` → **every image takes a full row**. A 3-image gallery rendered as 3 stacked full-width images. |
| Columns / Buttons / Social Links | items touching |
| Query Loop results | no grid gap, **plus** shifted ~42px right by the base `ul, ol` margin |
| Any flex/grid Group | items touching |

The gap values restated here are **Core's own defaults** (`2em` = `core/columns`' `spacing.blockGap.__experimentalDefault`; `0.5em` = the fallback Core writes into its own `calc()`), not a Customify opinion.

## 30k-site safety

Everything a block support can set is declared inside `:where()` (specificity 0), so:

- a site that **does** enable blockGap keeps Core's `.wp-container-*{gap:…}` rule;
- a per-block gap set in the editor still wins;
- **any custom CSS an existing install already wrote to work around the breakage keeps winning too** — which is what makes this safe on installs that have been living with it.

For Gallery, overriding the result would have meant out-specifying a two-class rule *and* clobbering per-gallery user values, so instead this fills in the first link of Core's own chain (`--wp--style--gallery-gap-default`), which WordPress leaves undefined.

## Comments

New `base/_comment-blocks.scss`, imported by **both** the frontend and the editor stylesheet so the two stay in step.

- Thread hierarchy is a guide line down the **centre of the parent's avatar**, continuous from the avatar to the last reply and stopping there — deliberately not a card per comment.
- Nested indent is token-driven so it can drop on narrow viewports without losing structure: a depth-3 reply at 390px goes from **136px → 262px** of text column.
- Muted date / edit link so the author name leads; reply link with hover + `:focus-visible`; `prefers-reduced-motion` respected.
- Content handles long paragraphs, links, lists and media — including restoring the list markers Core's `.wp-block-comment-template ol` rule strips from a list written *inside* a comment.

## Also fixed

- **`#respond` floats never cleared** → the cookie-consent row and submit button wrapped into the sliver beside the last float. Hits the classic and the block comment form equally.
- `.comment-list ul { list-style: none }` stripped markers from a commenter's own list.
- Base list margins leaked into `.wp-block-comment-template` and `.wp-block-post-template` (~42px per level).
- **Tables**: every cell was tinted on top of Core's full grid, reading as one grey slab — and the blanket `tbody td` background silently outranked Core's own cell-colour classes, so colours the user picked in the editor never showed. Now horizontal rules only, zebra left to `is-style-stripes`, user cell colours work again.
- "Post author" badge compared `user_id === post_author` as strings → a post with author 0 badged **every** guest comment.
- Accordion (WP 7.0) had nothing separating one item from the next.
- `wp_link_pages()` output was unstyled body copy.
- Corrected two comments in `base/_blocks.scss` that documented the blockGap fallback as "variable absent → fallback applies", which is not what happens.

## Editor / frontend parity

Rules scoped to `.content-area` / `.entry-content` are emitted **unscoped** in editor context: WordPress rewrites every selector in an injected theme editor stylesheet to sit under `.editor-styles-wrapper`, so a frontend-scoped selector matches nothing in the canvas. Without the split, flex gaps and content-list rhythm differed between writing and publishing.

Verified by diffing the compiled stylesheets — identical `.wp-block-*` coverage, **42 selectors each way**, no rule in either sheet referencing an ancestor that only exists in the other.

## Testing

Reproduction harness on the Customify theme dev site: a Single Post dynamic template plus two kitchen-sink posts covering **95 of 110 registered core blocks**, and a deterministic 10-comment fixture (4 top level, depth 2 and 3 branches). Block markup was validated through the site's real block editor — no invalid blocks, no "Attempt recovery".

- Desktop + 390px, no horizontal overflow (depth-3 right edge 374px = 390 − gutter).
- Classic single post (no dynamic template) confirms the fixes are theme-level, not template-specific.
- RTL build flips correctly; `php -l` clean; no JS touched.

The 15 unseeded core blocks are archive-only (`query-title`, `term-*`), block-theme-only (`template-part`), widget-area (`legacy-widget`, `widget-group`), editor-internal placeholders, or have no styling surface (`core/html`). `core/icon` renders empty for every attribute value tried — not covered, flagged separately.

## Limitations

- Editor parity was verified by compiled-CSS comparison rather than screenshots: the local sandbox's auto-login broke mid-session.
- `core/comment-template` never resolves inside the Blocksify template editor (perpetual spinner) and `core/comments-pagination` invents pages there. Product-level, reported separately, deliberately **not** worked around in the theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
