### PR TITLE
fix(buttons): scope Global Button Styling to content/form buttons

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -55,6 +55,7 @@ add_filter( 'customify_get_layout', function ( $layout ) {
 | `customify/customize/register_completed` | action | `(Customify_Customizer $customizer)` — fires after all registration | [`inc/customizer/class-customizer.php:1195`](../inc/customizer/class-customizer.php) |
 | `customify/customizer/panel_groups` | filter | `array` — panel grouping for UI organization | [`inc/customizer/class-customizer.php:1261`](../inc/customizer/class-customizer.php) |
 | `customify/get_styling_config` | filter | `array` — styling field config | [`inc/customizer/class-customizer.php:791`](../inc/customizer/class-customizer.php) |
+| `customify/buttons_forms/button_selector` | filter | `string $selector` — the global Button Styling scope (comma-separated selector list) | [`inc/customizer/configs/buttons-forms.php`](../inc/customizer/configs/buttons-forms.php) `customify_get_button_styling_selectors()` |
 
 ### 2.2 Auto-CSS pipeline
 
@@ -64,6 +65,18 @@ add_filter( 'customify_get_layout', function ( $layout ) {
 | `customify/auto-css` | filter | `string $css` — final assembled CSS before `wp_add_inline_style` | [`inc/customizer/class-customizer-auto-css.php`](../inc/customizer/class-customizer-auto-css.php) `render_css()` |
 | `customify/styling/<field>` | filter | `string $css` — append CSS template to a specific field (e.g. `customify/styling/primary-color`) | dynamic — emitted per-field by auto-CSS |
 | `customify/typography/field_uses_vars` | filter | `(bool $uses_vars, array $field)` — **per-field route.** Default is `true` only for the 8 foundation roles in `TYPO_VAR_MAP` (`global_typography_base_p`, `global_typography_base_heading`, `global_typography_heading_h1`…`h6`); leaf-global roles (site title, tagline, widget title) and per-component fields default `false`. Return `false` to force a foundation field through selector-scoped emit, or `true` to opt a non-foundation field into tokens (also requires an SCSS consumer at the matching selector — see [`SPEC-typography.md §6.4`](SPEC-typography.md)). | [`inc/customizer/class-customizer-auto-css.php`](../inc/customizer/class-customizer-auto-css.php) `typography_field_uses_vars()` |
+
+Example — bring a page builder's button class into the global Button Styling
+scope. The scope is an allowlist by design: bare `<button>` elements are only
+matched when they are a submit/reset control, are unclassed, or sit in a form
+with no `type` attribute, so component chrome (galleries, lightboxes, steppers,
+icon toggles) is never repainted. Anything else opts in explicitly:
+
+```php
+add_filter( 'customify/buttons_forms/button_selector', function ( $selector ) {
+    return $selector . ', .elementor-button';
+} );
+```
 
 Example — extend the primary color CSS targets without forking the config file:
 

--- a/inc/customizer/configs/buttons-forms.php
+++ b/inc/customizer/configs/buttons-forms.php
@@ -25,10 +25,9 @@
  *     rebuilds (and would drop) the `:root` Palette block — so editing these
  *     controls never disturbs the Colors palette in the Customizer preview.
  *
- * Button selectors mirror the theme's own button rule (base/_forms.scss) so the
- * composite output matches its specificity and, loading later (inline on the
- * `customify-style` handle), wins the cascade — including over WooCommerce
- * buttons.
+ * Button selectors mirror the theme's own button rule (base/_forms.scss) — see
+ * customify_get_button_styling_selectors() below for the scope contract shared
+ * by the two layers.
  *
  * ── 30k-site safety ──────────────────────────────────────────────────────────
  * Every subfield defaults to empty, so `Customify_Customizer_Auto_CSS::styling()`
@@ -38,6 +37,215 @@
  *
  * @package Customify
  */
+
+if ( ! function_exists( 'customify_split_selector_list' ) ) {
+	/**
+	 * Split a CSS selector list on its TOP-LEVEL commas.
+	 *
+	 * `explode( ',', … )` cannot be used on the scopes built below: they contain
+	 * functional pseudo-classes whose arguments are themselves comma-separated
+	 * (`:not(a, b)`, `:is(a, b)`). Splitting inside those parentheses yields
+	 * invalid selectors, which is why the previous revision of this file had to
+	 * carry a "keep every :not() comma-free" constraint — a constraint that
+	 * forced the chained `:not(a):not(b):not(c)…` form and, with it, runaway
+	 * specificity (each chained `:not()` adds a whole class level).
+	 *
+	 * @param string $list CSS selector list.
+	 * @return array<int, string> Individual selectors, trimmed, empties removed.
+	 */
+	function customify_split_selector_list( $list ) {
+		$parts = array();
+		$buffer = '';
+		$depth  = 0;
+		$length = strlen( $list );
+
+		for ( $i = 0; $i < $length; $i++ ) {
+			$char = $list[ $i ];
+
+			if ( '(' === $char ) {
+				$depth++;
+			} elseif ( ')' === $char ) {
+				$depth--;
+			} elseif ( ',' === $char && 0 === $depth ) {
+				$parts[] = trim( $buffer );
+				$buffer  = '';
+				continue;
+			}
+
+			$buffer .= $char;
+		}
+
+		$parts[] = trim( $buffer );
+
+		return array_values(
+			array_filter(
+				$parts,
+				function ( $part ) {
+					return '' !== $part;
+				}
+			)
+		);
+	}
+}
+
+if ( ! function_exists( 'customify_suffix_selector_list' ) ) {
+	/**
+	 * Append a pseudo-class to every selector in a list.
+	 *
+	 * Used to derive the `:hover` / `:focus` variant of a scope.
+	 *
+	 * @param string $list   CSS selector list.
+	 * @param string $pseudo Pseudo-class to append, e.g. `:hover`.
+	 * @return string
+	 */
+	function customify_suffix_selector_list( $list, $pseudo ) {
+		return implode(
+			', ',
+			array_map(
+				function ( $selector ) use ( $pseudo ) {
+					return $selector . $pseudo;
+				},
+				customify_split_selector_list( $list )
+			)
+		);
+	}
+}
+
+if ( ! function_exists( 'customify_get_button_styling_selectors' ) ) {
+	/**
+	 * The scope of the global "Button Styling" control.
+	 *
+	 * ── Why this is an allowlist ────────────────────────────────────────────
+	 * Until 0.4.22 this scope matched the BARE `button` element and tried to
+	 * subtract everything that is not a real button with a denylist of
+	 * individual class names. That approach failed structurally, twice over:
+	 *
+	 *  1. A denylist cannot enumerate third-party chrome. Every icon control a
+	 *     plugin renders as `<button class="…">` inherited the CTA skin —
+	 *     Blocksify's product-gallery thumbnails and thumb arrows
+	 *     (`.bsy-gallery__thumb`, `.bsy-gallery__thumb-nav`), lightGallery's
+	 *     `.lg-prev` / `.lg-next` / `.lg-close` / `.lg-zoom-in` /
+	 *     `.lg-fullscreen` / `.lg-autoplay-button` / `.lg-share`, PhotoSwipe's
+	 *     `.pswp__button`, and so on. Each one needed its own carve-out, and
+	 *     the next plugin needed the next carve-out.
+	 *  2. Chained `:not()` inflates specificity: EACH `:not()` contributes a
+	 *     full class level. The 0.4.22 selector
+	 *     `button:not(a):not(b):not(c):not(d):not(e):not(f)` scored (0,6,1) and
+	 *     is emitted inline on the `customify-style` handle (i.e. last), so it
+	 *     outranked the component's own stylesheet and could not be corrected
+	 *     downstream by the plugin, the child theme or custom CSS.
+	 *
+	 * ── The rule now ────────────────────────────────────────────────────────
+	 * A button is in scope when it OPTS IN by contract, or when it is
+	 * structurally a content/form control:
+	 *
+	 *  • Opt-in classes: `.button`, `.wp-block-button__link`,
+	 *    `.wp-element-button`, plus the `input` button types.
+	 *  • The bare `button` ELEMENT only when it is
+	 *      – an explicit `[type="submit"]` or `[type="reset"]`, or
+	 *      – UNCLASSED (`:not([class])`) — author-written content markup, or
+	 *      – inside a `<form>` with no `type` attribute at all, which per the
+	 *        HTML spec IS a submit button.
+	 *
+	 * Component chrome is, without exception, a CLASSED `type="button"`
+	 * element — that is what every icon control in every library emits — so it
+	 * now falls outside the scope structurally, with no per-library carve-out
+	 * and no future whack-a-mole.
+	 *
+	 * ── Specificity contract (deliberate, not incidental) ───────────────────
+	 *  • `.button` branch → (0,3,0). Load-bearing: it must keep outranking
+	 *    `.button.add_to_cart_button` / `.button.alt` (0,2,0) in
+	 *    compatibility/wc/_wc-elements.scss, otherwise saved Button Styling
+	 *    would stop applying to WooCommerce add-to-cart / checkout buttons.
+	 *  • bare `button` branch → (0,3,1), down from (0,6,1). The extra levels
+	 *    only ever existed to out-shout chrome the scope no longer touches.
+	 *  • `input[...]` branches → (0,2,0), unchanged from 0.4.22.
+	 *
+	 * Exclusion lists are single comma-separated `:not()` arguments, so adding
+	 * or removing an entry NEVER changes the specificity again.
+	 *
+	 * ── Theme-owned chrome ──────────────────────────────────────────────────
+	 * `.search-submit` and `.menu-mobile-toggle` are the theme's own icon
+	 * controls: an SVG magnifier pulled back over the search field, and the
+	 * hamburger. Both have dedicated Header-builder styling, exactly like
+	 * `.search-field` is excluded from the Field Styling scope below. They are
+	 * excluded here so a saved Button Styling value cannot repaint them —
+	 * their context rules (header/_search.scss, widgets/_widgets.scss) live in
+	 * the bundled stylesheet and can never outrank late inline CSS.
+	 *
+	 * NOTE: base/_forms.scss carries the same scope for the theme's DEFAULT
+	 * button skin, with two documented differences — it keeps `.search-submit`
+	 * in scope (that default is what 30k sites already render, and the header /
+	 * widget context rules do successfully override the low-specificity bundled
+	 * rule), and it uses `:where()` for the chrome exclusions to hold its
+	 * historical (0,1,1). Keep the two in lockstep when editing either.
+	 *
+	 * @return array{normal:string,hover:string}
+	 */
+	function customify_get_button_styling_selectors() {
+		// Block-editor / WooCommerce-blocks chrome. `[class*="wp-block-"]` and
+		// `[class*="wc-block-"]` peel off ANY element carrying such a token —
+		// that is how core blocks (Search submit, File download, Embed "Try
+		// again") and WooCommerce blocks (quantity steppers, filter toggles)
+		// render their internal buttons.
+		$chrome_blocks = '[class*="wp-block-"], [class*="wc-block-"]';
+
+		// Non-block chrome: editor / Customizer UI (`.components-button`,
+		// `.customize-partial-edit-shortcut-button`, the classic editor's
+		// `.ed_button` quicktags, WooCommerce's `.lightbox-trigger`) plus the
+		// theme's own icon controls. Most are already excluded by the intent
+		// gate — they are classed `type="button"` elements — but naming them
+		// costs nothing (single `:not()` list) and documents intent.
+		$chrome_ui = '.components-button, .customize-partial-edit-shortcut-button, .ed_button, .lightbox-trigger, .search-submit, .menu-mobile-toggle';
+
+		// Intent gate for the bare `button` element (see docblock).
+		$bare_gate = '[type="submit"], [type="reset"], :not([class])';
+
+		$selectors = array(
+			// Opt-in class. Two chained :not() → (0,3,0), see contract above.
+			'.button:not(' . $chrome_blocks . '):not(' . $chrome_ui . ')',
+
+			// Bare element, intent-gated → (0,3,1).
+			'button:is(' . $bare_gate . '):not(' . $chrome_blocks . '):not(' . $chrome_ui . ')',
+
+			// A <button> in a <form> with no type attribute is a submit button
+			// per the HTML spec, whatever classes it carries (WPForms, Mailchimp
+			// and friends ship exactly this markup).
+			'form button:not([type]):not(' . $chrome_blocks . '):not(' . $chrome_ui . ')',
+
+			// input button types are form controls by definition — no gate
+			// needed. Single :not() list each → (0,2,0), unchanged from 0.4.22.
+			'input[type="button"]:not(' . $chrome_blocks . ', ' . $chrome_ui . ')',
+			'input[type="reset"]:not(' . $chrome_blocks . ', ' . $chrome_ui . ')',
+			'input[type="submit"]:not(' . $chrome_blocks . ', ' . $chrome_ui . ')',
+
+			// Core block / theme.json button contracts.
+			'.wp-block-button__link',
+			'.wp-element-button:not(.components-button)',
+		);
+
+		$normal = implode( ', ', $selectors );
+
+		/**
+		 * Filter the global Button Styling scope.
+		 *
+		 * Lets a child theme or Customify Pro extend the scope (e.g. add a
+		 * page-builder's button class) without forking this file. The `:hover`
+		 * variant is derived from the filtered value, so both states stay
+		 * consistent.
+		 *
+		 * @since 0.4.23
+		 *
+		 * @param string $normal Comma-separated selector list.
+		 */
+		$normal = apply_filters( 'customify/buttons_forms/button_selector', $normal );
+
+		return array(
+			'normal' => $normal,
+			'hover'  => customify_suffix_selector_list( $normal, ':hover' ),
+		);
+	}
+}
 
 if ( ! function_exists( 'customify_customizer_buttons_forms_config' ) ) {
 	/**
@@ -50,45 +258,9 @@ if ( ! function_exists( 'customify_customizer_buttons_forms_config' ) ) {
 		$section = 'customify_buttons_forms';
 
 		// ── Selector lists ───────────────────────────────────────────────────
-		// Buttons: mirror the global button rule in base/_forms.scss so the
-		// composite output ties its specificity and wins by load order. Built
-		// once, then a `:hover` variant is derived for the Hover tab.
-		// The bare `button` part also excludes:
-		//   - the Customizer preview's selective-refresh edit-shortcut buttons
-		//     (round pencil icons WP injects next to editable partials inside
-		//     the preview iframe) — they are plain <button>s and would
-		//     otherwise get the full theme button skin;
-		//   - `.menu-mobile-toggle` — the hamburger trigger is a <button> with
-		//     its own dedicated nav-icon styling (transparent bg, no padding,
-		//     custom hover). Letting Button Styling reach it paints the
-		//     hamburger with the brand button background.
-		//   - `.input-pm-act` — the WooCommerce quantity stepper's +/- pair
-		//     (injected by `_wc_plus_minus()` in
-		//     src/frontend/js/compatibility/woocommerce.js, used on cart,
-		//     mini-cart and single product). They are plain <button>s sitting
-		//     directly against the qty input, so the brand button background
-		//     painted them as if they were CTAs.
-		//   - `.wc-block-components-quantity-selector__button` — the same
-		//     stepper in the Cart/Checkout blocks. Its class is `wc-block-…`,
-		//     NOT `wp-block-…`, so the carve-out above does not cover it. The
-		//     SCSS neutralizer in
-		//     src/frontend/scss/compatibility/wc/_woocommerce-main.scss only
-		//     handles the bundled :hover state layer — the Customizer's inline
-		//     CSS outranks any bundled rule, so the normal-state background has
-		//     to be excluded here at the source.
-		//   - `.show-password-input` — WooCommerce's show/hide password toggle,
-		//     an empty <button> overlaying the right edge of every password
-		//     field (login, register, checkout, edit-account). It is an icon
-		//     control, so a brand background turns it into a solid square.
-		//     Styled in src/frontend/scss/compatibility/wc/_wc-forms.scss.
-		// Keep every :not() comma-free ($suffix_each below splits on commas).
-		$button_selector = '.button:not([class*="wp-block-"]):not(.menu-mobile-toggle), '
-			. 'button:not([class*="wp-block-"]):not(.customize-partial-edit-shortcut-button):not(.menu-mobile-toggle):not(.input-pm-act):not(.wc-block-components-quantity-selector__button):not(.show-password-input), '
-			. 'input[type="button"]:not([class*="wp-block-"]), '
-			. 'input[type="reset"]:not([class*="wp-block-"]), '
-			. 'input[type="submit"]:not([class*="wp-block-"]), '
-			. '.wp-block-button__link, '
-			. '.wp-element-button:not(.components-button)';
+		// Buttons: see customify_get_button_styling_selectors() for the scope
+		// contract (allowlist + intent gate) and the specificity rationale.
+		$button = customify_get_button_styling_selectors();
 
 		// Form fields: the input/select/textarea family from base/_forms.scss.
 		// `input[type="search"]:not(.search-field)` deliberately EXCLUDES the
@@ -103,19 +275,7 @@ if ( ! function_exists( 'customify_customizer_buttons_forms_config' ) ) {
 			. 'input[type="week"], input[type="time"], input[type="datetime"], '
 			. 'input[type="datetime-local"], input[type="color"], select, textarea';
 
-		// Derive `:hover` / `:focus` variants by suffixing each comma-separated
-		// selector (none of these selectors contain commas inside :not()).
-		$suffix_each = function ( $list, $pseudo ) {
-			$parts = array_map(
-				function ( $sel ) use ( $pseudo ) {
-					return trim( $sel ) . $pseudo;
-				},
-				explode( ',', $list )
-			);
-			return implode( ', ', $parts );
-		};
-		$button_hover = $suffix_each( $button_selector, ':hover' );
-		$field_focus  = $suffix_each( $field_selector, ':focus' );
+		$field_focus = customify_suffix_selector_list( $field_selector, ':focus' );
 
 		// Subfields to HIDE in the popover (keep it focused on bg / border /
 		// radius / shadow + text color + padding). `false` hides a subfield;
@@ -159,17 +319,19 @@ if ( ! function_exists( 'customify_customizer_buttons_forms_config' ) ) {
 			),
 
 			// Button styling — Advanced Styling popover (Normal / Hover).
-			// Applies to every theme button, including WooCommerce buttons.
+			// Applies to content and form buttons, including WooCommerce
+			// buttons. Component chrome (gallery, lightbox, steppers, icon
+			// toggles, editor UI) is out of scope by construction.
 			array(
 				'name'        => 'customify_button_styling',
 				'type'        => 'styling',
 				'section'     => $section,
 				'priority'    => 11,
 				'title'       => __( 'Button Styling', 'customify' ),
-				'description' => __( 'All theme buttons.', 'customify' ),
+				'description' => __( 'Content and form buttons, including WooCommerce.', 'customify' ),
 				'selector'    => array(
-					'normal' => $button_selector,
-					'hover'  => $button_hover,
+					'normal' => $button['normal'],
+					'hover'  => $button['hover'],
 				),
 				'css_format'  => 'styling',
 				'default'     => array(

--- a/src/frontend/scss/base/_base.scss
+++ b/src/frontend/scss/base/_base.scss
@@ -687,7 +687,15 @@ article.comment {
 --------------------------------------------------------------*/
 
 // Direction Nav
+// Used by the theme AND by Customify Pro's WooCommerce Booster (Quick View +
+// Product Gallery Slider render `<button type="button" class="slick-next
+// nav-btn …">`). Those are classed `type="button"` icon controls, so they sit
+// outside the global button scope in base/_forms.scss on purpose — which also
+// means they no longer inherit its `border: none`. Declare it here, next to
+// the rest of the component's own look, or the UA `outset` button border comes
+// back on the arrows.
 .nav-btn {
+    border: none;
     margin: auto;
     width: 24px;
     height: 24px;

--- a/src/frontend/scss/base/_forms.scss
+++ b/src/frontend/scss/base/_forms.scss
@@ -127,34 +127,71 @@ select {
     }
 }
 
-// `[class*="wp-block-"]` (and `[class*="wc-block-"]`) in the :not() lists
-// peel off ANY element whose class contains a `wp-block-*` / `wc-block-*`
-// token — that's how WP default blocks (Search submit, File download,
-// Embed "Try again", Latest Posts CTA, etc.) AND WooCommerce blocks
-// (product-filters overlay open/close toggles, etc.) render their internal
-// chrome buttons. Editor canvas + frontend both stop applying the broad
-// theme button styling to those, while the intentionally-styled content
-// buttons (`.wp-block-button__link`, `.wp-element-button`,
-// `.wc-block-cart__submit .wp-element-button`) stay listed explicitly so
-// they still pick up the theme look.
-// The single-class exclusions kept below (`.components-button`,
-// `.customize-partial-edit-shortcut-button`, `.lightbox-trigger`,
-// `.ed_button`, `.menu-mobile-toggle`) are not block-prefixed, so they
-// still need their own slot.
-.button:not(
-    [class*="wp-block-"],
-    [class*="wc-block-"],
-    .menu-mobile-toggle,
-    .components-button,
-    .customize-partial-edit-shortcut-button
-),
-button:not(.components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"], [class*="wc-block-"]),
-input[type="button"]:not(.ed_button, [class*="wp-block-"], [class*="wc-block-"]),
-input[type="reset"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]),
-.wc-block-cart__submit .wp-element-button,
-.wp-block-button__link,
-.wp-element-button:not(.components-button),
-input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]) {
+// ==========================================================================
+// Canonical "theme button surface" — the scope of the default button skin.
+//
+// ROOT CAUSE THIS REPLACES: the previous list matched the BARE `button`
+// element and subtracted "everything that is not a button" with a denylist of
+// individual class names. A denylist cannot enumerate third-party chrome, so
+// every icon control a plugin renders as `<button class="…">` inherited the
+// full CTA skin — Blocksify's product-gallery thumbnails / thumb arrows
+// (`.bsy-gallery__thumb`, `.bsy-gallery__thumb-nav`), lightGallery's
+// `.lg-prev` / `.lg-next` / `.lg-close` / `.lg-zoom-in` / `.lg-fullscreen` /
+// `.lg-autoplay-button` / `.lg-share`, PhotoSwipe's `.pswp__button`, and the
+// next plugin's controls after those.
+//
+// THE RULE NOW — a button is in scope when it OPTS IN by contract, or when it
+// is structurally a content/form control:
+//
+//   • Opt-in classes: `.button`, `.wp-block-button__link`,
+//     `.wp-element-button`, plus the `input` button types.
+//   • The bare `button` ELEMENT only when it is an explicit `[type="submit"]`
+//     / `[type="reset"]`, an UNCLASSED `<button>` (author-written content
+//     markup), or a `<button>` inside a `<form>` with no `type` attribute at
+//     all — which per the HTML spec IS a submit button.
+//
+// Component chrome is, without exception, a CLASSED `type="button"` element,
+// so it is now out of scope structurally — no per-library carve-out, no future
+// whack-a-mole. `.menu-mobile-toggle`, `.input-pm-act`,
+// `.wc-block-components-quantity-selector__button`, `.show-password-input` and
+// `.customize-partial-edit-shortcut-button` all fall out on their own; the
+// ones still named below are kept as documentation + belt-and-braces.
+//
+// SPECIFICITY: exclusions go through `:where()` (zero specificity) wherever
+// the historical score has to be preserved, so this rule keeps exactly the
+// weights it shipped with — `.button` (0,2,0), bare `button` (0,1,1),
+// `input[…]` (0,2,0). That matters: the header / widget context rules
+// (header/_search.scss, widgets/_widgets.scss) override this bundled default
+// at (0,2,0) and must keep winning. Adding or removing an exclusion can never
+// change these numbers again.
+//
+// `.search-submit` is deliberately still IN scope here (it is a `type="submit"`
+// control): that is what 30k sites already render on the 404 / no-results
+// search form, and the two contexts where the theme overlays it on the field
+// do override this default successfully. The Customizer's Button Styling scope
+// (inc/customizer/configs/buttons-forms.php) excludes it instead — late inline
+// CSS at high specificity is not overridable by those context rules. Keep the
+// two files in lockstep otherwise.
+// ==========================================================================
+$btn-chrome:
+    '[class*="wp-block-"], [class*="wc-block-"], .components-button, ' +
+    '.customize-partial-edit-shortcut-button, .ed_button, .lightbox-trigger, ' +
+    '.menu-mobile-toggle';
+
+$btn-bare-gate: '[type="submit"], [type="reset"], :not([class])';
+
+$btn-scope:
+    '.button:not(#{$btn-chrome}), ' +
+    'button:is(#{$btn-bare-gate}):where(:not(#{$btn-chrome})), ' +
+    'form button:not([type]):where(:not(#{$btn-chrome})), ' +
+    'input[type="button"]:not(#{$btn-chrome}), ' +
+    'input[type="reset"]:not(#{$btn-chrome}), ' +
+    'input[type="submit"]:not(#{$btn-chrome}), ' +
+    '.wp-block-button__link, ' +
+    '.wp-element-button:not(.components-button)';
+
+#{$btn-scope},
+.wc-block-cart__submit .wp-element-button {
     border: none;
     cursor: pointer;
     padding: 0px 1.3em;
@@ -219,17 +256,8 @@ input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-bu
     }
 }
 
-// Same `[class*="wp-block-"]` / `[class*="wc-block-"]` carve-out as above
-// so WP / WooCommerce block chrome doesn't inherit the primary-color fill.
-.button:not([class*="wp-block-"], [class*="wc-block-"]),
-button:not(.menu-mobile-toggle, .components-button, .customize-partial-edit-shortcut-button, .lightbox-trigger, [class*="wp-block-"], [class*="wc-block-"]),
-input[type="button"]:not(.ed_button, [class*="wp-block-"], [class*="wc-block-"]),
-.button:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]),
-input[type="button"]:not(.ed_button, .components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]),
-input[type="reset"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]),
-.wp-block-button__link,
-.wp-element-button:not(.components-button),
-input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]) {
+// Brand fill — same scope as the reset above, so the two can never drift.
+#{$btn-scope} {
     color: var(--customify-btn-on-primary, #ffffff);
     background: $color_primary;
     &:focus {
@@ -237,10 +265,12 @@ input[type="submit"]:not(.components-button, .customize-partial-edit-shortcut-bu
     }
 }
 
-.button[disabled]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]),
-button[disabled]:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]),
-button.disabled:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]),
-.button.disabled:not(.components-button, .customize-partial-edit-shortcut-button, [class*="wp-block-"], [class*="wc-block-"]) {
+// Disabled state — same intent gate, so a disabled gallery arrow or lightbox
+// control is dimmed by its own component CSS, not by ours.
+.button[disabled]:not(#{$btn-chrome}),
+.button.disabled:not(#{$btn-chrome}),
+button[disabled]:is(#{$btn-bare-gate}):where(:not(#{$btn-chrome})),
+button.disabled:is(#{$btn-bare-gate}):where(:not(#{$btn-chrome})) {
     opacity: 0.5;
 }
 

--- a/src/frontend/scss/compatibility/wc/_woocommerce-main.scss
+++ b/src/frontend/scss/compatibility/wc/_woocommerce-main.scss
@@ -139,20 +139,20 @@ p.demo_store,
     }
 
     // Block cart/checkout quantity stepper (Cart/Checkout blocks). The +/- are
-    // bare <button>s carrying a `wc-block-…` class (NOT `wp-block-…`), so the
-    // global theme button rule's `:not([class*="wp-block-"])` carve-out does
-    // NOT exclude them — its hover state leaks in and sets
-    // `color: --customify-on-primary` (white) + a `currentColor`-based
-    // state-layer `background-image` gradient. That turns the ＋/－ glyph white
-    // (invisible) and paints a gray fill behind it. Neutralize like .input-pm-act
-    // so the glyph stays visible and the stepper stays flat (no hover fill),
-    // matching the single-product stepper.
+    // bare <button>s carrying a `wc-block-…` class. They are now outside the
+    // global button scope twice over — that scope excludes `[class*="wc-block-"]`
+    // AND only reaches the bare element when it is a submit/reset control, an
+    // unclassed <button>, or a typeless <button> in a form, while these are
+    // classed `type="button"` (see the "canonical theme button surface" note in
+    // base/_forms.scss). Historically they were NOT excluded: the theme's hover
+    // state-layer leaked in, set `color: --customify-on-primary` (white) and a
+    // `currentColor` gradient, turning the ＋/－ glyph invisible over a gray fill.
     //
-    // Specificity note: the theme's state-layer rule is
-    // `button:not(…):not(.menu-mobile-toggle, .search-submit):hover` = (0,3,1),
-    // so the extra `.wc-block-components-quantity-selector` ancestor below is
-    // REQUIRED to reach (0,4,0) and actually drop the gradient — a single-class
-    // override (0,3,0) loses to it and the gray fill survives.
+    // Kept as a defensive neutralizer — it also flattens WooCommerce's own
+    // hover/focus treatment so the stepper matches the single-product one, and
+    // it still kills the Cart-block focus ring below. The
+    // `.wc-block-components-quantity-selector` ancestor keeps it at (0,4,0),
+    // above cart.css's own (0,3,0) rules.
     .wc-block-components-quantity-selector .wc-block-components-quantity-selector__button {
         &:hover,
         &:focus,

--- a/src/frontend/scss/header/builder_items/_nav_icon.scss
+++ b/src/frontend/scss/header/builder_items/_nav_icon.scss
@@ -11,6 +11,25 @@
     box-shadow: none;
     color: currentColor;
     transition: transform .3s, border .3s, background .3s, box-shadow .3s, opacity .3s, color .3s;
+
+    // The global button reset in base/_forms.scss now only covers content and
+    // form buttons (see its "canonical theme button surface" note). The
+    // hamburger is a classed `type="button"` icon control, so it sits outside
+    // that scope on purpose — but it used to inherit the reset's box model
+    // from there. Carry it explicitly, otherwise the UA button styling returns
+    // (outset border, block display, no min-height) and the trigger loses its
+    // centring. Values are copied verbatim from that reset; keep in lockstep.
+    border: none;
+    border-radius: 3px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5em;
+    max-width: 100%;
+    min-height: 2.6em;
+    line-height: 2.5em;
+    font-weight: 500;
+
     &[type="button"] {
         padding: 0px;
     }

--- a/tests/button-scope-test.php
+++ b/tests/button-scope-test.php
@@ -1,0 +1,481 @@
+<?php
+/**
+ * Regression tests for the global button scope.
+ *
+ * Guards the fix for the 0.4.21–0.4.22 leak where a saved
+ * `customify_button_styling` value repainted component chrome — Blocksify's
+ * product-gallery thumbnails/arrows and lightGallery's lightbox controls in
+ * particular — because the scope matched the bare `button` element and tried
+ * to subtract non-buttons with a denylist of class names.
+ *
+ * Two layers are covered:
+ *   1. The Customizer scope    — customify_get_button_styling_selectors()
+ *      in inc/customizer/configs/buttons-forms.php.
+ *   2. The default SCSS skin   — read back from the COMPILED
+ *      build/css/frontend/style-theme.css so the SCSS is tested as shipped.
+ *      Skipped with a notice when build/ has not been generated.
+ *
+ * Run with: php tests/button-scope-test.php
+ */
+
+// ─── Minimal WordPress stubs ────────────────────────────────────────────────
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = null ) {
+		return $text;
+	}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		return true;
+	}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value ) {
+		return $value;
+	}
+}
+
+require_once __DIR__ . '/../inc/customizer/configs/buttons-forms.php';
+
+// ─── Assertion helpers ──────────────────────────────────────────────────────
+$GLOBALS['customify_test_failures'] = 0;
+
+function customify_test_assert( $condition, $message ) {
+	if ( $condition ) {
+		return;
+	}
+	$GLOBALS['customify_test_failures']++;
+	echo "FAIL: {$message}\n";
+}
+
+function customify_test_assert_same( $expected, $actual, $message ) {
+	customify_test_assert(
+		$expected === $actual,
+		$message . ' (expected ' . var_export( $expected, true ) . ', got ' . var_export( $actual, true ) . ')'
+	);
+}
+
+// ─── A tiny CSS matcher ─────────────────────────────────────────────────────
+// Deliberately supports only the grammar the two scopes emit: descendant
+// combinators, type/class/attribute simple selectors and the functional
+// pseudo-classes :not() / :is() / :where(). That is enough to answer the one
+// question these tests ask — "does this element fall inside the scope?" —
+// without pulling in a CSS parser dependency.
+
+/**
+ * Split on whitespace that sits outside brackets and parentheses.
+ *
+ * @param string $selector Complex selector.
+ * @return array<int, string> Compound selectors, outermost ancestor first.
+ */
+function customify_test_split_compounds( $selector ) {
+	$parts  = array();
+	$buffer = '';
+	$depth  = 0;
+	$length = strlen( $selector );
+
+	for ( $i = 0; $i < $length; $i++ ) {
+		$char = $selector[ $i ];
+
+		if ( '(' === $char || '[' === $char ) {
+			$depth++;
+		} elseif ( ')' === $char || ']' === $char ) {
+			$depth--;
+		} elseif ( ' ' === $char && 0 === $depth ) {
+			if ( '' !== trim( $buffer ) ) {
+				$parts[] = trim( $buffer );
+			}
+			$buffer = '';
+			continue;
+		}
+
+		$buffer .= $char;
+	}
+
+	if ( '' !== trim( $buffer ) ) {
+		$parts[] = trim( $buffer );
+	}
+
+	return $parts;
+}
+
+/**
+ * Tokenize one compound selector into its simple selectors.
+ *
+ * @param string $compound Compound selector, e.g. `button:is(a, b):not(c)`.
+ * @return array<int, string>
+ */
+function customify_test_tokenize( $compound ) {
+	$tokens = array();
+	$buffer = '';
+	$depth  = 0;
+	$length = strlen( $compound );
+
+	for ( $i = 0; $i < $length; $i++ ) {
+		$char = $compound[ $i ];
+
+		if ( 0 === $depth && ( '.' === $char || '[' === $char || ':' === $char || '#' === $char ) && '' !== $buffer ) {
+			$tokens[] = $buffer;
+			$buffer   = '';
+		}
+
+		if ( '(' === $char || '[' === $char ) {
+			$depth++;
+		} elseif ( ')' === $char || ']' === $char ) {
+			$depth--;
+		}
+
+		$buffer .= $char;
+	}
+
+	if ( '' !== $buffer ) {
+		$tokens[] = $buffer;
+	}
+
+	return $tokens;
+}
+
+/**
+ * Does one simple selector match the element fixture?
+ *
+ * @param string $token Simple selector.
+ * @param array  $el    Element fixture (tag / classes / attrs).
+ * @return bool
+ */
+function customify_test_token_matches( $token, $el ) {
+	// Functional pseudo-classes.
+	if ( preg_match( '/^:(not|is|where|matches)\((.*)\)$/s', $token, $m ) ) {
+		$inner = customify_split_selector_list( $m[2] );
+		$any   = false;
+		foreach ( $inner as $candidate ) {
+			if ( customify_test_compound_matches( $candidate, $el ) ) {
+				$any = true;
+				break;
+			}
+		}
+		return 'not' === $m[1] ? ! $any : $any;
+	}
+
+	// State pseudo-classes are irrelevant to scope membership.
+	if ( ':' === $token[0] ) {
+		return true;
+	}
+
+	// Class.
+	if ( '.' === $token[0] ) {
+		return in_array( substr( $token, 1 ), $el['classes'], true );
+	}
+
+	// Attribute: [name], [name="v"], [name*="v"] (quotes optional — the
+	// compiled CSS is minified and drops them).
+	if ( '[' === $token[0] ) {
+		$body = substr( $token, 1, -1 );
+
+		if ( preg_match( '/^([\w-]+)(\*?)=["\']?(.*?)["\']?$/', $body, $m ) ) {
+			if ( ! isset( $el['attrs'][ $m[1] ] ) ) {
+				return false;
+			}
+			return '*' === $m[2]
+				? false !== strpos( $el['attrs'][ $m[1] ], $m[3] )
+				: $el['attrs'][ $m[1] ] === $m[3];
+		}
+
+		return isset( $el['attrs'][ $body ] );
+	}
+
+	// Type selector.
+	return $token === $el['tag'];
+}
+
+/**
+ * Does a compound selector match the element fixture?
+ *
+ * @param string $compound Compound selector.
+ * @param array  $el       Element fixture.
+ * @return bool
+ */
+function customify_test_compound_matches( $compound, $el ) {
+	foreach ( customify_test_tokenize( trim( $compound ) ) as $token ) {
+		if ( ! customify_test_token_matches( $token, $el ) ) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * Does any selector in the list match the element fixture?
+ *
+ * @param string $list Selector list.
+ * @param array  $el   Element fixture (may carry an `ancestors` array).
+ * @return bool
+ */
+function customify_test_scope_matches( $list, $el ) {
+	foreach ( customify_split_selector_list( $list ) as $selector ) {
+		$compounds = customify_test_split_compounds( $selector );
+		$subject   = array_pop( $compounds );
+
+		if ( ! customify_test_compound_matches( $subject, $el ) ) {
+			continue;
+		}
+
+		$ancestors_ok = true;
+		foreach ( $compounds as $ancestor_selector ) {
+			$found = false;
+			foreach ( $el['ancestors'] as $ancestor ) {
+				if ( customify_test_compound_matches( $ancestor_selector, $ancestor ) ) {
+					$found = true;
+					break;
+				}
+			}
+			if ( ! $found ) {
+				$ancestors_ok = false;
+				break;
+			}
+		}
+
+		if ( $ancestors_ok ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Specificity of a complex selector as [ids, classes, types].
+ *
+ * @param string $selector Complex selector.
+ * @return array{0:int,1:int,2:int}
+ */
+function customify_test_specificity( $selector ) {
+	$score = array( 0, 0, 0 );
+
+	foreach ( customify_test_split_compounds( $selector ) as $compound ) {
+		foreach ( customify_test_tokenize( $compound ) as $token ) {
+			if ( preg_match( '/^:(not|is|matches|has)\((.*)\)$/s', $token, $m ) ) {
+				$best = array( 0, 0, 0 );
+				foreach ( customify_split_selector_list( $m[2] ) as $inner ) {
+					$candidate = customify_test_specificity( $inner );
+					if ( $candidate > $best ) {
+						$best = $candidate;
+					}
+				}
+				$score[0] += $best[0];
+				$score[1] += $best[1];
+				$score[2] += $best[2];
+				continue;
+			}
+
+			// :where() contributes nothing — that is the point of using it.
+			if ( preg_match( '/^:where\(/', $token ) ) {
+				continue;
+			}
+
+			if ( '#' === $token[0] ) {
+				$score[0]++;
+			} elseif ( '.' === $token[0] || '[' === $token[0] || ( ':' === $token[0] && '::' !== substr( $token, 0, 2 ) ) ) {
+				$score[1]++;
+			} else {
+				$score[2]++;
+			}
+		}
+	}
+
+	return $score;
+}
+
+// ─── Element fixtures ───────────────────────────────────────────────────────
+$form_ancestor = array(
+	array(
+		'tag'     => 'form',
+		'classes' => array( 'cart' ),
+		'attrs'   => array( 'class' => 'cart' ),
+	),
+);
+
+/**
+ * Build an element fixture.
+ *
+ * @param string $tag       Tag name.
+ * @param string $classes   Space-separated class attribute (empty = unclassed).
+ * @param array  $attrs     Extra attributes.
+ * @param array  $ancestors Ancestor fixtures.
+ * @return array
+ */
+function customify_test_el( $tag, $classes = '', $attrs = array(), $ancestors = array() ) {
+	$class_list = '' === $classes ? array() : preg_split( '/\s+/', trim( $classes ) );
+
+	if ( '' !== $classes ) {
+		$attrs['class'] = $classes;
+	}
+
+	return array(
+		'tag'       => $tag,
+		'classes'   => $class_list,
+		'attrs'     => $attrs,
+		'ancestors' => $ancestors,
+	);
+}
+
+$submit = array( 'type' => 'submit' );
+$plain  = array( 'type' => 'button' );
+
+// label => [ element, in Customizer scope?, in default SCSS skin? ]
+$cases = array(
+	// ── Must stay styled (backward compatibility) ───────────────────────
+	'WooCommerce single add to cart'   => array( customify_test_el( 'button', 'single_add_to_cart_button button alt', $submit, $form_ancestor ), true, true ),
+	'WooCommerce apply coupon'         => array( customify_test_el( 'button', 'button', $submit, $form_ancestor ), true, true ),
+	'WooCommerce login submit'         => array( customify_test_el( 'button', 'woocommerce-button button woocommerce-form-login__submit', $submit, $form_ancestor ), true, true ),
+	'WooCommerce register submit'      => array( customify_test_el( 'button', 'woocommerce-Button button', $submit, $form_ancestor ), true, true ),
+	'WooCommerce product search'       => array( customify_test_el( 'button', '', $submit, $form_ancestor ), true, true ),
+	'Comment form submit input'        => array( customify_test_el( 'input', 'submit', $submit, $form_ancestor ), true, true ),
+	'Reset input'                      => array( customify_test_el( 'input', '', array( 'type' => 'reset' ), $form_ancestor ), true, true ),
+	'Unclassed content button'         => array( customify_test_el( 'button', '', array() ), true, true ),
+	'Classed form button, no type'     => array( customify_test_el( 'button', 'wpforms-submit', array(), $form_ancestor ), true, true ),
+	'Third-party form submit button'   => array( customify_test_el( 'button', 'mc-newsletter-submit', $submit, $form_ancestor ), true, true ),
+	'Theme .button link'               => array( customify_test_el( 'a', 'button' ), true, true ),
+	'Core Button block link'           => array( customify_test_el( 'a', 'wp-block-button__link wp-element-button' ), true, true ),
+	'theme.json element button'        => array( customify_test_el( 'button', 'wp-element-button', $submit, $form_ancestor ), true, true ),
+
+	// ── Must NOT be touched: Blocksify product gallery ──────────────────
+	'Blocksify gallery thumbnail'      => array( customify_test_el( 'button', 'bsy-gallery__thumb', $plain ), false, false ),
+	'Blocksify gallery thumb arrow'    => array( customify_test_el( 'button', 'bsy-gallery__thumb-nav is-next', $plain ), false, false ),
+	'Blocksify gallery arrow'          => array( customify_test_el( 'button', 'bsy-gallery__arrow', $plain ), false, false ),
+
+	// ── Must NOT be touched: lightGallery lightbox controls ─────────────
+	'lightGallery prev'                => array( customify_test_el( 'button', 'lg-prev lg-icon', $plain ), false, false ),
+	'lightGallery next'                => array( customify_test_el( 'button', 'lg-next lg-icon', $plain ), false, false ),
+	'lightGallery close'               => array( customify_test_el( 'button', 'lg-close lg-icon', $plain ), false, false ),
+	'lightGallery zoom in'             => array( customify_test_el( 'button', 'lg-zoom-in lg-icon', $plain ), false, false ),
+	'lightGallery fullscreen'          => array( customify_test_el( 'button', 'lg-fullscreen lg-icon', $plain ), false, false ),
+	'lightGallery autoplay'            => array( customify_test_el( 'button', 'lg-autoplay-button lg-icon', $plain ), false, false ),
+	'lightGallery share'               => array( customify_test_el( 'button', 'lg-share lg-icon', $plain ), false, false ),
+
+	// ── Must NOT be touched: other component chrome ─────────────────────
+	'PhotoSwipe close (no type attr)'  => array( customify_test_el( 'button', 'pswp__button pswp__button--close' ), false, false ),
+	'Mobile menu toggle'               => array( customify_test_el( 'button', 'menu-mobile-toggle item-button', $plain ), false, false ),
+	'Quantity stepper (classic)'       => array( customify_test_el( 'button', 'input-pm-act input-pm-plus', $plain, $form_ancestor ), false, false ),
+	'Quantity stepper (Cart block)'    => array( customify_test_el( 'button', 'wc-block-components-quantity-selector__button', $plain ), false, false ),
+	'Show/hide password toggle'        => array( customify_test_el( 'button', 'show-password-input', $plain, $form_ancestor ), false, false ),
+	'Core Search block submit'         => array( customify_test_el( 'button', 'wp-block-search__button', $submit, $form_ancestor ), false, false ),
+	'Gutenberg components button'      => array( customify_test_el( 'button', 'components-button', $plain ), false, false ),
+	'Customizer edit shortcut'         => array( customify_test_el( 'button', 'customize-partial-edit-shortcut-button', $plain ), false, false ),
+	'Style guide edit pencil'          => array( customify_test_el( 'button', 'csg-edit', $plain ), false, false ),
+	'Quicktags editor button'          => array( customify_test_el( 'input', 'ed_button button button-small', $plain ), false, false ),
+
+	// ── Theme-owned icon chrome: out of the Customizer scope, but still
+	//    carrying the bundled default skin (documented divergence). ──────
+	'Search submit icon'               => array( customify_test_el( 'button', 'search-submit', $submit, $form_ancestor ), false, true ),
+);
+
+// ─── 1. Customizer scope ────────────────────────────────────────────────────
+$selectors = customify_get_button_styling_selectors();
+
+foreach ( $cases as $label => $case ) {
+	list( $el, $expected ) = $case;
+	customify_test_assert_same(
+		$expected,
+		customify_test_scope_matches( $selectors['normal'], $el ),
+		'Customizer button scope — ' . $label
+	);
+}
+
+// ─── 2. Hover variant is derived 1:1 ────────────────────────────────────────
+$normal_parts = customify_split_selector_list( $selectors['normal'] );
+$hover_parts  = customify_split_selector_list( $selectors['hover'] );
+
+customify_test_assert_same( count( $normal_parts ), count( $hover_parts ), 'Hover scope has one selector per normal selector.' );
+
+foreach ( $hover_parts as $i => $hover_selector ) {
+	customify_test_assert_same(
+		$normal_parts[ $i ] . ':hover',
+		$hover_selector,
+		'Hover selector #' . $i . ' is the normal selector plus :hover.'
+	);
+}
+
+// A functional pseudo-class with comma-separated arguments must survive the
+// split — this is what the old explode(',') based helper corrupted.
+customify_test_assert(
+	false !== strpos( $selectors['hover'], 'button:is([type="submit"], [type="reset"], :not([class])):' ),
+	'Comma-carrying :is() arguments survive the hover derivation intact.'
+);
+customify_test_assert(
+	false === strpos( $selectors['hover'], '[type="reset"]:hover, :not([class])' ),
+	'The hover derivation does not split inside functional pseudo-class arguments.'
+);
+
+// ─── 3. Specificity contract ────────────────────────────────────────────────
+$by_prefix = array();
+foreach ( $normal_parts as $selector ) {
+	$by_prefix[ $selector ] = customify_test_specificity( $selector );
+}
+
+$find = function ( $needle ) use ( $by_prefix ) {
+	foreach ( $by_prefix as $selector => $score ) {
+		if ( 0 === strpos( $selector, $needle ) ) {
+			return $score;
+		}
+	}
+	return null;
+};
+
+// (0,3,0) keeps Button Styling above `.button.add_to_cart_button` (0,2,0) in
+// compatibility/wc/_wc-elements.scss — WooCommerce buttons must keep obeying it.
+customify_test_assert_same( array( 0, 3, 0 ), $find( '.button:not(' ), 'The `.button` branch stays at (0,3,0).' );
+
+// (0,3,1), down from the (0,6,1) that chained :not() produced in 0.4.22.
+customify_test_assert_same( array( 0, 3, 1 ), $find( 'button:is(' ), 'The bare `button` branch is (0,3,1), not the old (0,6,1).' );
+
+// Unchanged from 0.4.22 — a single :not() list, so it cannot creep.
+customify_test_assert_same( array( 0, 2, 1 ), $find( 'input[type="submit"]' ), 'The submit-input branch stays at (0,2,1).' );
+
+// No branch may ever match the bare element without an intent gate again.
+foreach ( $normal_parts as $selector ) {
+	customify_test_assert(
+		'button' !== $selector && 0 !== strpos( $selector, 'button:not(' ),
+		'No branch matches the bare `button` element unconditionally: ' . $selector
+	);
+}
+
+// ─── 4. Default SCSS skin, read back from the compiled stylesheet ───────────
+$compiled = dirname( __DIR__ ) . '/build/css/frontend/style-theme.css';
+
+if ( ! file_exists( $compiled ) ) {
+	echo "NOTE: build/css/frontend/style-theme.css missing — run `npm run build` to cover the SCSS layer.\n";
+} else {
+	$css   = file_get_contents( $compiled );
+	$scope = '';
+
+	if ( preg_match_all( '/([^{}]+)\{([^{}]*)\}/s', $css, $rules, PREG_SET_ORDER ) ) {
+		foreach ( $rules as $rule ) {
+			$body = str_replace( ' ', '', $rule[2] );
+			if ( false !== strpos( $rule[1], 'button:is(' ) && false !== strpos( $body, 'min-height:2.6em' ) ) {
+				$scope = trim( $rule[1] );
+				break;
+			}
+		}
+	}
+
+	customify_test_assert( '' !== $scope, 'The compiled stylesheet still carries the intent-gated button rule.' );
+
+	if ( '' !== $scope ) {
+		foreach ( $cases as $label => $case ) {
+			list( $el, , $expected ) = $case;
+			customify_test_assert_same(
+				$expected,
+				customify_test_scope_matches( $scope, $el ),
+				'Default SCSS button skin — ' . $label
+			);
+		}
+	}
+}
+
+// ─── Result ─────────────────────────────────────────────────────────────────
+if ( $GLOBALS['customify_test_failures'] > 0 ) {
+	echo "\n{$GLOBALS['customify_test_failures']} button scope test(s) failed.\n";
+	exit( 1 );
+}
+
+echo "Button scope tests passed.\n";


### PR DESCRIPTION
## Problem

On any site with a saved `customify_button_styling` value, Global Button Styling repainted **component chrome** as primary-filled CTAs:

- Blocksify product gallery — `.bsy-gallery__thumb`, `.bsy-gallery__thumb-nav`
- lightGallery lightbox — `.lg-prev` / `.lg-next` / `.lg-close` / `.lg-zoom-in` / `.lg-fullscreen` / `.lg-autoplay-button` / `.lg-share`
- PhotoSwipe toolbar, Blocksify Live Filter trigger, header + widget search icon, WooCommerce block quantity stepper, style-guide edit pencils

Repro: http://norelle.wp.local/product/form-kettlebell/ — Pip & Pebble is unaffected only because its `customify_button_styling` is empty.

Regression introduced in `bc5520e` (0.4.21), still present in 0.4.22 and `DEV`. Later commits only added individual exclusions.

## Root cause

Architectural, in **both** layers (SCSS default skin and the Customizer scope) — not a missing exclusion.

1. **Denylist on the bare `button` element.** Both layers matched `button` and subtracted "everything that is not a button" by class name. A denylist can never enumerate third-party chrome, so every icon control a plugin renders as `<button class="…">` inherited the CTA skin — and each one needed its own carve-out.
2. **Chained `:not()` inflates specificity** — one class level *each*. The Customizer selector `button:not(a):not(b):not(c):not(d):not(e):not(f)` scored **(0,6,1)** and is emitted inline on the `customify-style` handle (loads last), so it outranked the component's own stylesheet and could not be corrected downstream by the plugin, a child theme or custom CSS.

## Approach

Allowlist driven by intent. A button is in scope when it **opts in by contract** — `.button`, `.wp-block-button__link`, `.wp-element-button`, the `input` button types — or when it is **structurally a content/form control**:

- an explicit `[type="submit"]` / `[type="reset"]`, or
- an **unclassed** `<button>` (author-written content markup), or
- a `<button>` inside a `<form>` with **no `type` attribute** — per the HTML spec that *is* a submit button (WPForms, Mailchimp and friends ship exactly this).

Component chrome is, without exception, a **classed `type="button"`** element, so it now falls outside the scope structurally — no per-library carve-out, no future whack-a-mole. Verified against the real markup of lightGallery, Blocksify gallery, PhotoSwipe and WooCommerce blocks.

### Specificity is now a documented contract, not an accident

| Branch | Before | After | Why |
|---|---|---|---|
| `.button` | (0,3,0) | (0,3,0) | must keep outranking `.button.add_to_cart_button` (0,2,0) so WooCommerce buttons keep obeying saved values |
| bare `button` | **(0,6,1)** | **(0,3,1)** | the extra levels only ever existed to out-shout chrome the scope no longer touches |
| `input[…]` | (0,2,1) | (0,2,1) | unchanged |
| SCSS default skin | (0,1,1) / (0,2,0) | unchanged | `:where()` for exclusions, so header/widget context rules keep winning |

Every exclusion list is now a **single** comma-separated `:not()` argument — adding or removing an entry can never change specificity again.

### Deliberate divergence between the two layers

`.search-submit` stays **in** the SCSS default skin (that is what 30k sites already render on the 404 / no-results form, and the header/widget context rules do override the low-specificity bundled rule) but is **out** of the Customizer scope — late inline CSS at high specificity is not overridable by those context rules. Documented in lockstep comments in both files.

### Two theme-owned controls needed their box model back

`.menu-mobile-toggle` and `.nav-btn` sat outside the new scope but had *inherited* their reset from it. Both now declare it themselves, or the UA `outset` button border returns. `.nav-btn` is also used by **Customify Pro's WooCommerce Booster** (Quick View + Product Gallery Slider) — its slider arrows were being blown up from 24×24 round to 52×42 blue squares by the leak, and are now restored.

## QA

Computed styles diffed across **8 pages × 2 viewports**, before vs after (old CSS rebuilt and deployed, snapshot, new CSS deployed, snapshot, diff):

| Test | Result |
|---|---|
| Ordinary buttons keep Global Button Styling | ✅ 0 changes across all content/form buttons |
| Add to cart / login / register | ✅ byte-identical (`rgb(49,84,217)`, 2px border, `4px 24px`) — also coupon, update cart, place order, comment submit |
| Gallery thumbnails | ✅ `bg → transparent`, `padding 4px 24px → 0`, thumb-nav back to Blocksify's `rgba(255,255,255,.82)` + `border-radius: 50%` |
| lightGallery controls | ✅ native again — arrows `rgba(0,0,0,.45)`, toolbar transparent, icons `#999`, border 0 |
| Site with no saved value | ✅ simulated by stripping the generated rules: 26 changes, **all component chrome, 0 content/form buttons** |

Remaining exposure, measured: a third-party `<button type="button" class="…">` with **no CSS of its own** falls back to the browser default instead of a brand CTA pill. Every real chrome control audited (theme, Pro, Blocksify, WooCommerce, lightGallery, PhotoSwipe) has its own styling and is either unchanged or restored. Sites that want a custom class in scope can use the new filter.

## New API

`customify/buttons_forms/button_selector` — extend the scope without forking the config (documented in `docs/api-reference.md` §2.1 with an example).

## Regression test

`php tests/button-scope-test.php` — 34 element fixtures run through **both** scopes: the Customizer scope straight from PHP, the SCSS scope **read back from the compiled `build/css/frontend/style-theme.css`** (skipped with a notice when `build/` has not been generated). Also asserts the specificity contract, that the hover variant is derived 1:1, and that no branch ever matches the bare `button` element unconditionally.

Note: `/tests/` is gitignored, so the file was force-added — same as the existing `content-area-spacing-test.php`.

## 30k-site safety

No `theme_mod` key, value shape, default or sanitize callback touched. No public function, filter or class renamed or removed — only additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)