### PR TITLE
fix(customizer): hide cloned device labels

### DIFF
--- a/src/backend/customizer/scss/_control.scss
+++ b/src/backend/customizer/scss/_control.scss
@@ -195,6 +195,12 @@ $text_color: #555d66;
     }
 }
 
+// Customify clones WordPress' device buttons for responsive controls. Keep
+// those compact icon-only switchers while leaving the core footer labels intact.
+.customify-devices .devices__preview-label {
+    display: none;
+}
+
 /**
 * Group Field
  */


### PR DESCRIPTION
## Summary

- hide WordPress 7.1 visible device labels inside Customify-cloned responsive switchers
- keep the original WordPress Customizer footer device labels visible
- preserve the compact icon-only layout used by Customify controls

## Testing

- `npm run build`
- `git diff --check`
- verified in the WordPress Customizer that `.customify-devices .devices__preview-label` is hidden
- verified the original footer Desktop, Tablet, and Mobile labels remain visible