### PR TITLE
feat(search): hand the whole search region to dynamic templates; retire the teaser

### DIFF
--- a/inc/customizer/configs/search.php
+++ b/inc/customizer/configs/search.php
@@ -38,20 +38,6 @@ if ( ! function_exists( 'customify_customizer_search_config' ) ) {
 			),
 
 			array(
-				'name'            => $args['id'] . '_product_display',
-				'type'            => 'select',
-				'section'         => $level_2_panel,
-				'default'         => 'cards',
-				'choices'         => array(
-					'cards'  => __( 'Show product cards', 'customify' ),
-					'teaser' => __( 'Only link to product results', 'customify' ),
-				),
-				'selector'        => $args['selector'],
-				'render_callback' => $args['cb'],
-				'label'           => __( 'Products in mixed results', 'customify' ),
-			),
-
-			array(
 				'name'            => $args['id'] . '_default_scope',
 				'type'            => 'select',
 				'section'         => $level_2_panel,

--- a/inc/search/functions-search.php
+++ b/inc/search/functions-search.php
@@ -23,15 +23,21 @@
  *
  * Region takeover
  * ---------------
- * search.php additionally brackets its whole chrome with
+ * A search view additionally brackets its whole chrome with
  * `customify/search/region_start` / `customify/search/region_end`, and
  * customify_search_template_region_swap() offers that pair to Blocksify as a
  * WIDE swap seam. When a Dynamic Template wins a search view the theme's entire
  * search experience is replaced - heading, form, tabs, listing, pagination -
  * because the template IS the experience and theme chrome would only duplicate
- * it. Everything in this file therefore has to keep working under BOTH windows:
- * the wide region one on search.php, and the narrow loop one everywhere else
- * (the WooCommerce scoped search page, and any site without a template).
+ * it.
+ *
+ * The bracket is emitted on BOTH search paths, so the takeover is symmetrical:
+ * search.php prints the actions inline, and a product scoped search
+ * (`?s=…&post_type=product`, routed to woocommerce.php by WooCommerce's template
+ * loader) gets them from customify_search_wc_region_start() / _end() around the
+ * chrome customify_search_wc_heading() injects. Everything in this file
+ * therefore has to keep working under BOTH windows: the wide region one when a
+ * template wins, and the narrow loop one on any site without a template.
  *
  * @package customify
  */
@@ -1364,9 +1370,27 @@ if ( ! function_exists( 'customify_search_template_region_swap' ) ) {
 	 * `.content-inner`, not inside a loop grid wrapper, so the injected template
 	 * spans the content edge on its own and needs no neutralizer element.
 	 *
-	 * Never clobbers a seam somebody else already claimed - the WooCommerce
-	 * module widens a product scoped search to its own catalog bracket, and
-	 * first claimant wins.
+	 * Both search paths are claimed
+	 * ---------------------------------------------------------------------
+	 * A search renders through one of two templates, and the region actions are
+	 * emitted on BOTH, so one seam covers both:
+	 *
+	 *   - search.php            - brackets its chrome inline.
+	 *   - woocommerce.php       - a product scoped search
+	 *                             (`?s=…&post_type=product`) is routed there by
+	 *                             WooCommerce's template loader. The chrome is
+	 *                             injected by customify_search_wc_heading() on
+	 *                             `customify/content/before`, so
+	 *                             customify_search_wc_region_start() / _end()
+	 *                             emit the same pair around that injection AND
+	 *                             the WooCommerce content region.
+	 *
+	 * Never clobbers a seam somebody else already claimed - first claimant wins.
+	 * Blocksify's WooCommerce module widens product ARCHIVE views (shop, product
+	 * taxonomy) to its own `woocommerce_before/after_shop_loop` catalog bracket;
+	 * it declines on `is_search()` precisely because that bracket is too narrow
+	 * to reach the theme's search chrome. The two claims are therefore disjoint:
+	 * catalog views are its, search views are ours.
 	 *
 	 * Why the resolved template is checked by STRUCTURE, not by
 	 * customify_search_current_template()
@@ -1374,15 +1398,11 @@ if ( ! function_exists( 'customify_search_template_region_swap' ) ) {
 	 * Blocksify applies this filter from its resolver on `wp`, which runs long
 	 * before `template_include` - so the tracker is still empty when we are
 	 * asked, and reading it here would bail on every request. The guarantee is
-	 * enforced by the bracket hooks themselves instead: only search.php fires
-	 * `customify/search/region_start` / `customify/search/region_end`, so the
-	 * wide seam can only ever swap a region search.php actually printed.
-	 *
-	 * The one case that must NOT be claimed is therefore the one where handing
-	 * back these hooks would leave Blocksify with a seam that never fires: a
-	 * product scoped search renders through woocommerce.php, which brackets
-	 * nothing of ours. That view keeps the default loop_start/loop_end swap and
-	 * its injected heading exactly as before.
+	 * enforced by the bracket hooks themselves instead: only a search template
+	 * of ours emits `customify/search/region_start` / `region_end`, so the wide
+	 * seam can only ever swap a region the theme actually printed. If neither
+	 * path emits them the buffer never opens and the swap simply does not
+	 * happen - the request renders untouched rather than breaking.
 	 *
 	 * Publishing no template changes nothing: the filter only runs once a
 	 * template has already won this view, and the two actions stay inert
@@ -1405,14 +1425,6 @@ if ( ! function_exists( 'customify_search_template_region_swap' ) ) {
 			return $seam;
 		}
 
-		// Product scoped search: WooCommerce's template loader routes
-		// `is_post_type_archive( 'product' )` to its own template, which never
-		// fires the region actions. Same predicate customify_search_is_wc_scoped()
-		// uses, minus the template check that is not answerable this early.
-		if ( Customify()->is_woocommerce_active() && is_post_type_archive( 'product' ) ) {
-			return $seam;
-		}
-
 		return array(
 			// PHP_INT_MIN / PHP_INT_MAX so anything a child theme or plugin
 			// hangs on the region actions is captured by the same buffer - the
@@ -1424,6 +1436,63 @@ if ( ! function_exists( 'customify_search_template_region_swap' ) ) {
 	}
 }
 add_filter( 'blocksify_tb_classic_archive_swap', 'customify_search_template_region_swap' );
+
+if ( ! function_exists( 'customify_search_wc_region_start' ) ) {
+	/**
+	 * Open the search region bracket on the woocommerce.php path.
+	 *
+	 * search.php prints `customify/search/region_start` inline, but a product
+	 * scoped search never reaches it: WooCommerce's template loader routes
+	 * `is_post_type_archive( 'product' )` to woocommerce.php instead. Without an
+	 * emitter there, a page builder holding the region seam would be handed a
+	 * pair of hooks that never fire on half the search surface - so the theme's
+	 * injected chrome would survive and the winning template would render
+	 * stacked underneath it.
+	 *
+	 * woocommerce.php brackets its whole content region with
+	 * `customify/content/before` -> `customify/content/after`, and the chrome is
+	 * injected on the former at the default priority 10. Emitting at PHP_INT_MIN
+	 * therefore opens the region BEFORE the chrome exists, so a buffer opened
+	 * here captures the chrome, the WooCommerce catalog and anything else on
+	 * those two actions.
+	 *
+	 * Inert with nothing hooked, exactly like the search.php emitter: with no
+	 * template published, this fires an action nobody listens to and the page
+	 * renders byte for byte as before.
+	 *
+	 * @since 0.5.0
+	 */
+	function customify_search_wc_region_start() {
+		if ( ! customify_search_is_wc_scoped() ) {
+			return;
+		}
+
+		/** This action is documented in search.php */
+		do_action( 'customify/search/region_start' );
+	}
+}
+add_action( 'customify/content/before', 'customify_search_wc_region_start', PHP_INT_MIN );
+
+if ( ! function_exists( 'customify_search_wc_region_end' ) ) {
+	/**
+	 * Close the search region bracket on the woocommerce.php path.
+	 *
+	 * Mirror of customify_search_wc_region_start(): PHP_INT_MAX on
+	 * `customify/content/after` so the region closes only once the WooCommerce
+	 * content region and every other content/after callback have printed.
+	 *
+	 * @since 0.5.0
+	 */
+	function customify_search_wc_region_end() {
+		if ( ! customify_search_is_wc_scoped() ) {
+			return;
+		}
+
+		/** This action is documented in search.php */
+		do_action( 'customify/search/region_end' );
+	}
+}
+add_action( 'customify/content/after', 'customify_search_wc_region_end', PHP_INT_MAX );
 
 if ( ! function_exists( 'customify_search_wc_heading' ) ) {
 	/**

--- a/inc/search/functions-search.php
+++ b/inc/search/functions-search.php
@@ -7,11 +7,6 @@
  * content card for posts / pages / CPTs and the native WooCommerce product
  * card for products - plus a content type tab bar and per type result counts.
  *
- * Sites whose product listings are driven by an external template system can
- * drop product cards from the mixed page entirely (Search Results > "Products
- * in mixed results" = teaser) and link into the product scoped surface
- * instead.
- *
  * Swap window safety
  * ------------------
  * The listing is emitted as ONE pass over the MAIN query. Block based page
@@ -23,9 +18,20 @@
  * from inside an iteration - a group closes at the top of the iteration that
  * starts the next group, and the last group closes inside the final
  * iteration. Never buffer the listing and print it after the loop, and never
- * run a secondary WP_Query inside the listing region. Tabs, heading and the
- * products teaser render before the loop, pagination after it - all outside
- * the swap window.
+ * run a secondary WP_Query inside the listing region. Tabs and heading render
+ * before the loop, pagination after it - all outside the swap window.
+ *
+ * Region takeover
+ * ---------------
+ * search.php additionally brackets its whole chrome with
+ * `customify/search/region_start` / `customify/search/region_end`, and
+ * customify_search_template_region_swap() offers that pair to Blocksify as a
+ * WIDE swap seam. When a Dynamic Template wins a search view the theme's entire
+ * search experience is replaced - heading, form, tabs, listing, pagination -
+ * because the template IS the experience and theme chrome would only duplicate
+ * it. Everything in this file therefore has to keep working under BOTH windows:
+ * the wide region one on search.php, and the narrow loop one everywhere else
+ * (the WooCommerce scoped search page, and any site without a template).
  *
  * @package customify
  */
@@ -238,8 +244,8 @@ if ( ! function_exists( 'customify_search_get_default_scope' ) ) {
 	 * Content type unscoped searches should land on.
 	 *
 	 * Shop first sites want `?s=term` to open the product results directly
-	 * instead of the mixed page with its products teaser - one click less
-	 * between the search box and a product listing.
+	 * instead of the mixed page - one click less between the search box and a
+	 * product listing.
 	 *
 	 * @return string Valid post type slug, empty string when unscoped searches
 	 *                stay on the mixed "Everything" page.
@@ -277,8 +283,8 @@ if ( ! function_exists( 'customify_search_maybe_redirect_to_scope' ) ) {
 	 * same way, and the visitor can see and undo the scope.
 	 *
 	 * Never redirects into an empty surface: when the term has no matches in
-	 * the configured type the mixed page, with its no results block and its
-	 * products teaser, is the better landing.
+	 * the configured type the mixed page, with its no results block, is the
+	 * better landing.
 	 *
 	 * `cfy_all` is the explicit bypass the All tab carries, so clicking "All"
 	 * from a scoped view does not bounce straight back.
@@ -587,13 +593,6 @@ if ( ! function_exists( 'customify_search_tabs' ) ) {
 
 		$all_count = isset( $counts['all'] ) ? (int) $counts['all'] : 0;
 
-		// In teaser mode the mixed page lists no product cards, so the All tab
-		// counts content only - the Products tab and the teaser banner carry
-		// the product number.
-		if ( customify_search_is_products_teaser() && ! empty( $counts['product'] ) ) {
-			$all_count = max( 0, $all_count - (int) $counts['product'] );
-		}
-
 		$all_args = array( 's' => urlencode( $term ) );
 
 		// With a default scope armed, a bare `?s=term` would be redirected back
@@ -606,9 +605,11 @@ if ( ! function_exists( 'customify_search_tabs' ) ) {
 
 		$tabs = array();
 
-		// A zero-count All tab (teaser mode, term matching only products) leads
-		// to an empty mixed page - drop it. With one tab left the whole bar is
-		// suppressed below, which is right: nothing to navigate between.
+		// An All tab counting nothing leads to an empty mixed page - drop it.
+		// The total is the sum of the per type counts, so this only happens when
+		// the term matched nothing at all and no type tab follows either: with
+		// fewer than two tabs the whole bar is suppressed below, which is right
+		// - there is nothing to navigate between.
 		if ( $all_count > 0 ) {
 			$tabs[] = array(
 				'key'    => 'all',
@@ -708,155 +709,6 @@ if ( ! function_exists( 'customify_search_tabs' ) ) {
 				?>
 			</ul>
 		</nav>
-		<?php
-	}
-}
-
-if ( ! function_exists( 'customify_search_get_product_display' ) ) {
-	/**
-	 * How products behave in the mixed (unscoped) search listing.
-	 *
-	 * @return string `cards` - render product cards inline, or `teaser` - drop
-	 *                them and link to the product scoped results instead.
-	 */
-	function customify_search_get_product_display() {
-		$mode = Customify()->get_setting( 'search_results_product_display' );
-		$mode = is_string( $mode ) ? sanitize_key( $mode ) : '';
-
-		return ( 'teaser' === $mode ) ? 'teaser' : 'cards';
-	}
-}
-
-if ( ! function_exists( 'customify_search_is_products_teaser' ) ) {
-	/**
-	 * Are products replaced by a teaser link on the mixed search page?
-	 *
-	 * Meaningless without WooCommerce, where the setting simply no-ops.
-	 *
-	 * @return bool
-	 */
-	function customify_search_is_products_teaser() {
-		return ( Customify()->is_woocommerce_active() && 'teaser' === customify_search_get_product_display() );
-	}
-}
-
-if ( ! function_exists( 'customify_search_exclude_products_from_main_query' ) ) {
-	/**
-	 * Drop products from the unscoped main search query in teaser mode.
-	 *
-	 * Sites whose product loops are built by an external template system get a
-	 * design system clash when theme styled product cards sit in the mixed
-	 * listing. Excluding products here keeps the mixed page purely editorial;
-	 * the teaser banner then routes shoppers to the product scoped surface,
-	 * which the owning system still renders.
-	 *
-	 * Scoped searches, feeds, admin and secondary queries are never touched.
-	 *
-	 * @param WP_Query $query Query object.
-	 */
-	function customify_search_exclude_products_from_main_query( $query ) {
-		if ( is_admin() || ! is_a( $query, 'WP_Query' ) ) {
-			return;
-		}
-
-		if ( ! $query->is_main_query() || ! $query->is_search() || $query->is_feed() ) {
-			return;
-		}
-
-		if ( customify_search_query_is_type_scoped( $query ) ) {
-			return;
-		}
-
-		if ( ! customify_search_is_products_teaser() ) {
-			return;
-		}
-
-		// Flag only - the SQL lands in posts_where below. Setting `post_type`
-		// here would make the query LOOK type scoped: template resolvers match
-		// scoped search conditions with `in_array( $type, (array) $qv )`
-		// (Blocksify `query_scoped_to_post_type()`), so a template scoped to
-		// e.g. `search:post` would hijack the unscoped mixed page the moment
-		// the query var carries an array containing `post`.
-		$query->set( 'customify_search_teaser_exclude_products', true );
-	}
-}
-add_action( 'pre_get_posts', 'customify_search_exclude_products_from_main_query' );
-
-if ( ! function_exists( 'customify_search_teaser_posts_where' ) ) {
-	/**
-	 * SQL side of the teaser mode product exclusion.
-	 *
-	 * Runs only for queries flagged by
-	 * customify_search_exclude_products_from_main_query() and filters products
-	 * out at the WHERE level, leaving every public query var untouched.
-	 *
-	 * @param string        $where WHERE clause.
-	 * @param WP_Query|null $query Query object.
-	 *
-	 * @return string
-	 */
-	function customify_search_teaser_posts_where( $where, $query = null ) {
-		if ( ! is_a( $query, 'WP_Query' ) || ! $query->get( 'customify_search_teaser_exclude_products' ) ) {
-			return $where;
-		}
-
-		global $wpdb;
-
-		$where .= $wpdb->prepare( " AND {$wpdb->posts}.post_type <> %s", 'product' );
-
-		return $where;
-	}
-}
-add_filter( 'posts_where', 'customify_search_teaser_posts_where', 10, 2 );
-
-if ( ! function_exists( 'customify_search_products_teaser' ) ) {
-	/**
-	 * Banner linking to the product scoped results, for teaser mode.
-	 *
-	 * Chrome, not listing: it renders before the loop opens, next to the tabs,
-	 * and never from inside the swap window.
-	 */
-	function customify_search_products_teaser() {
-		if ( ! is_search() || '' !== customify_search_get_current_scope() ) {
-			return;
-		}
-
-		if ( ! customify_search_is_products_teaser() ) {
-			return;
-		}
-
-		// The counts helper runs its own per type queries, so it still sees the
-		// products the main query just excluded.
-		$term   = get_search_query( false );
-		$counts = customify_search_get_type_counts( $term );
-		$count  = isset( $counts['product'] ) ? (int) $counts['product'] : 0;
-
-		if ( $count < 1 ) {
-			return;
-		}
-
-		$url = add_query_arg(
-			array(
-				's'         => urlencode( $term ),
-				'post_type' => 'product',
-			),
-			home_url( '/' )
-		);
-		?>
-		<div class="cfy-search-products-teaser">
-			<span class="cfy-search-products-teaser-label">
-				<?php
-				printf(
-					/* translators: %s: number of products matching the search term. */
-					esc_html( _n( '%s product matches your search', '%s products match your search', $count, 'customify' ) ),
-					esc_html( number_format_i18n( $count ) )
-				);
-				?>
-			</span>
-			<a class="cfy-search-products-teaser-link" href="<?php echo esc_url( $url ); ?>">
-				<?php esc_html_e( 'View products', 'customify' ); ?> &rarr;
-			</a>
-		</div>
 		<?php
 	}
 }
@@ -1238,11 +1090,6 @@ if ( ! function_exists( 'customify_search_results_layout' ) ) {
 	 * this file before restructuring anything in here.
 	 */
 	function customify_search_results_layout() {
-		// Chrome, before the early return on purpose: a teaser mode search that
-		// only matched products has an empty main query, and "nothing found"
-		// with no pointer to the matching products would be a dead end.
-		customify_search_products_teaser();
-
 		if ( ! have_posts() ) {
 			get_template_part( 'template-parts/content', 'none' );
 
@@ -1489,6 +1336,94 @@ if ( ! function_exists( 'customify_search_is_wc_scoped' ) ) {
 		return 'search.php' !== basename( customify_search_current_template() );
 	}
 }
+
+if ( ! function_exists( 'customify_search_template_region_swap' ) ) {
+	/**
+	 * Hand the WHOLE search region to a Blocksify Dynamic Template.
+	 *
+	 * Blocksify swaps a classic theme's listing by buffering the main query's
+	 * `loop_start` -> `loop_end` window and echoing the winning template
+	 * instead. On a search page that window is too narrow: the theme's heading,
+	 * results form and tab bar sit OUTSIDE it, so a template designed as a
+	 * complete search experience ends up stacked below a duplicate set of theme
+	 * chrome. A search template IS the whole experience - if the site owner
+	 * built one, the theme has nothing left to contribute.
+	 *
+	 * `blocksify_tb_classic_archive_swap` is Blocksify's seam for exactly this:
+	 * an integration returns a WIDER pair of bracket hooks and the resolver
+	 * buffers between them instead. Contract, mirrored from the WooCommerce
+	 * module (`Blocksify_CL_Woo_Hooks::archive_swap_seam()`):
+	 *
+	 *     array(
+	 *         'open'  => array( <hook>, <priority> ), // ob_start() here
+	 *         'close' => array( <hook>, <priority> ), // discard + echo template
+	 *         'frame' => bool,                        // grid-bleed neutralizer
+	 *     )
+	 *
+	 * `frame` is false here: the region actions fire directly inside
+	 * `.content-inner`, not inside a loop grid wrapper, so the injected template
+	 * spans the content edge on its own and needs no neutralizer element.
+	 *
+	 * Never clobbers a seam somebody else already claimed - the WooCommerce
+	 * module widens a product scoped search to its own catalog bracket, and
+	 * first claimant wins.
+	 *
+	 * Why the resolved template is checked by STRUCTURE, not by
+	 * customify_search_current_template()
+	 * ---------------------------------------------------------------------
+	 * Blocksify applies this filter from its resolver on `wp`, which runs long
+	 * before `template_include` - so the tracker is still empty when we are
+	 * asked, and reading it here would bail on every request. The guarantee is
+	 * enforced by the bracket hooks themselves instead: only search.php fires
+	 * `customify/search/region_start` / `customify/search/region_end`, so the
+	 * wide seam can only ever swap a region search.php actually printed.
+	 *
+	 * The one case that must NOT be claimed is therefore the one where handing
+	 * back these hooks would leave Blocksify with a seam that never fires: a
+	 * product scoped search renders through woocommerce.php, which brackets
+	 * nothing of ours. That view keeps the default loop_start/loop_end swap and
+	 * its injected heading exactly as before.
+	 *
+	 * Publishing no template changes nothing: the filter only runs once a
+	 * template has already won this view, and the two actions stay inert
+	 * markers otherwise.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param mixed $seam Seam claimed so far - null when nothing claimed it.
+	 *
+	 * @return mixed Seam array when the theme's search region should be swapped
+	 *               whole, otherwise the incoming value untouched.
+	 */
+	function customify_search_template_region_swap( $seam ) {
+		// Somebody else owns this view's seam already.
+		if ( ! empty( $seam ) ) {
+			return $seam;
+		}
+
+		if ( ! is_search() ) {
+			return $seam;
+		}
+
+		// Product scoped search: WooCommerce's template loader routes
+		// `is_post_type_archive( 'product' )` to its own template, which never
+		// fires the region actions. Same predicate customify_search_is_wc_scoped()
+		// uses, minus the template check that is not answerable this early.
+		if ( Customify()->is_woocommerce_active() && is_post_type_archive( 'product' ) ) {
+			return $seam;
+		}
+
+		return array(
+			// PHP_INT_MIN / PHP_INT_MAX so anything a child theme or plugin
+			// hangs on the region actions is captured by the same buffer - the
+			// takeover is the whole region or nothing.
+			'open'  => array( 'customify/search/region_start', PHP_INT_MIN ),
+			'close' => array( 'customify/search/region_end', PHP_INT_MAX ),
+			'frame' => false,
+		);
+	}
+}
+add_filter( 'blocksify_tb_classic_archive_swap', 'customify_search_template_region_swap' );
 
 if ( ! function_exists( 'customify_search_wc_heading' ) ) {
 	/**

--- a/search.php
+++ b/search.php
@@ -11,6 +11,24 @@ get_header(); ?>
 	<div class="content-inner">
 		<?php
 		do_action( 'customify/content/before' );
+
+		/**
+		 * Fires immediately before the theme's search chrome opens.
+		 *
+		 * Together with `customify/search/region_end` this brackets the WHOLE
+		 * search experience the theme renders: heading, results form, tab bar,
+		 * listing and pagination. The pair exists so a page builder that owns
+		 * this view can replace all of it in one go instead of stacking its own
+		 * design under the theme's chrome - see
+		 * customify_search_template_region_swap() in
+		 * inc/search/functions-search.php.
+		 *
+		 * Inert on its own: with nothing hooked, both actions render nothing.
+		 *
+		 * @since 0.5.0
+		 */
+		do_action( 'customify/search/region_start' );
+
 		customify_blog_posts_heading();
 		?>
 		<div class="cfy-search-results">
@@ -23,6 +41,16 @@ get_header(); ?>
 			?>
 		</div><!-- /.cfy-search-results -->
 		<?php
+		/**
+		 * Fires immediately after the theme's search chrome closes.
+		 *
+		 * Closing half of the region bracket opened by
+		 * `customify/search/region_start` - see that action for the contract.
+		 *
+		 * @since 0.5.0
+		 */
+		do_action( 'customify/search/region_end' );
+
 		do_action( 'customify/content/after' );
 		?>
 	</div><!-- #.content-inner -->

--- a/src/frontend/scss/layouts/_search-results.scss
+++ b/src/frontend/scss/layouts/_search-results.scss
@@ -122,40 +122,6 @@
     }
 }
 
-/* Products teaser
---------------------------------------------- */
-// Shown instead of inline product cards when the mixed listing is set to link
-// out to the product scoped results.
-.cfy-search-products-teaser {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.4em 1em;
-    margin: 0 0 1.75em;
-    padding: 0.75em 1em;
-    border: 1px solid $color_border;
-    border-radius: 4px;
-
-    .cfy-search-products-teaser-label {
-        color: $color_meta;
-        font-size: 0.9375em;
-    }
-
-    .cfy-search-products-teaser-link {
-        color: $color_primary;
-        font-size: 0.9375em;
-        font-weight: 600;
-        text-decoration: none;
-        white-space: nowrap;
-
-        &:hover,
-        &:focus {
-            text-decoration: underline;
-        }
-    }
-}
-
 /* Type group sections
 --------------------------------------------- */
 .cfy-search-section-title {
@@ -176,7 +142,7 @@
 }
 
 // Only a section that FOLLOWS another group needs separating space; the first
-// one sits flush under the tabs / teaser, which carry their own bottom margin.
+// one sits flush under the tabs, which carry their own bottom margin.
 // Grid items already add 2.5em below the previous group.
 .cfy-search-results-grid + .cfy-search-section-title {
     margin-top: 1.5em;


### PR DESCRIPTION
Follow-up to #472 (search framework). Two maintainer decisions, one PR.

## A. Full-region takeover via Blocksify's existing seam

**Problem.** Blocksify's classic-theme resolver swaps only the main query's `loop_start` → `loop_end` window. On a search page that window covers the listing and nothing else, so a Dynamic Template built as a *complete* search experience rendered **underneath** the theme's heading, results form and tab bar — two search UIs stacked on one page.

**Decision.** When a template owns a search view, the theme's entire search chrome disappears. The template *is* the experience; anything the theme adds is a duplicate.

**How.** `search.php` now brackets its whole region with two new public actions:

| Action | Fires |
|---|---|
| `customify/search/region_start` | immediately before `customify_blog_posts_heading()` |
| `customify/search/region_end` | immediately after the closing `</div><!-- .cfy-search-results -->` |

Heading, results form, tab bar, listing and pagination all live inside the pair. Both are additive and documented inline; with nothing hooked they render nothing.

`customify_search_template_region_swap()` then hands that pair to Blocksify's existing `blocksify_tb_classic_archive_swap` filter, mirroring the contract the WooCommerce module already uses (`Blocksify_CL_Woo_Hooks::archive_swap_seam()`):

```php
array(
    'open'  => array( <hook>, <priority> ), // resolver ob_start()s here
    'close' => array( <hook>, <priority> ), // discards the buffer, echoes the template
    'frame' => bool,                        // grid-bleed neutralizer wrapper
)
```

- `frame` is **false**: the region actions fire directly inside `.content-inner`, not inside a loop grid/flex wrapper, so the injected template spans the content edge on its own (`swap_no_frame` → plain echo, no neutralizer `<style>`/`<script>`).
- `PHP_INT_MIN` / `PHP_INT_MAX` so anything a child theme or plugin hangs on the region actions is captured by the same buffer — the takeover is the whole region or nothing.

**When the seam is declined** (returns the incoming value untouched):

1. Something already claimed it — first claimant wins.
2. Not a search view.

**One deviation from the brief, worth a look on review.** The brief asked to gate on `customify_search_current_template()`. That tracker cannot be read here: Blocksify applies the seam filter from its resolver on `wp` (`add_action( 'wp', array( __CLASS__, 'resolve' ) )`), which runs long before `template_include`, so the tracker is still empty and reading it would bail on every request. The same guarantee is enforced **structurally** instead — only a search template of ours emits the region actions, so the wide seam can only ever swap a region the theme actually printed, and if neither path emits them the buffer never opens and the request renders untouched. All of this is written up in the function's docblock.

No template published → nothing changes: the filter only runs once a template has already won the view, and the two actions stay inert markers.

## A2. Symmetry round — the `woocommerce.php` path

*(Added after review of the first round; requires PressMaximum/blocksify#419.)*

The first round shipped the takeover for the `search.php` path only and **explicitly bailed** on a product scoped search. That left the original bug alive on exactly one view: `?s=term&post_type=product`.

**Root cause, confirmed on both sides.** WooCommerce routes that URL to `woocommerce.php` because `is_post_type_archive( 'product' )` is true on a type-scoped search — the same fact behind blocksify#416. That also makes WC's `is_shop()` true, so Blocksify's `Blocksify_CL_Woo_Hooks::archive_swap_seam()` claimed `blocksify_tb_classic_archive_swap` for the view and handed the resolver WC's catalog bracket (`woocommerce_before_shop_loop` → `woocommerce_after_shop_loop`). The plugin registers that filter at boot, so it claimed first; this theme's callback then saw a non-null seam and stood down (and would have bailed anyway). Net result: the winning `search:product` template replaced only the catalog and rendered **under** the chrome `customify_search_wc_heading()` injects.

**Fix, both sides.**

- **Blocksify** (PressMaximum/blocksify#419): `archive_swap_seam()` now declines on any `is_search()` view. The catalog bracket cannot reach a theme's search chrome, so search views belong to whoever can bracket the whole surface — same boundary #416 drew for archive *conditions*. Product catalog views (`/shop/`, product taxonomies) are untouched.
- **Theme** (this PR): `woocommerce.php` already brackets its whole content region with `customify/content/before` → `customify/content/after`, and the chrome is injected on the former at priority 10. So the **same public action pair** is emitted there too:

| Emitter | Hook | Priority |
|---|---|---|
| `customify_search_wc_region_start()` | `customify/content/before` | `PHP_INT_MIN` (ahead of the chrome) |
| `customify_search_wc_region_end()` | `customify/content/after` | `PHP_INT_MAX` (after the WC content region) |

  Both self-guard on `customify_search_is_wc_scoped()`. With the actions now reaching both paths, the `is_post_type_archive( 'product' )` bail is removed and the seam claims every search view. One contract, both paths, and third parties can hook the region on either.

The two claims are now **disjoint**: catalog views are Blocksify's, search views are the theme's. The never-clobber-non-null guard stays as the tie-break for any third claimant.

**Known trade-off.** Blocksify's `preserve_notices()` only runs when its WC module claims, so on a product scoped search where a template wins, WooCommerce notices printed inside `woocommerce_before_shop_loop` land in the discarded buffer. That is the intended semantics of a whole-region takeover (the template owns the view), and notices are rare on a search page; worth a follow-up if it bites.

### Verified on a real site (Customify 2026, WP 7.0.4, PHP 8.4, WooCommerce)

Templates published: `search` (all), `search:product`, `search:post`, `search:page`, `cpt_archive:product`.

| View | Before | After |
|---|---|---|
| `?s=top&post_type=product` | chrome **and** template stacked (`cfy-search-results--wc`×1 + template×3) | **template only** — zero `cfy-search*` classes, no theme `h1`, real product cards |
| `?s=top` | template only | unchanged, byte-identical |
| `?s=zzzqqqxyz` (empty) | template empty state | unchanged, byte-identical |
| `?s=top&post_type=page` | template only | unchanged, byte-identical |
| `/shop/` | `cpt_archive` template via WC seam | unchanged, byte-identical — the WC seam claim on non-search views still works |
| `/` | — | unchanged, byte-identical |

**Fallback proof (hard requirement).** With all four search-condition templates set to `draft`, every one of those six URLs is **byte-identical** to the pre-patch build — including the bug view, where the theme chrome returns in full (heading + results form + WooCommerce `<ul class="products">` grid). Comparison captures were taken one deploy per step with a settle wait, because the test host runs OPcache with `revalidate_freq=2` and a same-second capture silently serves the previous build.

No PHP `Warning` / `Fatal error` / `Notice` in any response (checked against a positive control; the host's own pre-existing `open_basedir` notice from `99-studio-loader.php` is excluded).

## B. The products teaser is retired

The template/tabs world made teaser mode obsolete. It was introduced by #472 (commit `b858764e`) and has **never shipped in a release**, so it is removed outright — no deprecation shims, confirmed via `git log -S` on every key and function name.

Removed:

- setting `search_results_product_display` (`inc/customizer/configs/search.php`)
- `customify_search_get_product_display`, `customify_search_is_products_teaser`, `customify_search_products_teaser`, `customify_search_exclude_products_from_main_query`, `customify_search_teaser_posts_where` and their `pre_get_posts` / `posts_where` registrations
- the teaser-mode All-count adjustment in `customify_search_tabs()` (the All count is plain `counts['all']` again)
- the teaser call site in `customify_search_results_layout()`
- the `.cfy-search-products-teaser` block in `src/frontend/scss/layouts/_search-results.scss`

Kept and re-checked after removal: tabs, results form, counts, grouped sections, no-results popular products, and the default-scope redirect. The redirect no longer interacts with the teaser but still makes sense on its own, and the `cfy_all` bypass stays because the redirect stays — it is the only way to reach "Everything" from a scoped view. The `$all_count > 0` guard on the All tab is now purely defensive (the total is the sum of per-type counts, so it can only be zero when nothing matched at all); its comment was rewritten to say so.

## Verification

- `php -l` clean on all three changed PHP files; all files LF-only.
- Frontend-only webpack build: `.cfy-search-products-teaser` is gone from `build/css/frontend/style-theme.css`, `.cfy-search-tabs` still present.
- `.pot` never contained the teaser strings, so no `makepot` run was needed.
- No WordPress site was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

